### PR TITLE
fix(ci): build create-urateam before tarball integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
-    "test:integration": "pnpm --filter @urateam/core test:integration && pnpm --filter create-urateam test:integration",
+    "test:integration": "pnpm --filter @urateam/core test:integration && pnpm --filter create-urateam build && pnpm --filter create-urateam test:integration",
     "lint": "turbo lint",
     "dev": "turbo dev"
   },


### PR DESCRIPTION
## Summary
Root \`pnpm test:integration\` now runs \`pnpm --filter create-urateam build\` before \`pnpm --filter create-urateam test:integration\`. Without this, the consolidated \"Integration Tests\" CI job fails because \`pnpm pack\` produces a tarball with no \`dist/\` (the package wasn't built), and the test's \`beforeAll\` then crashes when it tries to dynamically import \`scaffold()\` from the installed copy.

The dedicated \`create-urateam tarball integration\` job already builds first and passes — this fix gives the consolidated job the same setup.

## Why this surfaced now
The create-urateam tarball integration test is new (PR #29). It runs in two CI jobs:
1. The dedicated \`create-urateam tarball integration\` job — has an explicit build step → passes
2. The consolidated \`Integration Tests\` job — invoked via root \`pnpm test:integration\` → no build step → fails

The duplicate was only exposed once main contained both PRs, which happened when this round of issue PRs was merged.

## Test plan
- [ ] CI \`Integration Tests\` job goes green on this branch
- [ ] CI \`create-urateam tarball integration\` job still passes (no behavior change for it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)