### PR TITLE
fix(ci): upgrade npm to latest for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,11 @@ jobs:
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1.
+      # Node 22 ships with npm 10.x, so we upgrade explicitly.
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Fixes the persistent 404 on \`PUT /@urateam/core\` in the publish workflow. Root cause: Node 22 ships with **npm 10.9.7**, but trusted publishing (OIDC token exchange) was added in **npm 11.5.1**.

## Evidence

From the \`v0.1.3\` publish run logs:

\`\`\`
node: v22.22.2
npm: 10.9.7
...
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX   ← masked placeholder set by setup-node
...
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@urateam%2fcore - Not found
\`\`\`

The provenance statement was signed successfully (proving OIDC itself works), but npm 10.x doesn't exchange the OIDC token for a publish token — it falls back to \`NODE_AUTH_TOKEN\` which \`setup-node\` set to an empty placeholder. The resulting PUT with no valid auth gets 404 from npm (which obscures auth failures as "not found").

## Fix

\`\`\`yaml
- name: Upgrade npm to latest
  run: npm install -g npm@latest
\`\`\`

Added right after \`setup-node\`. With npm 11+, the OIDC flow engages correctly and trusted publishing works.

## After merge

\`\`\`bash
git tag -d v0.1.3
git push origin :refs/tags/v0.1.3
git tag v0.1.3
git push origin v0.1.3
\`\`\`

The retag will trigger the publish workflow with the new npm version and publish all 4 packages to npm.

## Why this wasn't caught earlier

- The workflow "succeeded" from a CI perspective for the first step that signs the provenance — the failure happens deeper
- npm's error message ("404 Not Found - PUT") is misleading for auth failures on existing packages
- \`setup-node\`'s placeholder-token behavior when \`NODE_AUTH_TOKEN\` is unset isn't documented as a trusted-publishing blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)