### PR TITLE
fix: use pnpm pack + npm publish for OIDC provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,14 +30,28 @@ jobs:
       - name: Test
         run: pnpm test
 
-      - name: Publish @urateam/core
-        run: pnpm --filter @urateam/core publish --access public --no-git-checks --provenance
+      # pnpm pack resolves workspace:* to real versions in the tarball.
+      # npm publish the tarball with --provenance for OIDC-based auth.
+      - name: Pack and publish @urateam/core
+        run: |
+          cd packages/core
+          pnpm pack
+          npm publish *.tgz --access public --provenance
 
-      - name: Publish @urateam/dashboard
-        run: pnpm --filter @urateam/dashboard publish --access public --no-git-checks --provenance
+      - name: Pack and publish @urateam/dashboard
+        run: |
+          cd packages/dashboard
+          pnpm pack
+          npm publish *.tgz --access public --provenance
 
-      - name: Publish @urateam/cli
-        run: pnpm --filter @urateam/cli publish --access public --no-git-checks --provenance
+      - name: Pack and publish @urateam/cli
+        run: |
+          cd packages/cli
+          pnpm pack
+          npm publish *.tgz --access public --provenance
 
-      - name: Publish create-urateam
-        run: pnpm --filter create-urateam publish --access public --no-git-checks --provenance
+      - name: Pack and publish create-urateam
+        run: |
+          cd packages/create-urateam
+          pnpm pack
+          npm publish *.tgz --access public --provenance


### PR DESCRIPTION
## Summary

Fixes 404 error on npm publish with trusted publishing (OIDC).

**Root cause:** `pnpm publish --provenance` doesn't reliably exchange the OIDC token provisioned by `setup-node`. `npm publish --provenance` does.

**Fix:** Two-step publish per package:
1. `pnpm pack` — resolves `workspace:*` to real versions in the tarball
2. `npm publish *.tgz --provenance` — publishes with OIDC auth

## Test plan

- [ ] Tag v0.1.2 after merge, verify all 4 packages publish successfully
- [ ] Verify `npm view @urateam/cli dependencies` shows real version numbers (not workspace:*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)