### PR TITLE
test(pm): direct schema regression coverage for PmAgentConfigSchema (#24)

### DIFF
--- a/packages/core/src/__tests__/pm-types.test.ts
+++ b/packages/core/src/__tests__/pm-types.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { PmAgentConfigSchema } from "../pm/types.js";
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { PmAgentConfigSchema, type PmAgentConfig } from "../pm/types.js";
 
 describe("PmAgentConfigSchema", () => {
   it("validates a complete valid config", () => {
@@ -78,5 +78,107 @@ describe("PmAgentConfigSchema", () => {
     };
     const result = PmAgentConfigSchema.safeParse(config);
     expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct schema regression coverage (#24)
+//
+// These tests exist so that a future zod migration or schema edit cannot
+// silently change a default or drop a field without a failing test. Every
+// case calls PmAgentConfigSchema.parse() directly rather than relying on a
+// downstream consumer's behaviour. Mirrors the stageModels coverage added in
+// PR #10 — defaults here are business-critical for PM Agent throughput.
+// ---------------------------------------------------------------------------
+describe("PmAgentConfigSchema — full coverage", () => {
+  const minimalRequired = {
+    enabled: true,
+    dailyTokenBudget: 5_000_000,
+    slackChannelId: "C0123456789",
+    teamIds: ["team-abc"],
+  };
+
+  it("parses a minimal config (only required fields)", () => {
+    const parsed = PmAgentConfigSchema.parse(minimalRequired);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.dailyTokenBudget).toBe(5_000_000);
+    expect(parsed.slackChannelId).toBe("C0123456789");
+    expect(parsed.teamIds).toEqual(["team-abc"]);
+  });
+
+  it("parses a full config with every optional field set", () => {
+    const full: PmAgentConfig = {
+      enabled: false,
+      cronIntervalMs: 600_000,
+      maxInFlight: 7,
+      triageBatchSize: 10,
+      dailyTokenBudget: 12_000_000,
+      slackChannelId: "C9999999999",
+      teamIds: ["team-a", "team-b", "team-c"],
+      stuckIssueRecovery: false,
+      stuckIssueTargetState: "Todo",
+      stuckIssueMaxPerTick: 25,
+    };
+    const parsed = PmAgentConfigSchema.parse(full);
+    expect(parsed).toEqual(full);
+  });
+
+  it("applies defaults for stuck-issue recovery fields", () => {
+    const parsed = PmAgentConfigSchema.parse(minimalRequired);
+    expect(parsed.stuckIssueRecovery).toBe(true);
+    expect(parsed.stuckIssueTargetState).toBe("Backlog");
+    expect(parsed.stuckIssueMaxPerTick).toBe(5);
+  });
+
+  it("applies defaults for cronIntervalMs, maxInFlight, triageBatchSize", () => {
+    const parsed = PmAgentConfigSchema.parse(minimalRequired);
+    expect(parsed.cronIntervalMs).toBe(1_800_000);
+    expect(parsed.maxInFlight).toBe(3);
+    expect(parsed.triageBatchSize).toBe(3);
+  });
+
+  it("rejects invalid stuckIssueTargetState enum value", () => {
+    const result = PmAgentConfigSchema.safeParse({
+      ...minimalRequired,
+      stuckIssueTargetState: "Done",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative cronIntervalMs", () => {
+    const result = PmAgentConfigSchema.safeParse({
+      ...minimalRequired,
+      cronIntervalMs: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-positive dailyTokenBudget", () => {
+    const result = PmAgentConfigSchema.safeParse({
+      ...minimalRequired,
+      dailyTokenBudget: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty slackChannelId", () => {
+    const result = PmAgentConfigSchema.safeParse({
+      ...minimalRequired,
+      slackChannelId: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects stuckIssueMaxPerTick < 1", () => {
+    const result = PmAgentConfigSchema.safeParse({
+      ...minimalRequired,
+      stuckIssueMaxPerTick: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("infers a type matching PmAgentConfig", () => {
+    const parsed = PmAgentConfigSchema.parse(minimalRequired);
+    expectTypeOf(parsed).toEqualTypeOf<PmAgentConfig>();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a 'PmAgentConfigSchema — full coverage' describe block in `pm-types.test.ts` with 10 new direct parse cases
- Covers minimal/full configs, defaults for the stuck-issue recovery fields (which had no direct coverage), enum + numeric edge cases, and type inference
- Mirrors the stageModels coverage added in PR #10 — guards against silent default drift during zod migrations

## Test plan
- [x] `npx vitest run packages/core/src/__tests__/pm-types.test.ts` — 17 passed
- [x] `pnpm --filter @urateam/core build`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)