### PR TITLE
test(create-urateam): integration test for installed tarball (#21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,25 @@ jobs:
 
       - name: Run integration tests
         run: pnpm test:integration
+
+  create-urateam-tarball:
+    name: create-urateam tarball integration
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build create-urateam
+        run: pnpm --filter create-urateam build
+
+      - name: Pack, install, and exercise the tarball
+        run: pnpm --filter create-urateam test:integration

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
-    "test:integration": "pnpm --filter @urateam/core test:integration",
+    "test:integration": "pnpm --filter @urateam/core test:integration && pnpm --filter create-urateam test:integration",
     "lint": "turbo lint",
     "dev": "turbo dev"
   },

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "prompts": "^2.4.2"

--- a/packages/create-urateam/src/__tests__/integration/tarball.test.ts
+++ b/packages/create-urateam/src/__tests__/integration/tarball.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { tmpdir } from "node:os";
+
+/**
+ * End-to-end packaging test for create-urateam.
+ *
+ * 1. `pnpm pack` the package into a tarball
+ * 2. `npm install <tarball>` into a clean temp directory
+ * 3. Import scaffold() from the installed copy and run it against a scratch dir
+ * 4. Assert all expected files exist (sidecar, project root, .gitignore)
+ *
+ * Regression guard for the 0.1.4 ENOENT .gitignore crash: npm publish
+ * automatically excludes files literally named `.gitignore` from tarballs,
+ * which broke `create-urateam` when it tried to read `template/.gitignore`
+ * at runtime. This test would have caught that before publish.
+ *
+ * We import scaffold() directly rather than spawning the bin shim because
+ * the bin uses interactive `prompts`, which doesn't compose with piped
+ * stdin in the test runner. Importing from the installed dist/ exercises
+ * the same code path (template resolution + .gitignore inlining) that
+ * crashed in 0.1.4 — the publishing concern this test guards against.
+ */
+
+const PACKAGE_DIR = resolve(__dirname, "..", "..", "..");
+
+interface ScaffoldFn {
+  (opts: {
+    projectDir: string;
+    projectName: string;
+    linearApiKey: string;
+    linearTeamId: string;
+    repoUrl: string;
+    defaultBranch: string;
+  }): void;
+}
+
+describe("create-urateam — installed tarball", () => {
+  let workRoot: string;
+  let tarballPath: string;
+  let installRoot: string;
+  let installedScaffold: ScaffoldFn;
+
+  beforeAll(async () => {
+    workRoot = mkdtempSync(join(tmpdir(), "create-urateam-tarball-"));
+
+    // 1. Pack
+    execFileSync("pnpm", ["pack", "--pack-destination", workRoot], {
+      cwd: PACKAGE_DIR,
+      stdio: "pipe",
+    });
+
+    const tgz = readdirSync(workRoot).find((f) => f.endsWith(".tgz"));
+    if (!tgz) throw new Error("pnpm pack produced no .tgz file");
+    tarballPath = join(workRoot, tgz);
+
+    // 2. Install into a clean tree
+    installRoot = join(workRoot, "install");
+    mkdirSync(installRoot, { recursive: true });
+    execFileSync("npm", ["init", "-y"], { cwd: installRoot, stdio: "pipe" });
+    execFileSync("npm", ["install", tarballPath], {
+      cwd: installRoot,
+      stdio: "pipe",
+    });
+
+    // 3. Dynamically import scaffold() from the installed copy
+    const installedDist = join(
+      installRoot,
+      "node_modules",
+      "create-urateam",
+      "dist",
+      "index.js",
+    );
+    const mod = (await import(pathToFileURL(installedDist).href)) as {
+      scaffold: ScaffoldFn;
+    };
+    installedScaffold = mod.scaffold;
+  }, 120_000);
+
+  afterAll(() => {
+    if (workRoot) rmSync(workRoot, { recursive: true, force: true });
+  });
+
+  it("packs and installs without errors", () => {
+    expect(existsSync(tarballPath)).toBe(true);
+    expect(existsSync(join(installRoot, "node_modules", "create-urateam"))).toBe(true);
+  });
+
+  it("installed package contains dist/ and template/", () => {
+    const installedRoot = join(installRoot, "node_modules", "create-urateam");
+    expect(existsSync(join(installedRoot, "dist", "index.js"))).toBe(true);
+    expect(existsSync(join(installedRoot, "template"))).toBe(true);
+    expect(existsSync(join(installedRoot, "template", ".urateam"))).toBe(true);
+  });
+
+  it("exposes scaffold() from the installed dist/ entry", () => {
+    expect(typeof installedScaffold).toBe("function");
+  });
+
+  it("scaffolds a fresh project from the installed package", () => {
+    const projectDir = join(workRoot, "scratch-project");
+    installedScaffold({
+      projectDir,
+      projectName: "scratch-project",
+      linearApiKey: "lin_api_test",
+      linearTeamId: "team-test",
+      repoUrl: "https://github.com/test/repo",
+      defaultBranch: "main",
+    });
+
+    // Sidecar files
+    expect(existsSync(join(projectDir, ".urateam", "package.json"))).toBe(true);
+    expect(existsSync(join(projectDir, ".urateam", ".env"))).toBe(true);
+    expect(existsSync(join(projectDir, ".urateam", "Dockerfile"))).toBe(true);
+    expect(existsSync(join(projectDir, ".urateam", "docker-compose.yml"))).toBe(true);
+    expect(existsSync(join(projectDir, ".urateam", "README.md"))).toBe(true);
+
+    // Project root files
+    expect(existsSync(join(projectDir, "CLAUDE.md"))).toBe(true);
+    expect(existsSync(join(projectDir, "README.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".gitignore"))).toBe(true);
+  });
+
+  it(".gitignore from installed copy has urateam entries (regression guard for 0.1.4 ENOENT)", () => {
+    const projectDir = join(workRoot, "gitignore-check");
+    installedScaffold({
+      projectDir,
+      projectName: "gitignore-check",
+      linearApiKey: "lin_api_test",
+      linearTeamId: "team-test",
+      repoUrl: "https://github.com/test/repo",
+      defaultBranch: "main",
+    });
+
+    const gitignore = readFileSync(join(projectDir, ".gitignore"), "utf-8");
+    expect(gitignore).toContain("# urateam sidecar");
+    expect(gitignore).toContain(".urateam/.env");
+    expect(gitignore).toContain(".urateam/.env.*");
+    expect(gitignore).toContain("!.urateam/.env.example");
+    expect(gitignore).toContain(".urateam/node_modules/");
+  });
+});

--- a/packages/create-urateam/vitest.config.ts
+++ b/packages/create-urateam/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Default unit-test run. Integration tests live under integration/ and
+    // run via vitest.integration.config.ts so they don't slow down the inner
+    // dev loop with `pnpm pack` + `npm install`.
+    exclude: ["**/node_modules/**", "**/dist/**", "src/__tests__/integration/**"],
+  },
+});

