### PR TITLE
fix(ci): skip 'already published' errors in publish workflow

### DIFF
--- a/.github/scripts/publish-package.sh
+++ b/.github/scripts/publish-package.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Publish a single package tarball to npm via trusted publishing (OIDC).
+# Exits 0 if the version already exists on npm (skip, not an error) so the
+# workflow can publish all 4 packages on each tag even when some versions
+# are unchanged.
+#
+# Usage: publish-package.sh <tarball-glob>
+set -euo pipefail
+
+TARBALL=$(ls $1)
+if [ -z "$TARBALL" ]; then
+  echo "error: no tarball found matching $1" >&2
+  exit 1
+fi
+
+echo "Publishing $TARBALL"
+
+# Capture stderr to detect the "already published" error without losing it.
+if ! output=$(npx -y npm@latest publish "$TARBALL" --access public --provenance 2>&1); then
+  if echo "$output" | grep -qi "cannot publish over the previously published versions"; then
+    echo "$output"
+    echo ""
+    echo "ℹ️  Version already exists on npm — skipping (not an error)."
+    exit 0
+  fi
+  echo "$output" >&2
+  exit 1
+fi
+
+echo "$output"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,27 +35,33 @@ jobs:
       # instead of a global self-upgrade (`npm install -g npm@latest` leaves
       # the bundled install in a broken state where it can't find its own
       # transitive deps like promise-retry).
+      #
       # pnpm pack resolves workspace:* to real versions in the tarball.
+      #
+      # The `publish-package` helper script skips "version already exists"
+      # errors so per-package version bumps are supported (the workflow
+      # publishes all 4 packages on each tag, but some may already be at
+      # the same version).
       - name: Pack and publish @urateam/core
         run: |
           cd packages/core
           pnpm pack
-          npx -y npm@latest publish *.tgz --access public --provenance
+          ../../.github/scripts/publish-package.sh *.tgz
 
       - name: Pack and publish @urateam/dashboard
         run: |
           cd packages/dashboard
           pnpm pack
-          npx -y npm@latest publish *.tgz --access public --provenance
+          ../../.github/scripts/publish-package.sh *.tgz
 
       - name: Pack and publish @urateam/cli
         run: |
           cd packages/cli
           pnpm pack
-          npx -y npm@latest publish *.tgz --access public --provenance
+          ../../.github/scripts/publish-package.sh *.tgz
 
       - name: Pack and publish create-urateam
         run: |
           cd packages/create-urateam
           pnpm pack
-          npx -y npm@latest publish *.tgz --access public --provenance
+          ../../.github/scripts/publish-package.sh *.tgz


### PR DESCRIPTION
## Summary

Unblocks per-package version bumps by teaching the publish workflow to skip "cannot publish over existing version" errors instead of failing.

## Problem

The v0.1.6 publish run failed on the first step:

\`\`\`
npm error You cannot publish over the previously published versions: 0.1.4.
\`\`\`

Why: PR #16 bumped **only** \`create-urateam\` to \`0.1.6\` (the other 3 packages stayed at \`0.1.4\`). But the workflow publishes all 4 packages unconditionally on every tag. Hitting \`@urateam/core@0.1.4\` (already on npm) fails the entire job, blocking \`create-urateam@0.1.6\` from publishing.

## Fix

New helper \`.github/scripts/publish-package.sh\` wraps \`npx -y npm@latest publish\` and:
- **On success:** echoes output and exits 0
- **On "already published" error:** logs the skip and exits 0 (not a real failure)
- **On any other error:** exits 1 (fails the job)

The workflow now calls this helper for each package instead of invoking \`npm publish\` directly.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| All 4 packages bumped | ✅ Publishes all | ✅ Publishes all |
| 1 package bumped, 3 unchanged | ❌ Fails on first unchanged | ✅ Skips unchanged, publishes changed |
| Real publish failure (auth, network) | ❌ Fails job | ❌ Fails job |

## How to use

1. Merge this PR
2. Retag \`v0.1.6\`: \`git tag -d v0.1.6 && git push origin :refs/tags/v0.1.6 && git tag v0.1.6 && git push origin v0.1.6\`
3. Watch the workflow: \`@urateam/core\`, \`@urateam/dashboard\`, \`@urateam/cli\` get skipped (still at 0.1.4), \`create-urateam@0.1.6\` publishes

Future per-package bumps will Just Work without needing to version-bump every package in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)