### PR TITLE
fix(create-urateam): preserve .env and package.json on re-run (v0.1.6)

### DIFF
--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "bin": {
     "create-urateam": "dist/index.js"

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -241,4 +241,92 @@ describe("scaffold — sidecar pattern", () => {
       expect(existsSync(join(projectDir, ".urateam", ".env"))).toBe(true);
     });
   });
+
+  describe("re-run safety (running create-urateam twice)", () => {
+    it("preserves existing .urateam/.env with real credentials", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate user editing .env with real credentials
+      const customEnv =
+        "LINEAR_API_KEY=lin_api_REAL_KEY\n" +
+        "LINEAR_WEBHOOK_SECRET=whsec_REAL\n" +
+        "DASHBOARD_PASSWORD=my_chosen_password\n";
+      writeFileSync(join(projectDir, ".urateam", ".env"), customEnv);
+
+      // Re-run scaffold with different options
+      scaffold({
+        projectDir,
+        projectName: "rerun-project",
+        linearApiKey: "lin_api_DIFFERENT",
+        linearTeamId: "different-team",
+        repoUrl: "https://github.com/other/repo",
+        defaultBranch: "main",
+      });
+
+      const envAfter = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+      expect(envAfter).toBe(customEnv);
+      expect(envAfter).toContain("lin_api_REAL_KEY");
+      expect(envAfter).not.toContain("lin_api_DIFFERENT");
+      expect(envAfter).toContain("my_chosen_password");
+    });
+
+    it("preserves existing .urateam/package.json with custom deps", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate user adding a custom dep to .urateam/package.json
+      const customPkg = {
+        name: "rerun-project-urateam",
+        private: true,
+        type: "module",
+        scripts: { dev: "ura dev", start: "ura start" },
+        dependencies: {
+          "@urateam/cli": "^0.1.4",
+          "some-custom-plugin": "^1.0.0",
+        },
+      };
+      writeFileSync(
+        join(projectDir, ".urateam", "package.json"),
+        JSON.stringify(customPkg, null, 2) + "\n",
+      );
+
+      // Re-run scaffold
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const pkgAfter = JSON.parse(
+        readFileSync(join(projectDir, ".urateam", "package.json"), "utf-8"),
+      );
+      expect(pkgAfter.dependencies["some-custom-plugin"]).toBe("^1.0.0");
+    });
+
+    it("refreshes template files like Dockerfile and docker-compose.yml", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate stale/corrupted Dockerfile
+      writeFileSync(join(projectDir, ".urateam", "Dockerfile"), "# stale content");
+
+      // Re-run scaffold
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const dockerfileAfter = readFileSync(
+        join(projectDir, ".urateam", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfileAfter).not.toContain("# stale content");
+      expect(dockerfileAfter).toContain("FROM node");
+    });
+
+    it(".gitignore append is idempotent across multiple runs", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+      scaffold(baseOptions(projectDir, "rerun-project"));
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const content = readFileSync(join(projectDir, ".gitignore"), "utf-8");
+      const matches = content.match(/^\.urateam\/\.env$/gm);
+      expect(matches?.length).toBe(1);
+    });
+  });
 });

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -4,6 +4,7 @@ import {
   writeFileSync,
   cpSync,
   readFileSync,
+  readdirSync,
   statSync,
   existsSync,
   appendFileSync,
@@ -56,38 +57,61 @@ export function scaffold(options: ScaffoldOptions): void {
     templateDir = join(__dirname, "..", "..", "template");
   }
 
-  // --- Sidecar files: copy template/.urateam/ → projectDir/.urateam/ (force overwrite) ---
+  // --- Sidecar files: refresh template files but preserve .env and package.json ---
+  // Template files (Dockerfile, docker-compose.yml, .env.example, README.md)
+  // are always overwritten with the latest version from the package.
+  // User-editable files (.env, package.json) are preserved if they exist
+  // so re-running create-urateam is safe and non-destructive to credentials.
   const urateamDir = join(projectDir, ".urateam");
-  cpSync(join(templateDir, ".urateam"), urateamDir, { recursive: true, force: true });
+  mkdirSync(urateamDir, { recursive: true });
 
-  // Write .urateam/package.json — the sidecar's own package.json
-  const pkg = {
-    name: `${projectName}-urateam`,
-    private: true,
-    type: "module",
-    scripts: {
-      dev: "ura dev",
-      start: "ura start",
-    },
-    dependencies: {
-      "@urateam/cli": "^0.1.4",
-    },
-  };
-  writeFileSync(join(urateamDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+  // Copy template files from template/.urateam/, skipping .env (generated below)
+  const urateamTemplateDir = join(templateDir, ".urateam");
+  for (const entry of readdirSync(urateamTemplateDir)) {
+    // .env is never in the template — it's generated below — but guard anyway
+    if (entry === ".env") continue;
+    const src = join(urateamTemplateDir, entry);
+    const dest = join(urateamDir, entry);
+    cpSync(src, dest, { recursive: true, force: true });
+  }
 
-  // Write .urateam/.env from user-provided values
-  const envContent = [
-    `LINEAR_API_KEY=${linearApiKey}`,
-    `LINEAR_WEBHOOK_SECRET=`,
-    `LINEAR_TEAM_ID=${linearTeamId}`,
-    `REPO_URL=${repoUrl}`,
-    `REPO_DEFAULT_BRANCH=${defaultBranch}`,
-    `REPO_TEAM_ID=${linearTeamId}`,
-    `DATABASE_URL=postgres://urateam:password@postgres:5432/urateam`,
-    `DASHBOARD_USER=admin`,
-    `DASHBOARD_PASSWORD=${randomBytes(16).toString("hex")}`,
-  ].join("\n") + "\n";
-  writeFileSync(join(urateamDir, ".env"), envContent);
+  // Write .urateam/package.json only if absent (user may have customized deps)
+  const pkgPath = join(urateamDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    const pkg = {
+      name: `${projectName}-urateam`,
+      private: true,
+      type: "module",
+      scripts: {
+        dev: "ura dev",
+        start: "ura start",
+      },
+      dependencies: {
+        "@urateam/cli": "^0.1.4",
+      },
+    };
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  }
+
+  // Write .urateam/.env only if absent — preserves real credentials on re-run.
+  // On first run, generates a random DASHBOARD_PASSWORD and fills in values
+  // from user prompts. On re-run, the existing .env is kept intact so users
+  // can iterate without losing credentials. To force a re-prompt, delete .env.
+  const envPath = join(urateamDir, ".env");
+  if (!existsSync(envPath)) {
+    const envContent = [
+      `LINEAR_API_KEY=${linearApiKey}`,
+      `LINEAR_WEBHOOK_SECRET=`,
+      `LINEAR_TEAM_ID=${linearTeamId}`,
+      `REPO_URL=${repoUrl}`,
+      `REPO_DEFAULT_BRANCH=${defaultBranch}`,
+      `REPO_TEAM_ID=${linearTeamId}`,
+      `DATABASE_URL=postgres://urateam:password@postgres:5432/urateam`,
+      `DASHBOARD_USER=admin`,
+      `DASHBOARD_PASSWORD=${randomBytes(16).toString("hex")}`,
+    ].join("\n") + "\n";
+    writeFileSync(envPath, envContent);
+  }
 
   // --- Project root files: copy only if absent (don't clobber user files) ---
   // Files with {{PROJECT_NAME}} placeholder get the substitution applied.


### PR DESCRIPTION
## Summary

Re-running \`create-urateam .\` in a project that already has a \`.urateam/\` sidecar now preserves user-edited files instead of clobbering them.

## Problem

Before this fix, re-running \`create-urateam .\`:
- Generated a new random \`DASHBOARD_PASSWORD\` every time
- Wiped out real Linear credentials the user had put in \`.env\`
- Replaced customized \`package.json\` (losing any extra deps)

This made the scaffold actively hostile to iteration — users would run it once, edit credentials, then accidentally destroy them on a second run.

## Fix

| File | First run | Re-run |
|---|---|---|
| \`.urateam/.env\` | Generated from prompts | **Preserved** (your real credentials) |
| \`.urateam/package.json\` | Generated | **Preserved** (your custom deps) |
| \`.urateam/Dockerfile\` | Copied from template | **Refreshed** from template |
| \`.urateam/docker-compose.yml\` | Copied | **Refreshed** |
| \`.urateam/.env.example\` | Copied | **Refreshed** |
| \`.urateam/README.md\` | Copied | **Refreshed** |

Rationale:
- **Template files** (Dockerfile, compose, etc.) should stay fresh so users benefit from framework improvements
- **User data** (.env with credentials, package.json with custom deps) must survive re-runs

To force a fresh \`.env\` re-prompt, users can simply delete \`.urateam/.env\` and re-run.

## Implementation

Replaced the blind \`cpSync(templateDir/.urateam, urateamDir, { force: true })\` with a per-file loop that skips \`.env\` (generated dynamically), then gates both \`package.json\` and \`.env\` writes behind \`existsSync\` checks.

## Tests (17 → 21)

Added 4 re-run safety tests:
- Preserves existing \`.urateam/.env\` with real credentials
- Preserves existing \`.urateam/package.json\` with custom deps
- Refreshes template files like Dockerfile and docker-compose.yml on re-run
- \`.gitignore\` append is idempotent across multiple runs (verified by running scaffold 3 times)

## Version

Bumps \`create-urateam\` from \`0.1.5\` to \`0.1.6\`. Other packages stay at \`0.1.4\` — they don't have this issue.

## After merge

\`\`\`bash
git checkout main && git pull
git tag v0.1.6
git push origin v0.1.6
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)