### PR TITLE
ci: opt in to Node 24 runtime for JS actions (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Opt in early to the Node 24 runtime that GitHub will force for all
+# JavaScript actions starting June 2nd, 2026. This silences the
+# deprecation warnings and surfaces any incompatibility now.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-test:
     name: Build & Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
 
+# Opt in early to the Node 24 runtime that GitHub will force for all
+# JavaScript actions starting June 2nd, 2026.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     name: Build & Publish


### PR DESCRIPTION
## Summary
- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level on `ci.yml` and `publish.yml`
- Silences the Node 20 deprecation warnings on `actions/checkout@v4`, `actions/setup-node@v4`, and `pnpm/action-setup@v4`
- Surfaces any incompatibility now instead of at the June 2, 2026 cutover

## Test plan
- [ ] CI run on this PR shows no Node 20 deprecation warnings
- [ ] Build & unit tests still pass on Node 24 runtime
- [ ] Verified by next `v0.1.X` tag publish

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)