### PR TITLE
fix(cli): read version from package.json (#19)

### DIFF
--- a/packages/cli/src/__tests__/version.test.ts
+++ b/packages/cli/src/__tests__/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getPackageVersion } from "../version.js";
+
+describe("getPackageVersion", () => {
+  it("returns the version from package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, "..", "..", "package.json"), "utf8"),
+    ) as { version: string };
+    expect(getPackageVersion()).toBe(pkg.version);
+  });
+
+  it("returns a semver-shaped string", () => {
+    expect(getPackageVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,13 +24,14 @@ import { webhookCommand } from "./commands/webhook.js";
 import { configCommand } from "./commands/config.js";
 import { startCommand } from "./commands/start.js";
 import { migrateCommand } from "./commands/migrate.js";
+import { getPackageVersion } from "./version.js";
 
 const program = new Command();
 
 program
   .name("ura")
   .description("urateam CLI")
-  .version("0.1.4");
+  .version(getPackageVersion());
 
 program.addCommand(runCommand);
 program.addCommand(devCommand);

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function getPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // Built layout: dist/version.js → ../package.json
+  // Source layout (tsx): src/version.ts → ../package.json
+  const pkgPath = join(here, "..", "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+  return pkg.version;
+}


### PR DESCRIPTION
## Summary
- New `getPackageVersion()` helper in `packages/cli/src/version.ts` reads `package.json` relative to the compiled module
- `index.ts` calls it instead of the hardcoded `"0.1.4"` literal
- Adds direct test asserting the helper matches `package.json` and is semver-shaped

## Test plan
- [x] `pnpm --filter @urateam/cli build`
- [x] `npx vitest run src/__tests__/version.test.ts`
- [x] `node packages/cli/dist/index.js --version` prints `0.1.4`

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)