### PR TITLE
fix: use Drizzle typed operators for crossTimestamp queries

### DIFF
--- a/packages/core/src/pm/actions/db-queries.ts
+++ b/packages/core/src/pm/actions/db-queries.ts
@@ -1,6 +1,6 @@
 import type { AnyDb } from "../../db/client.js";
 import { pipelineRuns } from "../../db/schema.js";
-import { sql } from "drizzle-orm";
+import { and, gte, inArray } from "drizzle-orm";
 
 /** Statuses considered "active" (pipeline currently running). */
 export const ACTIVE_STATUSES = ["queued", "running"] as const;
@@ -23,7 +23,7 @@ export async function getActiveAndRecentIssueIds(
   const activeRows = await db
     .select({ issueId: pipelineRuns.issueId })
     .from(pipelineRuns)
-    .where(sql`${pipelineRuns.status} in ('running', 'queued')`);
+    .where(inArray(pipelineRuns.status, [...ACTIVE_STATUSES]));
   const activeIssueIds = new Set<string>((activeRows as any[]).map((r) => r.issueId));
 
   const recentCutoff = new Date(Date.now() - recentWindowMs);
@@ -31,8 +31,10 @@ export async function getActiveAndRecentIssueIds(
     .select({ issueId: pipelineRuns.issueId })
     .from(pipelineRuns)
     .where(
-      sql`${pipelineRuns.status} in ('completed', 'failed')
-        AND ${pipelineRuns.completedAt} >= ${recentCutoff}`,
+      and(
+        inArray(pipelineRuns.status, ["completed", "failed"]),
+        gte(pipelineRuns.completedAt, recentCutoff),
+      ),
     );
   const recentlyProcessed = new Set<string>((recentRows as any[]).map((r) => r.issueId));
 


### PR DESCRIPTION
## Summary

Port of [ateam PR #180](https://github.com/JonB32/ateam/pull/180). Fixes `ERR_INVALID_ARG_TYPE` crash on Postgres.

Raw `sql` template literals passed `Date` objects directly to the Postgres driver, which expects strings. `crossTimestamp`'s `toDriver()` serializer only runs through Drizzle's typed operators (`gte`, `lt`, `inArray`), not raw SQL templates.

## Changes

`packages/core/src/pm/actions/db-queries.ts`:
- Active runs query: `sql\`...in ('running', 'queued')\`` → `inArray(pipelineRuns.status, [...ACTIVE_STATUSES])`
- Recent runs query: raw `sql` with `AND` → `and(inArray(...), gte(pipelineRuns.completedAt, recentCutoff))`

In urateam, both queries live in the shared `getActiveAndRecentIssueIds()` helper (unlike ateam where they were inline in start-todo.ts and recover-stuck.ts).

## Test plan

- [x] 21 start-todo + recover-stuck tests pass
- [x] No test changes needed (mocks return arrays regardless of query method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)