### PR TITLE
refactor: extract shared DB helper, simplify scaffolding

### DIFF
--- a/packages/core/src/pm/actions/db-queries.ts
+++ b/packages/core/src/pm/actions/db-queries.ts
@@ -1,0 +1,40 @@
+import type { AnyDb } from "../../db/client.js";
+import { pipelineRuns } from "../../db/schema.js";
+import { sql } from "drizzle-orm";
+
+/** Statuses considered "active" (pipeline currently running). */
+export const ACTIVE_STATUSES = ["queued", "running"] as const;
+
+/** Default window for considering a recently-completed run as still "fresh". */
+const RECENT_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Fetch two sets of issue identifiers from the pipeline_runs table:
+ * - activeIssueIds: issues with a currently running/queued pipeline
+ * - recentlyProcessed: issues with a completed/failed run within the recent window
+ *
+ * Used by both startTodoIssues and recoverStuckInProgressIssues to avoid
+ * re-processing issues that already have pipeline activity.
+ */
+export async function getActiveAndRecentIssueIds(
+  db: AnyDb,
+  recentWindowMs = RECENT_WINDOW_MS,
+): Promise<{ activeIssueIds: Set<string>; recentlyProcessed: Set<string> }> {
+  const activeRows = await db
+    .select({ issueId: pipelineRuns.issueId })
+    .from(pipelineRuns)
+    .where(sql`${pipelineRuns.status} in ('running', 'queued')`);
+  const activeIssueIds = new Set<string>((activeRows as any[]).map((r) => r.issueId));
+
+  const recentCutoff = new Date(Date.now() - recentWindowMs);
+  const recentRows = await db
+    .select({ issueId: pipelineRuns.issueId })
+    .from(pipelineRuns)
+    .where(
+      sql`${pipelineRuns.status} in ('completed', 'failed')
+        AND ${pipelineRuns.completedAt} >= ${recentCutoff}`,
+    );
+  const recentlyProcessed = new Set<string>((recentRows as any[]).map((r) => r.issueId));
+
+  return { activeIssueIds, recentlyProcessed };
+}

--- a/packages/core/src/pm/actions/recover-stuck.ts
+++ b/packages/core/src/pm/actions/recover-stuck.ts
@@ -1,7 +1,7 @@
 import type { AnyDb } from "../../db/client.js";
 import { pipelineRuns } from "../../db/schema.js";
 import { inArray } from "drizzle-orm";
-import { sql } from "drizzle-orm";
+import { getActiveAndRecentIssueIds } from "./db-queries.js";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
 
@@ -76,25 +76,8 @@ export async function recoverStuckInProgressIssues(
     return [];
   }
 
-  // 2. Fetch all active (running or queued) pipeline run issueIds in one DB query
-  const activeRows = await db
-    .select({ issueId: pipelineRuns.issueId })
-    .from(pipelineRuns)
-    .where(sql`${pipelineRuns.status} in ('running', 'queued')`);
-  const activeIssueIds = new Set<string>((activeRows as any[]).map((r) => r.issueId));
-
-  // 2b. Also fetch issues with recently completed/failed runs (within last 30 min)
-  // to avoid recovering issues whose pipeline just finished but Linear state hasn't
-  // propagated yet
-  const recentCutoff = new Date(Date.now() - 30 * 60 * 1000);
-  const recentRows = await db
-    .select({ issueId: pipelineRuns.issueId })
-    .from(pipelineRuns)
-    .where(
-      sql`${pipelineRuns.status} in ('completed', 'failed')
-        AND ${pipelineRuns.completedAt} >= ${recentCutoff}`,
-    );
-  const recentlyProcessed = new Set<string>((recentRows as any[]).map((r) => r.issueId));
+  // 2. Fetch active and recently-processed issue IDs in one shared helper
+  const { activeIssueIds, recentlyProcessed } = await getActiveAndRecentIssueIds(db);
 
   // 3. Identify stuck issues: In Progress in Linear but no active DB run
   // NOTE: DB stores issue.identifier (e.g. "BEC-120"), not issue.id (Linear UUID)