--- a/packages/create-urateam/vitest.integration.config.ts
+++ b/packages/create-urateam/vitest.integration.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Integration test configuration for create-urateam.
+ *
+ * Runs `pnpm pack` + `npm install <tarball>` in a temp dir, then exercises
+ * the installed copy. Catches packaging bugs that unit tests against the
+ * source tree miss (e.g. the 0.1.4 → 0.1.5 .gitignore ENOENT crash, where
+ * npm strips files literally named `.gitignore` from published tarballs).
+ *
+ * Slow: each test pays a pack + install cost. Run via:
+ *   pnpm --filter create-urateam test:integration
+ */
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/integration/**/*.test.ts"],
+    passWithNoTests: true,
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    pool: "forks",
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `packages/create-urateam/src/__tests__/integration/tarball.test.ts` — packs, installs, and exercises the published tarball end-to-end (5 assertions)
- Imports `scaffold()` from the installed `dist/` rather than spawning the bin shim (the bin uses interactive `prompts` which doesn't compose with piped stdin)
- New `vitest.integration.config.ts` and `vitest.config.ts` exclusions, new `test:integration` script
- Root `pnpm test:integration` now runs core **and** create-urateam integration suites
- New CI job `create-urateam tarball integration` (continue-on-error, same shape as existing integration-tests job)

## Test plan
- [x] `pnpm --filter create-urateam test` — 21 unit tests pass
- [x] `pnpm --filter create-urateam test:integration` — 5 integration tests pass (~9s)
- [x] `pnpm --filter create-urateam build`
- [ ] CI 'create-urateam tarball integration' job goes green

## Regression coverage
The 0.1.4 ENOENT `.gitignore` crash would surface here as a `template/.gitignore` missing from the installed tarball or a runtime ENOENT in the `.gitignore from installed copy` test.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)