### PR TITLE
feat(core): bump zod to v4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     "nanoid": "^5.0.0",
     "pino": "^10.3.1",
     "postgres": "^3.4.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,7 +78,7 @@ export const PipelineConfigSchema = z.object({
   /** Per-stage model overrides. Keys are stage names; values are model strings passed to the Agent SDK.
    *  Invalid model strings are passed through as-is (let the SDK error, no local validation).
    *  Example: { implement: "claude-opus-4-6", test: "claude-haiku-4-5" } */
-  stageModels: z.record(z.string()).optional(),
+  stageModels: z.record(z.string(), z.string()).optional(),
   /** Fail the pipeline run if the agent did not commit its work and auto-commit was triggered.
    *  When false (default), auto-commit is a silent safety net and the run continues normally.
    *  When true, triggering auto-commit is treated as a pipeline error so the issue surfaces immediately. */
@@ -111,7 +111,7 @@ export type SetupCommand = z.infer<typeof SetupCommandSchema>;
 export const McpServerEntrySchema = z.object({
   command: z.string(),
   args: z.array(z.string()).optional(),
-  env: z.record(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
 });
 
 export const PluginEntrySchema = z.object({
@@ -121,7 +121,7 @@ export const PluginEntrySchema = z.object({
 
 export const PluginConfigSchema = z.object({
   /** Explicit MCP servers to always include */
-  mcpServers: z.record(McpServerEntrySchema).optional(),
+  mcpServers: z.record(z.string(), McpServerEntrySchema).optional(),
   /** MCP server names to never include */
   excludeMcpServers: z.array(z.string()).optional(),
   /** Explicit plugins to always include */
@@ -139,7 +139,7 @@ export const DevcontainerConfigSchema = z.object({
   /** Override path to devcontainer config */
   configPath: z.string().optional(),
   /** Extra environment variables for the container */
-  env: z.record(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
 });
 export type DevcontainerConfig = z.infer<typeof DevcontainerConfigSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.90
-        version: 0.2.101(zod@3.25.76)
+        version: 0.2.101(zod@4.3.6)
       '@hono/node-server':
         specifier: ^1.14.0
         version: 1.19.13(hono@4.12.12)
@@ -94,8 +94,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.9
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
@@ -1972,16 +1972,16 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
-  '@anthropic-ai/claude-agent-sdk@0.2.101(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.101(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      zod: 3.25.76
+      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      zod: 4.3.6
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -1996,11 +1996,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.81.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@babel/runtime@7.29.2': {}
 
@@ -2309,7 +2309,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
@@ -2326,8 +2326,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -3544,8 +3544,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

Closes #4. Bumps \`zod\` from \`^3.24.0\` to \`^4.3.6\` in \`@urateam/core\` to match the peer dependency required by \`@anthropic-ai/claude-agent-sdk\`. Eliminates this install warning:

\`\`\`
✕ unmet peer zod@^4.0.0: found 3.25.76
\`\`\`

## Breaking change handled: \`z.record()\` signature

Zod v4 made the key schema argument to \`z.record()\` required (previously defaulted to \`z.string()\`). Four call sites updated in \`packages/core/src/types.ts\`:

| Field | Before | After |
|---|---|---|
| \`PipelineConfigSchema.stageModels\` | \`z.record(z.string())\` | \`z.record(z.string(), z.string())\` |
| \`McpServerEntrySchema.env\` | \`z.record(z.string())\` | \`z.record(z.string(), z.string())\` |
| \`PluginConfigSchema.mcpServers\` | \`z.record(McpServerEntrySchema)\` | \`z.record(z.string(), McpServerEntrySchema)\` |
| \`DevcontainerConfigSchema.env\` | \`z.record(z.string())\` | \`z.record(z.string(), z.string())\` |

Without this fix, the inferred types became \`Record<string, unknown>\` instead of \`Record<string, string>\`, causing 11 TypeScript errors in \`runner.ts\` where these values flow into strongly-typed consumers (e.g., \`DevcontainerConfig.env\`).

## What didn't change

Everything else — \`z.object\`, \`z.string()\`, \`z.number()\`, \`z.array\`, \`z.enum\`, \`.optional()\`, \`.default()\`, etc. all work identically. Only \`z.record()\` had a breaking signature change that affected our usage.

## Verification

- ✅ \`@urateam/core\` builds clean with \`tsc --strict\`
- ✅ 861 core tests pass
- ✅ 1,049 total monorepo tests pass (core + dashboard + cli + scaffold)
- ✅ \`pnpm install\` produces no peer dependency warnings
- ✅ No runtime behavior change — same schemas, same validations

## Test plan

- [x] Full monorepo test suite
- [ ] Manual smoke test: scaffold a new project with \`create-urateam\`, verify no zod warning
- [ ] Manual smoke test: run \`ura dev\` with a real pipeline to confirm Zod parsing still works at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)