--- a/packages/core/src/pm/actions/start-todo.ts
+++ b/packages/core/src/pm/actions/start-todo.ts
@@ -1,6 +1,5 @@
 import type { AnyDb } from "../../db/client.js";
-import { pipelineRuns } from "../../db/schema.js";
-import { sql } from "drizzle-orm";
+import { getActiveAndRecentIssueIds } from "./db-queries.js";
 import { resolvePipeline } from "../../pipeline/router.js";
 import { mapIssueToSchema } from "../../executor/prompt/schema-mapper.js";
 import type { PipelineConfig, RepoConfig } from "../../types.js";
@@ -54,12 +53,8 @@ export async function startTodoIssues(
     return [];
   }
 
-  // 2. Fetch all active (running or queued) pipeline run issueIds
-  const activeRows = await db
-    .select({ issueId: pipelineRuns.issueId })
-    .from(pipelineRuns)
-    .where(sql`${pipelineRuns.status} in ('running', 'queued')`);
-  const activeIssueIds = new Set<string>((activeRows as any[]).map((r) => r.issueId));
+  // 2. Fetch active and recently-processed issue IDs in one shared helper
+  const { activeIssueIds, recentlyProcessed } = await getActiveAndRecentIssueIds(db);
 
   // 3. Filter to orphaned issues (in Todo but no active pipeline run)
   // NOTE: DB stores issue.identifier (e.g. "BEC-120"), not issue.id (Linear UUID)
@@ -71,17 +66,6 @@ export async function startTodoIssues(
   }
 
   // 3b. Skip issues with recently completed/failed runs (within last 30 min)
