### PR TITLE
fix(create-urateam): inline .gitignore content (npm excludes .gitignore files)

### DIFF
--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "bin": {
     "create-urateam": "dist/index.js"

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -122,13 +122,28 @@ describe("scaffold — sidecar pattern", () => {
       expect(content).not.toContain("{{PROJECT_NAME}}");
     });
 
-    it(".gitignore template has .env.* wildcard with example exception", () => {
+    it(".gitignore has .env.* wildcard with example exception", () => {
       const projectDir = join(tempDir, "my-project");
       scaffold(baseOptions(projectDir, "my-project"));
 
       const content = readFileSync(join(projectDir, ".gitignore"), "utf-8");
       expect(content).toContain(".urateam/.env.*");
       expect(content).toContain("!.urateam/.env.example");
+    });
+
+    it(".gitignore content is inlined (not loaded from template file)", () => {
+      // Regression test: npm publish excludes files named `.gitignore` from
+      // tarballs automatically, so if the scaffold were to read it from disk,
+      // it would fail with ENOENT when installed from npm. This test verifies
+      // that the scaffold works regardless of whether template/.gitignore
+      // exists on disk.
+      const projectDir = join(tempDir, "my-project");
+      scaffold(baseOptions(projectDir, "my-project"));
+
+      const content = readFileSync(join(projectDir, ".gitignore"), "utf-8");
+      expect(content).toContain("# urateam sidecar");
+      expect(content).toContain(".urateam/.env");
+      expect(content).toContain(".urateam/node_modules/");
     });
   });
 

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -101,13 +101,13 @@ export function scaffold(options: ScaffoldOptions): void {
     writeFileSync(dest, content.replace(/\{\{PROJECT_NAME\}\}/g, projectName));
   }
 
-  // Ensure .gitignore at project root has the urateam entries
+  // Ensure .gitignore at project root has the urateam entries.
+  // Content is inlined here (not loaded from template/) because npm publish
+  // excludes files named `.gitignore` from published packages automatically,
+  // which would cause an ENOENT at runtime in installed create-urateam.
   const gitignorePath = join(projectDir, ".gitignore");
-  const gitignoreTemplateSrc = join(templateDir, ".gitignore");
-  const templateGitignore = readFileSync(gitignoreTemplateSrc, "utf-8");
-
   if (!existsSync(gitignorePath)) {
-    writeFileSync(gitignorePath, templateGitignore);
+    writeFileSync(gitignorePath, URATEAM_GITIGNORE);
   } else {
     const existing = readFileSync(gitignorePath, "utf-8");
     // Check for the bare `.urateam/.env` entry as a standalone line.
@@ -117,10 +117,28 @@ export function scaffold(options: ScaffoldOptions): void {
       .some((line) => line.trim() === ".urateam/.env");
     if (!hasBareEntry) {
       const separator = existing.endsWith("\n") ? "\n" : "\n\n";
-      appendFileSync(gitignorePath, separator + templateGitignore);
+      appendFileSync(gitignorePath, separator + URATEAM_GITIGNORE);
     }
   }
 }
+
+/**
+ * Inlined .gitignore content for the urateam sidecar.
+ *
+ * IMPORTANT: This is intentionally NOT loaded from `template/.gitignore`.
+ * When this package is published to npm, files named `.gitignore` are
+ * automatically excluded from the tarball by npm's default rules, so the
+ * file wouldn't exist at runtime in an installed copy. Inlining avoids
+ * the packaging pitfall entirely.
+ */
+const URATEAM_GITIGNORE = `# urateam sidecar
+.urateam/.env
+.urateam/.env.*
+!.urateam/.env.example
+.urateam/node_modules/
+.urateam/dist/
+.urateam/pnpm-lock.yaml
+`;
 
 // CLI entrypoint — only runs when executed directly (not when imported for testing)
 async function main() {

--- a/packages/create-urateam/template/.gitignore
+++ b/packages/create-urateam/template/.gitignore
@@ -1,7 +1,0 @@
-# urateam sidecar
-.urateam/.env
-.urateam/.env.*
-!.urateam/.env.example
-.urateam/node_modules/
-.urateam/dist/
-.urateam/pnpm-lock.yaml


### PR DESCRIPTION
## Summary

Fixes a runtime ENOENT crash in \`create-urateam@0.1.4\` when run via \`npx\`:

\`\`\`
Error: ENOENT: no such file or directory, open '.../create-urateam/template/.gitignore'
\`\`\`

## Root cause

\`npm publish\` **automatically excludes files named \`.gitignore\`** from tarballs, regardless of what the \`files\` field says. Even though \`package.json\` has \`"files": ["dist", "template"]\`, \`template/.gitignore\` is silently dropped.

Verified by inspecting the published tarball:

\`\`\`
$ npm pack create-urateam@0.1.4
$ tar -tzf create-urateam-0.1.4.tgz
package/template/CLAUDE.md
package/template/README.md
package/template/.urateam/.env.example
package/template/.urateam/Dockerfile
package/template/.urateam/README.md
package/template/.urateam/docker-compose.yml
...
# Note: no template/.gitignore
\`\`\`

Tests missed this because vitest runs against the local source tree where \`template/.gitignore\` exists. The bug only surfaces after installing from the npm registry.

## Fix

Inline the \`.gitignore\` content as a TypeScript constant in \`src/index.ts\`:

\`\`\`ts
const URATEAM_GITIGNORE = \`# urateam sidecar
.urateam/.env
.urateam/.env.*
!.urateam/.env.example
.urateam/node_modules/
.urateam/dist/
.urateam/pnpm-lock.yaml
\`;
\`\`\`

Removes the disk dependency entirely. Deleted \`template/.gitignore\`.

## Regression test

Added \`.gitignore content is inlined (not loaded from template file)\` — verifies the scaffold works regardless of whether the template file exists on disk, with explicit assertions on the expected entries.

## Version bump

Only \`create-urateam\` bumped to \`0.1.5\`. The other 3 packages at \`0.1.4\` don't have this bug and don't need republishing.

## After merge

\`\`\`bash
git checkout main && git pull
git tag v0.1.5
git push origin v0.1.5
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)