### PR TITLE
fix(create-urateam): preserve .env and package.json on re-run

### DIFF
--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -241,4 +241,92 @@ describe("scaffold — sidecar pattern", () => {
       expect(existsSync(join(projectDir, ".urateam", ".env"))).toBe(true);
     });
   });
+
+  describe("re-run safety (running create-urateam twice)", () => {
+    it("preserves existing .urateam/.env with real credentials", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate user editing .env with real credentials
+      const customEnv =
+        "LINEAR_API_KEY=lin_api_REAL_KEY\n" +
+        "LINEAR_WEBHOOK_SECRET=whsec_REAL\n" +
+        "DASHBOARD_PASSWORD=my_chosen_password\n";
+      writeFileSync(join(projectDir, ".urateam", ".env"), customEnv);
+
+      // Re-run scaffold with different options
+      scaffold({
+        projectDir,
+        projectName: "rerun-project",
+        linearApiKey: "lin_api_DIFFERENT",
+        linearTeamId: "different-team",
+        repoUrl: "https://github.com/other/repo",
+        defaultBranch: "main",
+      });
+
+      const envAfter = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+      expect(envAfter).toBe(customEnv);
+      expect(envAfter).toContain("lin_api_REAL_KEY");
+      expect(envAfter).not.toContain("lin_api_DIFFERENT");
+      expect(envAfter).toContain("my_chosen_password");
+    });
+
+    it("preserves existing .urateam/package.json with custom deps", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate user adding a custom dep to .urateam/package.json
+      const customPkg = {
+        name: "rerun-project-urateam",
+        private: true,
+        type: "module",
+        scripts: { dev: "ura dev", start: "ura start" },
+        dependencies: {
+          "@urateam/cli": "^0.1.4",
+          "some-custom-plugin": "^1.0.0",
+        },
+      };
+      writeFileSync(
+        join(projectDir, ".urateam", "package.json"),
+        JSON.stringify(customPkg, null, 2) + "\n",
+      );
+
+      // Re-run scaffold
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const pkgAfter = JSON.parse(
+        readFileSync(join(projectDir, ".urateam", "package.json"), "utf-8"),
+      );
+      expect(pkgAfter.dependencies["some-custom-plugin"]).toBe("^1.0.0");
+    });
+
+    it("refreshes template files like Dockerfile and docker-compose.yml", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate stale/corrupted Dockerfile
+      writeFileSync(join(projectDir, ".urateam", "Dockerfile"), "# stale content");
+
+      // Re-run scaffold
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const dockerfileAfter = readFileSync(
+        join(projectDir, ".urateam", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfileAfter).not.toContain("# stale content");
+      expect(dockerfileAfter).toContain("FROM node");
+    });
+
+    it(".gitignore append is idempotent across multiple runs", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+      scaffold(baseOptions(projectDir, "rerun-project"));
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const content = readFileSync(join(projectDir, ".gitignore"), "utf-8");
+      const matches = content.match(/^\.urateam\/\.env$/gm);
+      expect(matches?.length).toBe(1);
+    });
+  });
 });

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -4,6 +4,7 @@ import {
   writeFileSync,
   cpSync,
   readFileSync,
+  readdirSync,
   statSync,
   existsSync,
   appendFileSync,
@@ -56,38 +57,61 @@ export function scaffold(options: ScaffoldOptions): void {
     templateDir = join(__dirname, "..", "..", "template");
   }
 
-  // --- Sidecar files: copy template/.urateam/ → projectDir/.urateam/ (force overwrite) ---
+  // --- Sidecar files: refresh template files but preserve .env ---
+  // Template files (Dockerfile, docker-compose.yml, .env.example, README.md)
+  // are always overwritten with the latest version from the package.
+  // User-editable files (.env, package.json) are preserved if they exist
+  // so re-running create-urateam is safe and non-destructive to credentials.
   const urateamDir = join(projectDir, ".urateam");
-  cpSync(join(templateDir, ".urateam"), urateamDir, { recursive: true, force: true });
+  mkdirSync(urateamDir, { recursive: true });
 
-  // Write .urateam/package.json — the sidecar's own package.json
-  const pkg = {
-    name: `${projectName}-urateam`,
-    private: true,
-    type: "module",
-    scripts: {
-      dev: "ura dev",
-      start: "ura start",
-    },
-    dependencies: {
-      "@urateam/cli": "^0.1.4",
-    },
-  };
-  writeFileSync(join(urateamDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+  // Copy template files from template/.urateam/, skipping .env if user has one
+  const urateamTemplateDir = join(templateDir, ".urateam");
+  for (const entry of readdirSync(urateamTemplateDir)) {
+    const src = join(urateamTemplateDir, entry);
+    const dest = join(urateamDir, entry);
+    // .env is never in the template — it's generated below — but guard anyway
+    if (entry === ".env") continue;
+    cpSync(src, dest, { recursive: true, force: true });
+  }
 
-  // Write .urateam/.env from user-provided values
-  const envContent = [
-    `LINEAR_API_KEY=${linearApiKey}`,
-    `LINEAR_WEBHOOK_SECRET=`,
-    `LINEAR_TEAM_ID=${linearTeamId}`,
-    `REPO_URL=${repoUrl}`,
-    `REPO_DEFAULT_BRANCH=${defaultBranch}`,
-    `REPO_TEAM_ID=${linearTeamId}`,
-    `DATABASE_URL=postgres://urateam:password@postgres:5432/urateam`,
-    `DASHBOARD_USER=admin`,
-    `DASHBOARD_PASSWORD=${randomBytes(16).toString("hex")}`,
-  ].join("\n") + "\n";
-  writeFileSync(join(urateamDir, ".env"), envContent);
+  // Write .urateam/package.json only if absent (user may have customized deps)
+  const pkgPath = join(urateamDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    const pkg = {
+      name: `${projectName}-urateam`,
+      private: true,
+      type: "module",
+      scripts: {
+        dev: "ura dev",
+        start: "ura start",
+      },
+      dependencies: {
+        "@urateam/cli": "^0.1.4",
+      },
+    };
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  }
+
+  // Write .urateam/.env only if absent — preserves real credentials on re-run.
+  // On first run, generates a random DASHBOARD_PASSWORD and fills in the values
+  // from user prompts. On re-run, the existing .env is kept intact and the
+  // user can re-edit it manually if they want to update credentials.
+  const envPath = join(urateamDir, ".env");
+  if (!existsSync(envPath)) {
+    const envContent = [
+      `LINEAR_API_KEY=${linearApiKey}`,
+      `LINEAR_WEBHOOK_SECRET=`,
+      `LINEAR_TEAM_ID=${linearTeamId}`,
+      `REPO_URL=${repoUrl}`,
+      `REPO_DEFAULT_BRANCH=${defaultBranch}`,
+      `REPO_TEAM_ID=${linearTeamId}`,
+      `DATABASE_URL=postgres://urateam:password@postgres:5432/urateam`,
+      `DASHBOARD_USER=admin`,
+      `DASHBOARD_PASSWORD=${randomBytes(16).toString("hex")}`,
+    ].join("\n") + "\n";
+    writeFileSync(envPath, envContent);
+  }
 
   // --- Project root files: copy only if absent (don't clobber user files) ---
   // Files with {{PROJECT_NAME}} placeholder get the substitution applied.


### PR DESCRIPTION
Re-running `create-urateam .` in a project that already has a .urateam/ sidecar now preserves user-edited files instead of clobbering them:

- .urateam/.env — preserved (real Linear credentials, custom password)
- .urateam/package.json — preserved (custom deps added by the user)
- .urateam/Dockerfile, docker-compose.yml, README.md, .env.example — refreshed from the latest template (template files, not user data)

## Why this matters

Before this fix, re-running `create-urateam .` generated a new random DASHBOARD_PASSWORD every time, wiped out any real Linear credentials the user had put in .env, and replaced their customized package.json. That made the scaffold actively hostile to iteration.

Now re-running is safe: templates get refreshed, credentials stay put. Users can still manually delete .urateam/.env to force a re-prompt.

## Tests

Added 4 re-run safety tests:
- Preserves existing .urateam/.env with real credentials
- Preserves existing .urateam/package.json with custom deps
- Refreshes template files like Dockerfile and docker-compose.yml
- .gitignore append is idempotent across multiple runs