-  const orphanedIdentifiers = orphaned.map((i: any) => i.identifier);
-  const recentCutoff = new Date(Date.now() - 30 * 60 * 1000);
-  const recentRuns = await db
-    .select({ issueId: pipelineRuns.issueId })
-    .from(pipelineRuns)
-    .where(
-      sql`${pipelineRuns.issueId} in (${sql.join(orphanedIdentifiers.map((id: string) => sql`${id}`), sql`, `)})
-        AND ${pipelineRuns.status} in ('completed', 'failed')
-        AND ${pipelineRuns.completedAt} >= ${recentCutoff}`,
-    );
-  const recentlyProcessed = new Set<string>((recentRuns as any[]).map((r) => r.issueId));
   const filteredOrphaned = orphaned.filter((issue: any) => {
     if (recentlyProcessed.has(issue.identifier)) {
       log.info(

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -159,6 +159,17 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           tick.errors.push(`recover: ${(err as Error).message}`);
         }
 
+        // Fetch workflow states once per tick to avoid redundant Linear API round-trips
+        let stateMap = new Map<string, string>();
+        if (!actions) {
+          try {
+            stateMap = await resolveWorkflowStates(await getLinearClient(), config.teamIds);
+          } catch (err) {
+            log.error({ err }, "resolveWorkflowStates failed");
+            tick.errors.push(`resolveWorkflowStates: ${(err as Error).message}`);
+          }
+        }
+
         // --- Stuck In Progress issue recovery sweep ---
         if (config.stuckIssueRecovery !== false) {
           try {
@@ -170,10 +181,9 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
                   teamIds: config.teamIds,
                   targetState: config.stuckIssueTargetState ?? "Backlog",
                   maxPerTick: config.stuckIssueMaxPerTick ?? 5,
+                  stateMap,
                   postSlackNotification: (issues) =>
                     getSlackNotifier().postStuckIssueRecovered(issues),
-                  // stateMap is not yet resolved here; recoverStuckInProgressIssues will
-                  // fetch it internally if not provided
                 });
             if (stuckResult.length > 0) {
               tick.recoveredStuckIssues = stuckResult.map((r) => r.identifier);
@@ -188,10 +198,12 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           }
         }
 
+        // Compute available slots once for both startTodo and promote
+        const slotsAvailable = config.maxInFlight - (tick.budgetGuard.activeCount ?? 0);
+
         // --- Start pipelines for orphaned Todo issues ---
         if (deps.runner?.start && deps.pipelineConfigs && deps.repoConfigs) {
           try {
-            const slotsAvailable = config.maxInFlight - (tick.budgetGuard.activeCount ?? 0);
             if (slotsAvailable > 0 && !tick.budgetGuard.promoteBlocked) {
               const todoResults = actions?.startTodoIssues
                 ? await actions.startTodoIssues({} as any)
@@ -213,17 +225,6 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           } catch (err) {
             log.error({ err }, "startTodoIssues failed");
             tick.errors.push(`startTodo: ${(err as Error).message}`);
-          }
-        }
-
-        // Fetch workflow states once per tick to avoid redundant Linear API round-trips
-        let stateMap = new Map<string, string>();
-        if (!actions) {
-          try {
-            stateMap = await resolveWorkflowStates(await getLinearClient(), config.teamIds);
-          } catch (err) {
-            log.error({ err }, "resolveWorkflowStates failed");
-            tick.errors.push(`resolveWorkflowStates: ${(err as Error).message}`);
           }
         }
 
@@ -267,8 +268,6 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
 
         if (!tick.budgetGuard.promoteBlocked && !isPmPaused()) {
           try {
-            const slotsAvailable = config.maxInFlight - tick.budgetGuard.activeCount;
-
             if (actions) {
               tick.promoted = await actions.promoteReadyIssues({} as any);
             } else {

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync, copyFileSync, readFileSync, readdirSync, statSync } from "fs";
+import { mkdirSync, writeFileSync, cpSync, readFileSync, statSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import { randomBytes } from "crypto";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,19 +14,6 @@ export interface ScaffoldOptions {
   linearTeamId: string;
   repoUrl: string;
   defaultBranch: string;
-}
-
-function copyDirRecursive(src: string, dest: string): void {
-  mkdirSync(dest, { recursive: true });
-  for (const entry of readdirSync(src)) {
-    const srcPath = join(src, entry);
-    const destPath = join(dest, entry);
-    if (statSync(srcPath).isDirectory()) {
-      copyDirRecursive(srcPath, destPath);
-    } else {
-      copyFileSync(srcPath, destPath);
-    }
-  }
 }
 
 /**
@@ -42,7 +30,7 @@ export function scaffold(options: ScaffoldOptions): void {
   if (!statSync(templateDir, { throwIfNoEntry: false })?.isDirectory()) {
     templateDir = join(__dirname, "..", "..", "template");
   }
-  copyDirRecursive(templateDir, projectDir);
+  cpSync(templateDir, projectDir, { recursive: true });
 
   // Write package.json
   const pkg = {
@@ -69,7 +57,7 @@ export function scaffold(options: ScaffoldOptions): void {
     `REPO_TEAM_ID=${linearTeamId}`,
     `DATABASE_URL=postgres://urateam:password@postgres:5432/urateam`,
     `DASHBOARD_USER=admin`,
-    `DASHBOARD_PASSWORD=changeme`,
+    `DASHBOARD_PASSWORD=${randomBytes(16).toString("hex")}`,
   ].join("\n") + "\n";
   writeFileSync(join(projectDir, ".env"), envContent);
 


### PR DESCRIPTION
## Summary

Code review findings applied — no breaking changes, no logic changes.

- **Extract `getActiveAndRecentIssueIds()`** shared by `start-todo.ts` and `recover-stuck.ts` — eliminates duplicate active-runs + recent-runs query patterns and the magic 30-minute constant
- **Hoist `resolveWorkflowStates`** before stuck-recovery in scheduler — eliminates redundant Linear API call (was called twice per tick)
- **Compute `slotsAvailable` once** in scheduler — removes inconsistent `?? 0` guard between startTodo and promote
- **Replace `copyDirRecursive` with `fs.cpSync`** in create-urateam — removes hand-rolled stdlib reimplementation
- **Generate random dashboard password** instead of hardcoded `changeme` in scaffolded `.env`

## Test plan

- [x] 21 start-todo + recover-stuck tests pass
- [x] 5 scaffold tests pass
- [x] 861 full suite tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)