### PR TITLE
chore: bump to v0.1.4

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ const program = new Command();
 program
   .name("ura")
   .description("urateam CLI")
-  .version("0.1.3");
+  .version("0.1.4");
 
 program.addCommand(runCommand);
 program.addCommand(devCommand);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "bin": {
     "create-urateam": "dist/index.js"

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -70,7 +70,7 @@ export function scaffold(options: ScaffoldOptions): void {
       start: "ura start",
     },
     dependencies: {
-      "@urateam/cli": "^0.1.3",
+      "@urateam/cli": "^0.1.4",
     },
   };
   writeFileSync(join(urateamDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",


### PR DESCRIPTION
## Summary

Bumps all 4 packages from \`0.1.3\` to \`0.1.4\`.

## Why 0.1.4 (not retry 0.1.3)

During the v0.1.3 publish run, \`@urateam/core\` successfully published but the remaining 3 packages failed with permission-denied 404s because trusted publishing was only configured on \`@urateam/core\`.

Retrying \`v0.1.3\` would fail on \`@urateam/core\` with "cannot publish over existing version". Bumping to \`v0.1.4\` lets all 4 packages publish fresh once the remaining policies are configured.

## ⚠️ Prerequisite before tagging v0.1.4

Configure trusted publishing on npmjs.com for **3 remaining packages**:

- https://www.npmjs.com/package/@urateam/dashboard → Settings → Publishing access
- https://www.npmjs.com/package/@urateam/cli → Settings → Publishing access
- https://www.npmjs.com/package/create-urateam → Settings → Publishing access

For each, click **"Add publishing policy"** and enter:
- **Publisher:** GitHub Actions
- **Repository:** \`JonB32/urateam\`
- **Workflow filename:** \`publish.yml\`
- **Environment:** *(leave blank)*

\`@urateam/core\` already has this configured from the v0.1.3 success — don't need to re-add.

## Also updated

- CLI version string: \`"0.1.3"\` → \`"0.1.4"\`
- Scaffold template dep pin: \`@urateam/cli@^0.1.3\` → \`^0.1.4\`

## Verification

- ✅ All 4 packages at \`0.1.4\`
- ✅ Full build succeeds
- ✅ No runtime changes

## After merge + policy config

\`\`\`bash
git checkout main && git pull
git tag v0.1.4
git push origin v0.1.4
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)