### PR TITLE
fix: auto-load .env in ura CLI entrypoint

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+// Auto-load .env file from the current working directory before any command
+// imports read process.env. Uses Node 22's built-in loadEnvFile (no deps).
+// Silently skips if .env doesn't exist. Existing env vars always win.
+try {
+  process.loadEnvFile();
+} catch {
+  // .env missing or unreadable — continue without it
+}
+
 import { Command } from "commander";
 import { runCommand } from "./commands/run.js";
 import { devCommand } from "./commands/dev.js";


### PR DESCRIPTION
## Summary

Closes #5. \`ura dev\` and \`ura start\` now automatically load \`.env\` from the current working directory — no more \`set -a && source .env && set +a && npx ura dev\`.

## Approach

Uses Node 22's built-in \`process.loadEnvFile()\` (stable since Node 21.7). Zero dependencies.

\`\`\`ts
try {
  process.loadEnvFile();
} catch {
  // .env missing or unreadable — continue without it
}
\`\`\`

Placed at the top of \`packages/cli/src/index.ts\` **before** any command imports so env vars are set before handlers read \`process.env\`.

## Behavior verified

- ✅ \`.env\` in cwd is loaded automatically
- ✅ Missing \`.env\` is silently ignored (ENOENT caught)
- ✅ Explicit env vars override \`.env\` values (Node's default behavior)
- ✅ Works for both \`ura dev\` and \`ura start\` (same entrypoint)

## Test plan

- [x] Existing 36 CLI tests pass
- [x] Smoke-tested with/without \`.env\` present
- [x] Smoke-tested explicit env var override

🤖 Generated with [Claude Code](https://claude.com/claude-code)