### PR TITLE
fix(ci): use npx to run npm@latest for publish (don't self-upgrade)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,6 @@ jobs:
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
-      # npm trusted publishing (OIDC) requires npm >= 11.5.1.
-      # Node 22 ships with npm 10.x, so we upgrade explicitly.
-      - name: Upgrade npm to latest
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -35,28 +30,32 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1.
+      # Node 22 ships with npm 10.x. Use npx to fetch a modern npm on demand
+      # instead of a global self-upgrade (`npm install -g npm@latest` leaves
+      # the bundled install in a broken state where it can't find its own
+      # transitive deps like promise-retry).
       # pnpm pack resolves workspace:* to real versions in the tarball.
-      # npm publish the tarball with --provenance for OIDC-based auth.
       - name: Pack and publish @urateam/core
         run: |
           cd packages/core
           pnpm pack
-          npm publish *.tgz --access public --provenance
+          npx -y npm@latest publish *.tgz --access public --provenance
 
       - name: Pack and publish @urateam/dashboard
         run: |
           cd packages/dashboard
           pnpm pack
-          npm publish *.tgz --access public --provenance
+          npx -y npm@latest publish *.tgz --access public --provenance
 
       - name: Pack and publish @urateam/cli
         run: |
           cd packages/cli
           pnpm pack
-          npm publish *.tgz --access public --provenance
+          npx -y npm@latest publish *.tgz --access public --provenance
 
       - name: Pack and publish create-urateam
         run: |
           cd packages/create-urateam
           pnpm pack
-          npm publish *.tgz --access public --provenance
+          npx -y npm@latest publish *.tgz --access public --provenance


### PR DESCRIPTION
## Summary

Fixes the MODULE_NOT_FOUND error from PR #12's \`npm install -g npm@latest\` approach. Uses \`npx -y npm@latest publish\` instead to fetch a fresh npm on-demand.

## Why the previous approach broke

PR #12 upgraded npm in-place via \`npm install -g npm@latest\`. On Node 22's bundled npm 10.x, the self-upgrade partially succeeds but corrupts module resolution:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

The new npm's files are installed but some transitive dependencies aren't linked correctly because the upgrade happens through the old npm that's being replaced.

## Fix

Use \`npx -y npm@latest publish\` instead. \`npx\` fetches a fresh npm into a temporary location and runs it there — the bundled npm 10.x stays intact for everything else (\`pnpm install\`, etc.).

\`\`\`yaml
- name: Pack and publish @urateam/core
  run: |
    cd packages/core
    pnpm pack
    npx -y npm@latest publish *.tgz --access public --provenance
\`\`\`

The \`-y\` flag auto-answers the "install npm@latest?" prompt so CI doesn't hang.

## After merge

\`\`\`bash
git tag -d v0.1.3
git push origin :refs/tags/v0.1.3
git tag v0.1.3
git push origin v0.1.3
\`\`\`

The retag will trigger the publish workflow with npm 11+ via npx, and OIDC trusted publishing should finally work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)