### PR TITLE
chore: bump to v0.1.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ const program = new Command();
 program
   .name("ura")
   .description("urateam CLI")
-  .version("0.1.0");
+  .version("0.1.3");
 
 program.addCommand(runCommand);
 program.addCommand(devCommand);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "bin": {
     "create-urateam": "dist/index.js"

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -70,7 +70,7 @@ export function scaffold(options: ScaffoldOptions): void {
       start: "ura start",
     },
     dependencies: {
-      "@urateam/cli": "^0.1.2",
+      "@urateam/cli": "^0.1.3",
     },
   };
   writeFileSync(join(urateamDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",


### PR DESCRIPTION
## Summary

Bumps all 4 packages to \`0.1.3\` for the next npm release.

## Release notes

### Closed issues

- **#5** — CLI auto-loads \`.env\` from cwd (no more \`set -a && source .env\`)
- **#6** — Sidecar deployment model (\`.urateam/\` subdirectory, not root dep)
- **#4** — Zod bumped to v4 (eliminates \`claude-agent-sdk\` peer warning)

### PRs included in v0.1.3

| PR | Description |
|---|---|
| #7 | \`fix: auto-load .env in ura CLI entrypoint\` |
| #8 | \`feat(create-urateam): sidecar pattern — .urateam/ subdirectory\` |
| #9 | \`feat(core): bump zod to v4\` |
| #10 | \`fix: PR review follow-ups\` |

## Also updated in this PR

- CLI version string in \`src/index.ts\`: \`"0.1.0"\` → \`"0.1.3"\` (was stale)
- Scaffold template dep pin: \`@urateam/cli@^0.1.2\` → \`^0.1.3\` so new projects pin to the release

## Verification

- ✅ All 4 packages at \`0.1.3\`
- ✅ Full monorepo test suite: **1,054 tests pass** (862 core + 140 dashboard + 36 cli + 16 scaffold)
- ✅ TypeScript build clean
- ✅ No runtime changes beyond version strings

## Next steps after merge

\`\`\`bash
git checkout main && git pull
git tag v0.1.3
git push origin v0.1.3
\`\`\`

The publish workflow (\`.github/workflows/publish.yml\`) will pick up the tag and publish all 4 packages to npm via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)