### PR TITLE
feat: audit log + export (enterprise 4.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,18 @@ It is a pnpm monorepo with 3 packages:
 4. Force-push the corrected branch: `git push --force-with-lease origin agent/<correct-issue>-<slug>`.
 5. On the contaminated branch, remove the stray commit: `git rebase -i --onto <parent-sha> <stray-sha> HEAD` or `git reset --hard <pre-stray-sha>`, then `git push --force-with-lease`.
 
+### Audit log (Enterprise feature 4.2)
+- Append-only `audit_events` table + read-time projection from `pipeline_runs`, `pm_approvals`, `budget_alerts` (no run-data duplication)
+- Module: `packages/core/src/audit/` — `events.ts` (typed builders), `writer.ts` (`logAuditEvent`, fire-and-forget; license-gated, returns no-op if `audit-log` feature unlicensed), `reader.ts` (`listAuditEvents` with cursor pagination), `projection.ts`, `retention.ts` (`pruneAuditLog` — sole authorized mutation), `csv.ts` (`streamAuditCsv` async iterator)
+- 16 event types: `run.{started,completed,failed,auto_merged,auto_merge_skipped}`, `pm.{approval_requested,approval_resolved,issue_promoted,issue_deprioritized,issue_cancelled,triage_classified}`, `budget.{alert_fired,run_refused}`, `license.validation_failed`, `config.loaded`, `dashboard.manual_action` (reserved)
+- Write sites: `pm/scheduler.ts` (budget refused, including `maxInFlight` blocks), `pm/actions/promote.ts`, `pm/actions/triage.ts`, `pm/actions/resolve-approvals.ts` (deprioritize/cancel — emitted on actual execution, not approval request), `license.ts` (via `logAuditEventUnchecked` — the only call site that bypasses the feature gate), `cli/commands/run.ts` (`config.loaded`)
+- **Immutability is convention-only**, enforced by `packages/core/src/__tests__/audit-immutability.test.ts` (greps for `delete(auditEvents)` / `update(auditEvents)`; only `audit/retention.ts` is allow-listed). Adding a new mutation site requires updating the allow-list.
+- Reader merges native rows + projected rows by `(timestamp DESC, id DESC)` and supports cursor-based SQL filtering on all 4 sources to avoid pagination truncation
+- Dashboard route: `/audit` (filter bar, HTMX pagination), `/audit/page` (partial), `/audit/export.csv` (streamed). All return 404 unless `isFeatureLicensed("audit-log")`. View: `packages/dashboard/src/views/audit.ts` — all user-controlled fields go through `escapeHtml`
+- Retention sweep runs in PM tick after `digest`, default 365 days, configurable via `auditLog.retentionDays`. Tick step is gated on `isFeatureLicensed("audit-log")`
+- **`config.loaded` event currently only fires from `ura run`** — `ura dev` / `ura start` (production paths) build config from env vars and have no file path to fingerprint. Follow-up to wire those when needed.
+- `/audit/event/:id` HTMX detail expansion route is in the spec but deferred — table shows truncated payload inline
+
 ### Coordination (`packages/core/src/pm/coordination.ts`)
 - DB-backed `active_work` table tracks files modified by in-flight pipeline runs
 - `upsertActiveWork` uses atomic `onConflictDoUpdate` (requires UNIQUE on `run_id`)

--- a/docs/superpowers/plans/2026-04-14-audit-log-and-export.md
+++ b/docs/superpowers/plans/2026-04-14-audit-log-and-export.md
@@ -1,0 +1,2182 @@
+# Audit Log + Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship enterprise feature 4.2 — append-only audit event log with dashboard view and CSV export — per `docs/superpowers/specs/2026-04-14-audit-log-design.md`.
+
+**Architecture:** Hybrid data model. A new `audit_events` table stores events that have no existing home (PM decisions, budget refusals, license/config events); a read-time projection layer maps `pipeline_runs`, `pm_approvals`, and `budget_alerts` rows into the same `AuditEvent` shape so nothing is duplicated. Reader merges the four streams by timestamp. Retention sweep is the sole authorized mutation; a lint test enforces it. Dashboard exposes a filtered feed and a streaming CSV export, both gated by `isFeatureLicensed("audit-log")`.
+
+**Tech Stack:** TypeScript, Drizzle ORM, better-sqlite3 / postgres-js, Hono+HTMX, Vitest, Zod, pino.
+
+---
+
+## File Structure
+
+### New files
+- `packages/core/src/db/migrations/sqlite/006_audit_events.sql` — table + indexes (SQLite)
+- `packages/core/src/db/migrations/postgres/007_audit_events.sql` — table + indexes (Postgres)
+- `packages/core/src/audit/index.ts` — barrel export
+- `packages/core/src/audit/writer.ts` — `logAuditEvent(db, event)` fire-and-forget
+- `packages/core/src/audit/events.ts` — typed event builders
+- `packages/core/src/audit/projection.ts` — map `pipeline_runs` / `pm_approvals` / `budget_alerts` rows → `AuditEvent[]`
+- `packages/core/src/audit/reader.ts` — `listAuditEvents(filters)` with cursor pagination
+- `packages/core/src/audit/retention.ts` — `pruneAuditLog(db, retentionDays)` (sole authorized mutation)
+- `packages/core/src/audit/csv.ts` — `streamAuditCsv(db, filters)` async iterator
+- `packages/core/src/__tests__/audit/writer.test.ts`
+- `packages/core/src/__tests__/audit/events.test.ts`
+- `packages/core/src/__tests__/audit/projection.test.ts`
+- `packages/core/src/__tests__/audit/reader.test.ts`
+- `packages/core/src/__tests__/audit/retention.test.ts`
+- `packages/core/src/__tests__/audit/csv.test.ts`
+- `packages/core/src/__tests__/audit-immutability.test.ts` — grep-based lint test
+- `packages/core/src/__tests__/integration/audit-e2e.test.ts`
+- `packages/dashboard/src/routes/audit.ts`
+- `packages/dashboard/src/views/audit.ts`
+- `packages/dashboard/src/__tests__/audit.test.ts`
+
+### Modified files
+- `packages/core/src/db/schema.ts` — add `auditEvents` table
+- `packages/core/src/db/client.ts` — extend `getCreateTablesDDL()`
+- `packages/core/src/types.ts` — `AuditEventSchema`, `AuditEventTypeSchema`, `AuditActorTypeSchema`, `AppConfig.auditLog`
+- `packages/core/src/license.ts` — add `"audit-log"` to Enterprise feature set; write `license.validation_failed` on failure
+- `packages/core/src/pm/scheduler.ts` — new `pruneAuditLog` step after `digest`; write `budget.run_refused` in budgetGuard using `evaluation.scopes`
+- `packages/core/src/pm/actions/promote.ts` — emit `pm.issue_promoted`
+- `packages/core/src/pm/actions/deprioritize.ts` — emit `pm.issue_deprioritized`
+- `packages/core/src/pm/actions/cancel.ts` — emit `pm.issue_cancelled`
+- `packages/core/src/pm/actions/triage.ts` — emit `pm.triage_classified`
+- `packages/cli/src/index.ts` (or whichever config loader runs at startup) — emit `config.loaded`
+- `packages/dashboard/src/views/layout.ts` — add "Audit" nav entry
+
+---
+
+## Task 1: Database schema + migration (foundation)
+
+**Files:**
+- Create: `packages/core/src/db/migrations/sqlite/006_audit_events.sql`
+- Create: `packages/core/src/db/migrations/postgres/007_audit_events.sql`
+- Modify: `packages/core/src/db/schema.ts`
+- Modify: `packages/core/src/db/client.ts` (`getCreateTablesDDL`)
+- Test: `packages/core/src/__tests__/db-audit-schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/db-audit-schema.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("audit_events schema", () => {
+  it("creates the table with required columns on fresh SQLite db", async () => {
+    const { db } = await createDb("sqlite::memory:");
+    const cols = (db as any).all(sql`PRAGMA table_info(audit_events)`) as Array<{name: string}>;
+    const names = cols.map(c => c.name).sort();
+    expect(names).toEqual([
+      "actor", "actor_type", "event_type", "id", "input_tokens",
+      "issue_id", "output_tokens", "payload", "run_id", "scope", "timestamp",
+    ]);
+  });
+
+  it("inserts and reads back an audit event", async () => {
+    const { db } = await createDb("sqlite::memory:");
+    await (db as any).insert(auditEvents).values({
+      id: "evt_1",
+      eventType: "pm.issue_promoted",
+      actor: "pm-agent",
+      actorType: "pm-agent",
+      scope: "team:T1",
+      runId: null,
+      issueId: "BEC-1",
+      inputTokens: 0,
+      outputTokens: 0,
+      payload: JSON.stringify({ test: true }),
+    });
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe("pm.issue_promoted");
+    expect(rows[0].timestamp).toBeInstanceOf(Date);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-audit-schema.test.ts
+```
+Expected: FAIL with `auditEvents` not exported or table missing.
+
+- [ ] **Step 3: Add the table to `db/schema.ts`**
+
+Add to `packages/core/src/db/schema.ts` at end:
+```ts
+export const auditEvents = sqliteTable("audit_events", {
+  id: text("id").primaryKey(),
+  timestamp: crossTimestamp("timestamp")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  eventType: text("event_type").notNull(),
+  actor: text("actor").notNull(),
+  actorType: text("actor_type").notNull(),
+  scope: text("scope"),
+  runId: text("run_id"),
+  issueId: text("issue_id"),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  payload: text("payload").notNull().default("{}"),
+});
+```
+
+- [ ] **Step 4: Create the SQLite migration file**
+
+Create `packages/core/src/db/migrations/sqlite/006_audit_events.sql`:
+```sql
+-- Enterprise feature 4.2: audit log + export
+CREATE TABLE IF NOT EXISTS audit_events (
+  id TEXT PRIMARY KEY,
+  timestamp INTEGER NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  actor_type TEXT NOT NULL,
+  scope TEXT,
+  run_id TEXT,
+  issue_id TEXT,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  payload TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);
+```
+
+- [ ] **Step 5: Create the Postgres migration file**
+
+Create `packages/core/src/db/migrations/postgres/007_audit_events.sql`:
+```sql
+-- Enterprise feature 4.2: audit log + export
+CREATE TABLE IF NOT EXISTS audit_events (
+  id TEXT PRIMARY KEY,
+  timestamp TIMESTAMPTZ NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  actor_type TEXT NOT NULL,
+  scope TEXT,
+  run_id TEXT,
+  issue_id TEXT,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  payload TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);
+```
+
+- [ ] **Step 6: Extend `getCreateTablesDDL()` in `db/client.ts`**
+
+Find `getCreateTablesDDL()` and append to the returned template string (before the closing backtick):
+```sql
+  CREATE TABLE IF NOT EXISTS audit_events (
+    id TEXT PRIMARY KEY,
+    timestamp ${ts} NOT NULL,
+    event_type TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    actor_type TEXT NOT NULL,
+    scope TEXT,
+    run_id TEXT,
+    issue_id TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    payload TEXT NOT NULL DEFAULT '{}'
+  );
+  CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);
+`;
+```
+
+- [ ] **Step 7: Run the test, verify it passes**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-audit-schema.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/core/src/db/schema.ts packages/core/src/db/client.ts packages/core/src/db/migrations packages/core/src/__tests__/db-audit-schema.test.ts
+git commit -m "feat(audit): add audit_events table and migration"
+```
+
+---
+
+## Task 2: Zod types for audit events
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+- Test: `packages/core/src/__tests__/audit-types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/audit-types.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { AuditEventSchema, AuditEventTypeSchema, AuditActorTypeSchema } from "../types.js";
+
+describe("audit event zod schemas", () => {
+  it("accepts all v1 event types", () => {
+    const types = [
+      "run.started","run.completed","run.failed","run.auto_merged","run.auto_merge_skipped",
+      "pm.approval_requested","pm.approval_resolved",
+      "pm.issue_promoted","pm.issue_deprioritized","pm.issue_cancelled","pm.triage_classified",
+      "budget.alert_fired","budget.run_refused",
+      "license.validation_failed","config.loaded","dashboard.manual_action",
+    ];
+    for (const t of types) expect(AuditEventTypeSchema.parse(t)).toBe(t);
+  });
+
+  it("rejects unknown event type", () => {
+    expect(() => AuditEventTypeSchema.parse("nope")).toThrow();
+  });
+
+  it("parses a minimal valid audit event", () => {
+    const evt = AuditEventSchema.parse({
+      id: "evt_1",
+      timestamp: new Date(),
+      eventType: "pm.issue_promoted",
+      actor: "pm-agent",
+      actorType: "pm-agent",
+      scope: null,
+      runId: null,
+      issueId: "BEC-1",
+      inputTokens: 0,
+      outputTokens: 0,
+      payload: { issueId: "BEC-1" },
+    });
+    expect(evt.eventType).toBe("pm.issue_promoted");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit-types.test.ts
+```
+Expected: FAIL — schemas don't exist.
+
+- [ ] **Step 3: Add schemas to `types.ts`**
+
+Append to `packages/core/src/types.ts`:
+```ts
+export const AuditEventTypeSchema = z.enum([
+  "run.started", "run.completed", "run.failed",
+  "run.auto_merged", "run.auto_merge_skipped",
+  "pm.approval_requested", "pm.approval_resolved",
+  "pm.issue_promoted", "pm.issue_deprioritized", "pm.issue_cancelled",
+  "pm.triage_classified",
+  "budget.alert_fired", "budget.run_refused",
+  "license.validation_failed", "config.loaded",
+  "dashboard.manual_action",
+]);
+export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
+
+export const AuditActorTypeSchema = z.enum([
+  "system", "pm-agent", "webhook", "dashboard-user", "cli",
+]);
+export type AuditActorType = z.infer<typeof AuditActorTypeSchema>;
+
+export const AuditEventSchema = z.object({
+  id: z.string(),
+  timestamp: z.date(),
+  eventType: AuditEventTypeSchema,
+  actor: z.string(),
+  actorType: AuditActorTypeSchema,
+  scope: z.string().nullable(),
+  runId: z.string().nullable(),
+  issueId: z.string().nullable(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  payload: z.record(z.unknown()),
+});
+export type AuditEvent = z.infer<typeof AuditEventSchema>;
+```
+
+Also add to the `AppConfig` zod schema (find the existing object and extend it):
+```ts
+auditLog: z.object({
+  enabled: z.boolean().optional(),
+  retentionDays: z.number().int().positive().optional().default(365),
+}).optional(),
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit-types.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/types.ts packages/core/src/__tests__/audit-types.test.ts
+git commit -m "feat(audit): zod schemas for audit events and config"
+```
+
+---
+
+## Task 3: Event builders (`audit/events.ts`)
+
+**Files:**
+- Create: `packages/core/src/audit/events.ts`
+- Create: `packages/core/src/audit/index.ts`
+- Test: `packages/core/src/__tests__/audit/events.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/src/__tests__/audit/events.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  pmPromotedEvent, pmDeprioritizedEvent, pmCancelledEvent, pmTriageClassifiedEvent,
+  budgetRefusedEvent, licenseValidationFailedEvent, configLoadedEvent,
+} from "../../audit/events.js";
+import { AuditEventSchema } from "../../types.js";
+
+describe("audit event builders", () => {
+  it("pmPromotedEvent produces a valid event", () => {
+    const evt = pmPromotedEvent({
+      issueId: "BEC-1", fromState: "Backlog", toState: "Todo",
+      priority: 2, reason: "top-of-queue",
+    });
+    const parsed = AuditEventSchema.parse(evt);
+    expect(parsed.eventType).toBe("pm.issue_promoted");
+    expect(parsed.actor).toBe("pm-agent");
+    expect(parsed.actorType).toBe("pm-agent");
+    expect(parsed.issueId).toBe("BEC-1");
+    expect(parsed.payload).toMatchObject({ fromState: "Backlog", toState: "Todo" });
+  });
+
+  it("budgetRefusedEvent includes scope breakdown", () => {
+    const evt = budgetRefusedEvent({
+      scope: "team:T1", scopeType: "team",
+      tokensUsed: 100000, limit: 100000, utilization: 100,
+    });
+    const parsed = AuditEventSchema.parse(evt);
+    expect(parsed.eventType).toBe("budget.run_refused");
+    expect(parsed.scope).toBe("team:T1");
+    expect(parsed.payload).toMatchObject({ tokensUsed: 100000, limit: 100000 });
+  });
+
+  it("licenseValidationFailedEvent sets actor=system", () => {
+    const evt = licenseValidationFailedEvent({ invalidReason: "expired" });
+    expect(evt.actor).toBe("system");
+    expect(evt.actorType).toBe("system");
+    expect(evt.eventType).toBe("license.validation_failed");
+  });
+
+  it("configLoadedEvent includes path + sha256 + tier", () => {
+    const evt = configLoadedEvent({ path: "/tmp/ura.yaml", sha256: "abc123", tier: "enterprise" });
+    expect(evt.eventType).toBe("config.loaded");
+    expect(evt.payload).toMatchObject({ path: "/tmp/ura.yaml", sha256: "abc123", tier: "enterprise" });
+  });
+
+  it("all builders return new ids and recent timestamps", () => {
+    const a = pmCancelledEvent({ issueId: "BEC-1", approvalId: "a1", reason: "stale" });
+    const b = pmCancelledEvent({ issueId: "BEC-2", approvalId: "a2", reason: "dup" });
+    expect(a.id).not.toBe(b.id);
+    expect(Date.now() - a.timestamp.getTime()).toBeLessThan(1000);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/events.test.ts
+```
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Create `audit/events.ts`**
+
+```ts
+import { randomUUID } from "node:crypto";
+import type { AuditEvent } from "../types.js";
+
+function base(partial: Partial<AuditEvent> & Pick<AuditEvent, "eventType" | "actor" | "actorType">): AuditEvent {
+  return {
+    id: `evt_${randomUUID()}`,
+    timestamp: new Date(),
+    scope: partial.scope ?? null,
+    runId: partial.runId ?? null,
+    issueId: partial.issueId ?? null,
+    inputTokens: partial.inputTokens ?? 0,
+    outputTokens: partial.outputTokens ?? 0,
+    payload: partial.payload ?? {},
+    ...partial,
+  };
+}
+
+export function pmPromotedEvent(args: {
+  issueId: string; fromState: string; toState: string; priority?: number; reason?: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.issue_promoted", actor: "pm-agent", actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: { fromState: args.fromState, toState: args.toState, priority: args.priority, reason: args.reason },
+  });
+}
+
+export function pmDeprioritizedEvent(args: {
+  issueId: string; oldPriority: number | null; newPriority: number; approvalId: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.issue_deprioritized", actor: "pm-agent", actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: { oldPriority: args.oldPriority, newPriority: args.newPriority, approvalId: args.approvalId },
+  });
+}
+
+export function pmCancelledEvent(args: {
+  issueId: string; approvalId: string; reason: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.issue_cancelled", actor: "pm-agent", actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: { approvalId: args.approvalId, reason: args.reason },
+  });
+}
+
+export function pmTriageClassifiedEvent(args: {
+  issueId: string; label: string; rationale: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.triage_classified", actor: "pm-agent", actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: { label: args.label, rationale: args.rationale.slice(0, 500) },
+  });
+}
+
+export function budgetRefusedEvent(args: {
+  scope: string; scopeType: "global" | "team" | "repo";
+  tokensUsed: number; limit: number; utilization: number; refusedRunId?: string;
+}): AuditEvent {
+  return base({
+    eventType: "budget.run_refused", actor: "pm-agent", actorType: "pm-agent",
+    scope: args.scope, runId: args.refusedRunId ?? null,
+    payload: {
+      scopeType: args.scopeType, tokensUsed: args.tokensUsed,
+      limit: args.limit, utilization: args.utilization,
+    },
+  });
+}
+
+export function licenseValidationFailedEvent(args: {
+  invalidReason: "missing" | "expired" | "bad-signature" | "wrong-issuer";
+  expiredAt?: Date;
+}): AuditEvent {
+  return base({
+    eventType: "license.validation_failed", actor: "system", actorType: "system",
+    payload: { invalidReason: args.invalidReason, expiredAt: args.expiredAt?.toISOString() },
+  });
+}
+
+export function configLoadedEvent(args: {
+  path: string; sha256: string; tier: string;
+}): AuditEvent {
+  return base({
+    eventType: "config.loaded", actor: "system", actorType: "system",
+    payload: { path: args.path, sha256: args.sha256, tier: args.tier },
+  });
+}
+```
+
+- [ ] **Step 4: Create barrel export**
+
+Create `packages/core/src/audit/index.ts`:
+```ts
+export * from "./events.js";
+export * from "./writer.js";
+export * from "./reader.js";
+export * from "./projection.js";
+export * from "./retention.js";
+export * from "./csv.js";
+```
+
+Note: later tasks will create the files referenced here. Until then, create stubs to prevent TS errors — or comment out the unresolved lines and uncomment as each task lands. Recommended: start with just `events.js` and add lines as subsequent tasks complete.
+
+For this task, use only:
+```ts
+export * from "./events.js";
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/events.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/audit packages/core/src/__tests__/audit/events.test.ts
+git commit -m "feat(audit): typed event builders"
+```
+
+---
+
+## Task 4: Writer (`audit/writer.ts`)
+
+**Files:**
+- Create: `packages/core/src/audit/writer.ts`
+- Modify: `packages/core/src/audit/index.ts`
+- Test: `packages/core/src/__tests__/audit/writer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/src/__tests__/audit/writer.test.ts`:
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents } from "../../db/schema.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent } from "../../audit/events.js";
+
+describe("logAuditEvent", () => {
+  it("persists an event row", async () => {
+    const { db } = await createDb("sqlite::memory:");
+    await logAuditEvent(db as any, pmPromotedEvent({
+      issueId: "BEC-1", fromState: "Backlog", toState: "Todo",
+    }));
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe("pm.issue_promoted");
+    expect(JSON.parse(rows[0].payload)).toMatchObject({ fromState: "Backlog", toState: "Todo" });
+  });
+
+  it("does not throw when the db insert fails", async () => {
+    const fakeDb = {
+      insert: () => ({ values: () => ({ run: () => { throw new Error("db down"); } }) }),
+    } as any;
+    // should not throw
+    await expect(logAuditEvent(fakeDb, pmPromotedEvent({
+      issueId: "BEC-1", fromState: "Backlog", toState: "Todo",
+    }))).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/writer.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create `audit/writer.ts`**
+
+```ts
+import type { AnyDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { createLogger } from "../logger.js";
+import type { AuditEvent } from "../types.js";
+
+const log = createLogger("audit.writer");
+
+/**
+ * Fire-and-forget insert of an audit event. Write failures are logged but
+ * never propagated — audit writes must not crash the caller.
+ *
+ * Callers should use `void logAuditEvent(...)` when they don't await.
+ */
+export async function logAuditEvent(db: AnyDb, event: AuditEvent): Promise<void> {
+  try {
+    await db.insert(auditEvents).values({
+      id: event.id,
+      timestamp: event.timestamp,
+      eventType: event.eventType,
+      actor: event.actor,
+      actorType: event.actorType,
+      scope: event.scope,
+      runId: event.runId,
+      issueId: event.issueId,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      payload: JSON.stringify(event.payload),
+    });
+  } catch (err) {
+    log.warn({ err, eventType: event.eventType, id: event.id }, "audit event write failed");
+  }
+}
+```
+
+Uncomment `export * from "./writer.js";` in `audit/index.ts`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/writer.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/audit/writer.ts packages/core/src/audit/index.ts packages/core/src/__tests__/audit/writer.test.ts
+git commit -m "feat(audit): fire-and-forget writer"
+```
+
+---
+
+## Task 5: Projection (`audit/projection.ts`)
+
+Projects `pipeline_runs`, `pm_approvals`, and `budget_alerts` rows into `AuditEvent[]`. Pure function — no DB calls here; the reader passes rows in.
+
+**Files:**
+- Create: `packages/core/src/audit/projection.ts`
+- Modify: `packages/core/src/audit/index.ts`
+- Test: `packages/core/src/__tests__/audit/projection.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/src/__tests__/audit/projection.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  projectPipelineRun, projectPmApproval, projectBudgetAlert,
+} from "../../audit/projection.js";
+
+describe("projection", () => {
+  it("projects a completed run into started + completed events", () => {
+    const startedAt = new Date("2026-04-01T10:00:00Z");
+    const completedAt = new Date("2026-04-01T10:05:00Z");
+    const events = projectPipelineRun({
+      id: "run_1", issueId: "BEC-1", pipelineKey: "auto-implement",
+      status: "completed", startedAt, completedAt,
+      totalInputTokens: 500, totalOutputTokens: 200,
+      runType: "standard", parentRunId: null, linearTeamId: "T1",
+      repoUrl: "https://github.com/x/y", autoMerged: null, autoMergeReason: null,
+      errorMessage: null,
+    } as any);
+    expect(events.map(e => e.eventType)).toEqual(["run.started", "run.completed"]);
+    expect(events[0].timestamp).toEqual(startedAt);
+    expect(events[1].timestamp).toEqual(completedAt);
+    expect(events[1].inputTokens).toBe(500);
+    expect(events[1].outputTokens).toBe(200);
+    expect(events[0].scope).toBe("team:T1");
+  });
+
+  it("projects a failed run into started + failed", () => {
+    const events = projectPipelineRun({
+      id: "run_2", issueId: "BEC-2", status: "failed",
+      startedAt: new Date(), completedAt: new Date(),
+      totalInputTokens: 0, totalOutputTokens: 0,
+      runType: "standard", parentRunId: null, linearTeamId: null,
+      repoUrl: "https://github.com/x/y", autoMerged: null, autoMergeReason: null,
+      errorMessage: "boom",
+    } as any);
+    expect(events.map(e => e.eventType)).toEqual(["run.started", "run.failed"]);
+    expect(events[1].payload.errorMessage).toBe("boom");
+  });
+
+  it("adds run.auto_merged when autoMerged=true", () => {
+    const events = projectPipelineRun({
+      id: "run_3", issueId: "BEC-3", status: "completed",
+      startedAt: new Date(), completedAt: new Date(),
+      totalInputTokens: 0, totalOutputTokens: 0,
+      runType: "standard", parentRunId: null, linearTeamId: null,
+      repoUrl: "x", autoMerged: true, autoMergeReason: "PR auto-merged",
+      errorMessage: null,
+    } as any);
+    expect(events.map(e => e.eventType)).toContain("run.auto_merged");
+  });
+
+  it("adds run.auto_merge_skipped when autoMerged=false with reason", () => {
+    const events = projectPipelineRun({
+      id: "run_4", issueId: "BEC-4", status: "completed",
+      startedAt: new Date(), completedAt: new Date(),
+      totalInputTokens: 0, totalOutputTokens: 0,
+      runType: "standard", parentRunId: null, linearTeamId: null,
+      repoUrl: "x", autoMerged: false, autoMergeReason: "diff too large",
+      errorMessage: null,
+    } as any);
+    expect(events.map(e => e.eventType)).toContain("run.auto_merge_skipped");
+  });
+
+  it("projects a pm approval into requested + resolved when resolvedAt set", () => {
+    const events = projectPmApproval({
+      id: "a1", issueId: "BEC-9", action: "cancel",
+      reason: "stale", slackMessageTs: "ts", status: "approved",
+      createdAt: new Date("2026-04-01"), resolvedAt: new Date("2026-04-02"),
+    } as any);
+    expect(events.map(e => e.eventType)).toEqual([
+      "pm.approval_requested", "pm.approval_resolved",
+    ]);
+  });
+
+  it("projects a budget alert", () => {
+    const ev = projectBudgetAlert({
+      id: "ba1", date: "2026-04-01", scope: "team:T1", threshold: 80,
+      firedAt: new Date("2026-04-01T10:00:00Z"),
+    } as any);
+    expect(ev.eventType).toBe("budget.alert_fired");
+    expect(ev.scope).toBe("team:T1");
+    expect(ev.payload).toMatchObject({ threshold: 80, date: "2026-04-01" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/projection.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create `audit/projection.ts`**
+
+```ts
+import type { AuditEvent, AuditActorType } from "../types.js";
+
+// Row types left loose-typed because drizzle-infer varies by driver;
+// projection consumers pass through `select().from(table)` results.
+type PipelineRunRow = {
+  id: string; issueId: string; status: string;
+  startedAt: Date; completedAt: Date | null;
+  totalInputTokens: number; totalOutputTokens: number;
+  runType: string; parentRunId: string | null;
+  linearTeamId: string | null; repoUrl: string;
+  autoMerged: boolean | null; autoMergeReason: string | null;
+  errorMessage: string | null;
+};
+
+function scopeForRun(row: PipelineRunRow): string | null {
+  if (row.linearTeamId) return `team:${row.linearTeamId}`;
+  return `repo:${row.repoUrl}`;
+}
+
+function actorForRun(row: PipelineRunRow): { actor: string; actorType: AuditActorType } {
+  if (row.runType === "review-feedback") return { actor: "github-webhook", actorType: "webhook" };
+  if (row.parentRunId) return { actor: "pm-agent", actorType: "pm-agent" };
+  return { actor: "linear-webhook", actorType: "webhook" };
+}
+
+export function projectPipelineRun(row: PipelineRunRow): AuditEvent[] {
+  const events: AuditEvent[] = [];
+  const { actor, actorType } = actorForRun(row);
+  const scope = scopeForRun(row);
+
+  events.push({
+    id: `proj_run_started_${row.id}`,
+    timestamp: row.startedAt,
+    eventType: "run.started",
+    actor, actorType, scope,
+    runId: row.id, issueId: row.issueId,
+    inputTokens: 0, outputTokens: 0,
+    payload: { runType: row.runType, repoUrl: row.repoUrl },
+  });
+
+  if (row.completedAt && row.status === "completed") {
+    events.push({
+      id: `proj_run_completed_${row.id}`,
+      timestamp: row.completedAt,
+      eventType: "run.completed",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: row.totalInputTokens,
+      outputTokens: row.totalOutputTokens,
+      payload: {},
+    });
+  }
+
+  if (row.completedAt && (row.status === "failed" || row.status === "retriable")) {
+    events.push({
+      id: `proj_run_failed_${row.id}`,
+      timestamp: row.completedAt,
+      eventType: "run.failed",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: row.totalInputTokens,
+      outputTokens: row.totalOutputTokens,
+      payload: { errorMessage: row.errorMessage, status: row.status },
+    });
+  }
+
+  if (row.autoMerged === true) {
+    events.push({
+      id: `proj_run_auto_merged_${row.id}`,
+      timestamp: row.completedAt ?? row.startedAt,
+      eventType: "run.auto_merged",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: 0, outputTokens: 0,
+      payload: { reason: row.autoMergeReason },
+    });
+  } else if (row.autoMerged === false && row.autoMergeReason) {
+    events.push({
+      id: `proj_run_auto_merge_skipped_${row.id}`,
+      timestamp: row.completedAt ?? row.startedAt,
+      eventType: "run.auto_merge_skipped",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: 0, outputTokens: 0,
+      payload: { reason: row.autoMergeReason },
+    });
+  }
+
+  return events;
+}
+
+type PmApprovalRow = {
+  id: string; issueId: string; action: string; reason: string;
+  status: string; createdAt: Date; resolvedAt: Date | null;
+};
+
+export function projectPmApproval(row: PmApprovalRow): AuditEvent[] {
+  const events: AuditEvent[] = [{
+    id: `proj_approval_requested_${row.id}`,
+    timestamp: row.createdAt,
+    eventType: "pm.approval_requested",
+    actor: "pm-agent", actorType: "pm-agent",
+    scope: null, runId: null, issueId: row.issueId,
+    inputTokens: 0, outputTokens: 0,
+    payload: { approvalId: row.id, action: row.action, reason: row.reason },
+  }];
+  if (row.resolvedAt) {
+    events.push({
+      id: `proj_approval_resolved_${row.id}`,
+      timestamp: row.resolvedAt,
+      eventType: "pm.approval_resolved",
+      actor: "pm-agent", actorType: "pm-agent",
+      scope: null, runId: null, issueId: row.issueId,
+      inputTokens: 0, outputTokens: 0,
+      payload: { approvalId: row.id, action: row.action, status: row.status },
+    });
+  }
+  return events;
+}
+
+type BudgetAlertRow = {
+  id: string; date: string; scope: string; threshold: number; firedAt: Date;
+};
+
+export function projectBudgetAlert(row: BudgetAlertRow): AuditEvent {
+  return {
+    id: `proj_budget_alert_${row.id}`,
+    timestamp: row.firedAt,
+    eventType: "budget.alert_fired",
+    actor: "pm-agent", actorType: "pm-agent",
+    scope: row.scope,
+    runId: null, issueId: null,
+    inputTokens: 0, outputTokens: 0,
+    payload: { threshold: row.threshold, date: row.date },
+  };
+}
+```
+
+Add `export * from "./projection.js";` to `audit/index.ts`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/projection.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/audit/projection.ts packages/core/src/audit/index.ts packages/core/src/__tests__/audit/projection.test.ts
+git commit -m "feat(audit): row-to-event projection"
+```
+
+---
+
+## Task 6: Reader (`audit/reader.ts`)
+
+Merges native audit rows with projected events and supports filtered, cursor-paginated queries.
+
+**Files:**
+- Create: `packages/core/src/audit/reader.ts`
+- Modify: `packages/core/src/audit/index.ts`
+- Test: `packages/core/src/__tests__/audit/reader.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/src/__tests__/audit/reader.test.ts`:
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents, pipelineRuns, pmApprovals, budgetAlerts } from "../../db/schema.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent, budgetRefusedEvent } from "../../audit/events.js";
+import { listAuditEvents } from "../../audit/reader.js";
+
+let db: any;
+
+beforeEach(async () => {
+  const c = await createDb("sqlite::memory:");
+  db = c.db;
+});
+
+async function seed() {
+  // native audit events
+  await logAuditEvent(db, pmPromotedEvent({ issueId: "BEC-1", fromState: "Backlog", toState: "Todo" }));
+  await logAuditEvent(db, budgetRefusedEvent({
+    scope: "team:T1", scopeType: "team", tokensUsed: 100, limit: 100, utilization: 100,
+  }));
+  // projectable: pipeline run
+  await db.insert(pipelineRuns).values({
+    id: "run_1", issueId: "BEC-9", issueTitle: "t", pipelineKey: "auto-implement",
+    repoUrl: "https://x.y/z", status: "completed",
+    startedAt: new Date("2026-04-01T10:00:00Z"),
+    completedAt: new Date("2026-04-01T10:05:00Z"),
+    totalInputTokens: 100, totalOutputTokens: 50, runType: "standard",
+    linearTeamId: "T1",
+  });
+}
+
+describe("listAuditEvents", () => {
+  it("returns native + projected events merged by time", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { limit: 100 });
+    const types = events.map(e => e.eventType).sort();
+    expect(types).toContain("pm.issue_promoted");
+    expect(types).toContain("budget.run_refused");
+    expect(types).toContain("run.started");
+    expect(types).toContain("run.completed");
+  });
+
+  it("filters by event type", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { eventTypes: ["run.completed"], limit: 100 });
+    expect(events.map(e => e.eventType)).toEqual(["run.completed"]);
+  });
+
+  it("filters by scope prefix-exact", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { scope: "team:T1", limit: 100 });
+    for (const e of events) expect(e.scope === "team:T1" || e.scope === null).toBeTruthy();
+    expect(events.some(e => e.scope === "team:T1")).toBe(true);
+  });
+
+  it("filters by date window", async () => {
+    await seed();
+    const from = new Date("2026-04-01T09:00:00Z");
+    const to = new Date("2026-04-01T10:10:00Z");
+    const { events } = await listAuditEvents(db, { from, to, limit: 100 });
+    for (const e of events) {
+      expect(e.timestamp >= from && e.timestamp <= to).toBe(true);
+    }
+  });
+
+  it("filters by runId", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { runId: "run_1", limit: 100 });
+    expect(events.length).toBeGreaterThan(0);
+    for (const e of events) expect(e.runId).toBe("run_1");
+  });
+
+  it("paginates via cursor", async () => {
+    // seed 5 promoted events
+    for (let i = 0; i < 5; i++) {
+      await logAuditEvent(db, pmPromotedEvent({ issueId: `BEC-${i}`, fromState: "Backlog", toState: "Todo" }));
+      await new Promise(r => setTimeout(r, 10));
+    }
+    const page1 = await listAuditEvents(db, { limit: 2 });
+    expect(page1.events).toHaveLength(2);
+    expect(page1.nextCursor).not.toBeNull();
+    const page2 = await listAuditEvents(db, { limit: 2, cursor: page1.nextCursor! });
+    expect(page2.events).toHaveLength(2);
+    const seen = new Set([...page1.events, ...page2.events].map(e => e.id));
+    expect(seen.size).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/reader.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create `audit/reader.ts`**
+
+```ts
+import { and, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { auditEvents, pipelineRuns, pmApprovals, budgetAlerts } from "../db/schema.js";
+import type { AuditEvent, AuditEventType } from "../types.js";
+import { projectPipelineRun, projectPmApproval, projectBudgetAlert } from "./projection.js";
+
+export interface ListAuditEventsFilters {
+  from?: Date;
+  to?: Date;
+  scope?: string;
+  eventTypes?: AuditEventType[];
+  actor?: string;
+  runId?: string;
+  issueId?: string;
+  q?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListAuditEventsResult {
+  events: AuditEvent[];
+  nextCursor: string | null;
+}
+
+interface Cursor { ts: string; id: string }
+
+function encodeCursor(c: Cursor): string {
+  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
+}
+
+function decodeCursor(s: string): Cursor {
+  return JSON.parse(Buffer.from(s, "base64url").toString("utf8"));
+}
+
+function parseNativeRow(row: any): AuditEvent {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    eventType: row.eventType,
+    actor: row.actor,
+    actorType: row.actorType,
+    scope: row.scope ?? null,
+    runId: row.runId ?? null,
+    issueId: row.issueId ?? null,
+    inputTokens: row.inputTokens ?? 0,
+    outputTokens: row.outputTokens ?? 0,
+    payload: (() => { try { return JSON.parse(row.payload ?? "{}"); } catch { return {}; } })(),
+  };
+}
+
+export async function listAuditEvents(
+  db: AnyDb,
+  filters: ListAuditEventsFilters = {},
+): Promise<ListAuditEventsResult> {
+  const limit = Math.min(filters.limit ?? 50, 500);
+  const cursor = filters.cursor ? decodeCursor(filters.cursor) : null;
+  const cursorTs = cursor ? new Date(cursor.ts) : null;
+
+  // Native audit_events query
+  const nativeConditions: any[] = [];
+  if (filters.from) nativeConditions.push(gte(auditEvents.timestamp, filters.from));
+  if (filters.to) nativeConditions.push(lte(auditEvents.timestamp, filters.to));
+  if (filters.scope) nativeConditions.push(eq(auditEvents.scope, filters.scope));
+  if (filters.eventTypes?.length) nativeConditions.push(inArray(auditEvents.eventType, filters.eventTypes));
+  if (filters.runId) nativeConditions.push(eq(auditEvents.runId, filters.runId));
+  if (filters.issueId) nativeConditions.push(eq(auditEvents.issueId, filters.issueId));
+  if (cursorTs) nativeConditions.push(lte(auditEvents.timestamp, cursorTs));
+
+  const nativeRows = await db.select().from(auditEvents)
+    .where(nativeConditions.length ? and(...nativeConditions) : undefined)
+    .orderBy(desc(auditEvents.timestamp))
+    .limit(limit * 2);
+
+  // Projected: pipeline_runs
+  const runConditions: any[] = [];
+  if (filters.from) runConditions.push(gte(pipelineRuns.startedAt, filters.from));
+  if (filters.to) runConditions.push(lte(pipelineRuns.startedAt, filters.to));
+  if (filters.runId) runConditions.push(eq(pipelineRuns.id, filters.runId));
+  if (filters.issueId) runConditions.push(eq(pipelineRuns.issueId, filters.issueId));
+  const runRows = await db.select().from(pipelineRuns)
+    .where(runConditions.length ? and(...runConditions) : undefined)
+    .orderBy(desc(pipelineRuns.startedAt))
+    .limit(limit * 2);
+
+  // Projected: pm_approvals
+  const apprRows = await db.select().from(pmApprovals)
+    .orderBy(desc(pmApprovals.createdAt))
+    .limit(limit * 2);
+
+  // Projected: budget_alerts
+  const alertRows = await db.select().from(budgetAlerts)
+    .orderBy(desc(budgetAlerts.firedAt))
+    .limit(limit * 2);
+
+  const merged: AuditEvent[] = [
+    ...nativeRows.map(parseNativeRow),
+    ...runRows.flatMap(projectPipelineRun as any),
+    ...apprRows.flatMap(projectPmApproval as any),
+    ...alertRows.map(projectBudgetAlert as any),
+  ];
+
+  // Apply filters that weren't pushed to SQL (actor prefix, q, eventType on projected, scope on projected)
+  const filtered = merged.filter(e => {
+    if (filters.from && e.timestamp < filters.from) return false;
+    if (filters.to && e.timestamp > filters.to) return false;
+    if (filters.scope && e.scope !== filters.scope) return false;
+    if (filters.eventTypes?.length && !filters.eventTypes.includes(e.eventType)) return false;
+    if (filters.actor && !e.actor.startsWith(filters.actor)) return false;
+    if (filters.runId && e.runId !== filters.runId) return false;
+    if (filters.issueId && e.issueId !== filters.issueId) return false;
+    if (filters.q) {
+      const hay = JSON.stringify(e.payload) + " " + e.actor;
+      if (!hay.toLowerCase().includes(filters.q.toLowerCase())) return false;
+    }
+    if (cursor) {
+      if (e.timestamp.getTime() > new Date(cursor.ts).getTime()) return false;
+      if (e.timestamp.getTime() === new Date(cursor.ts).getTime() && e.id >= cursor.id) return false;
+    }
+    return true;
+  });
+
+  // Sort desc by (timestamp, id)
+  filtered.sort((a, b) => {
+    const d = b.timestamp.getTime() - a.timestamp.getTime();
+    return d !== 0 ? d : (b.id > a.id ? 1 : -1);
+  });
+
+  const page = filtered.slice(0, limit);
+  const nextCursor = filtered.length > limit
+    ? encodeCursor({ ts: page[page.length - 1].timestamp.toISOString(), id: page[page.length - 1].id })
+    : null;
+
+  return { events: page, nextCursor };
+}
+```
+
+Add `export * from "./reader.js";` to `audit/index.ts`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/reader.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/audit/reader.ts packages/core/src/audit/index.ts packages/core/src/__tests__/audit/reader.test.ts
+git commit -m "feat(audit): reader with filters and cursor pagination"
+```
+
+---
+
+## Task 7: Retention sweep (`audit/retention.ts`)
+
+**Files:**
+- Create: `packages/core/src/audit/retention.ts`
+- Modify: `packages/core/src/audit/index.ts`
+- Test: `packages/core/src/__tests__/audit/retention.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/__tests__/audit/retention.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents, pipelineRuns } from "../../db/schema.js";
+import { pruneAuditLog } from "../../audit/retention.js";
+
+describe("pruneAuditLog", () => {
+  it("deletes rows older than retentionDays", async () => {
+    const { db } = await createDb("sqlite::memory:") as any;
+    const now = Date.now();
+    await db.insert(auditEvents).values([
+      { id: "old", timestamp: new Date(now - 400 * 86400000),
+        eventType: "pm.issue_promoted", actor: "pm-agent", actorType: "pm-agent", payload: "{}" },
+      { id: "new", timestamp: new Date(now - 10 * 86400000),
+        eventType: "pm.issue_promoted", actor: "pm-agent", actorType: "pm-agent", payload: "{}" },
+    ] as any);
+    const deleted = await pruneAuditLog(db, 365);
+    expect(deleted).toBe(1);
+    const rows = await db.select().from(auditEvents);
+    expect(rows.map((r: any) => r.id)).toEqual(["new"]);
+  });
+
+  it("does not touch pipeline_runs", async () => {
+    const { db } = await createDb("sqlite::memory:") as any;
+    await db.insert(pipelineRuns).values({
+      id: "r1", issueId: "BEC-1", issueTitle: "t", pipelineKey: "auto-implement",
+      repoUrl: "x", status: "completed",
+      startedAt: new Date(Date.now() - 400 * 86400000),
+    } as any);
+    await pruneAuditLog(db, 365);
+    const rows = await db.select().from(pipelineRuns);
+    expect(rows).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/retention.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create `audit/retention.ts`**
+
+```ts
+import { lt } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("audit.retention");
+
+/**
+ * Deletes audit_events rows older than `retentionDays`.
+ *
+ * This is the SOLE authorized mutation on the audit_events table. The
+ * audit-immutability lint test grep-checks that no other file in the
+ * codebase calls `update(auditEvents)` or `delete(auditEvents)`.
+ *
+ * Returns the number of rows deleted.
+ */
+export async function pruneAuditLog(db: AnyDb, retentionDays: number): Promise<number> {
+  const cutoff = new Date(Date.now() - retentionDays * 86400_000);
+  const result = await db.delete(auditEvents).where(lt(auditEvents.timestamp, cutoff));
+  const n = (result as any)?.changes ?? (result as any)?.rowCount ?? 0;
+  log.info({ retentionDays, cutoff, deleted: n }, "audit log pruned");
+  return n;
+}
+```
+
+Add `export * from "./retention.js";` to `audit/index.ts`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/retention.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/audit/retention.ts packages/core/src/audit/index.ts packages/core/src/__tests__/audit/retention.test.ts
+git commit -m "feat(audit): retention sweep"
+```
+
+---
+
+## Task 8: CSV stream (`audit/csv.ts`)
+
+**Files:**
+- Create: `packages/core/src/audit/csv.ts`
+- Modify: `packages/core/src/audit/index.ts`
+- Test: `packages/core/src/__tests__/audit/csv.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/__tests__/audit/csv.test.ts`:
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent } from "../../audit/events.js";
+import { streamAuditCsv } from "../../audit/csv.js";
+
+async function collect(iter: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const chunk of iter) out += chunk;
+  return out;
+}
+
+describe("streamAuditCsv", () => {
+  let db: any;
+  beforeEach(async () => { db = (await createDb("sqlite::memory:")).db; });
+
+  it("emits header row then data rows", async () => {
+    await logAuditEvent(db, pmPromotedEvent({ issueId: "BEC-1", fromState: "B", toState: "T" }));
+    const csv = await collect(streamAuditCsv(db, {}));
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe("timestamp_utc,event_type,actor,actor_type,scope,run_id,issue_id,input_tokens,output_tokens,payload_json");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(lines[1]).toContain("pm.issue_promoted");
+    expect(lines[1]).toContain("BEC-1");
+  });
+
+  it("escapes quotes and commas in payload", async () => {
+    const evt = pmPromotedEvent({ issueId: "BEC-1", fromState: "B", toState: "T", reason: 'has "quotes", commas' });
+    await logAuditEvent(db, evt);
+    const csv = await collect(streamAuditCsv(db, {}));
+    // Quoted field with escaped internal quotes
+    expect(csv).toMatch(/"[^"]*""quotes""[^"]*"/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/csv.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create `audit/csv.ts`**
+
+```ts
+import type { AnyDb } from "../db/client.js";
+import { listAuditEvents, type ListAuditEventsFilters } from "./reader.js";
+import type { AuditEvent } from "../types.js";
+
+const HEADER = "timestamp_utc,event_type,actor,actor_type,scope,run_id,issue_id,input_tokens,output_tokens,payload_json";
+
+function csvEscape(v: string | number | null | undefined): string {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function rowFor(e: AuditEvent): string {
+  return [
+    e.timestamp.toISOString(),
+    e.eventType,
+    e.actor,
+    e.actorType,
+    e.scope ?? "",
+    e.runId ?? "",
+    e.issueId ?? "",
+    e.inputTokens,
+    e.outputTokens,
+    JSON.stringify(e.payload),
+  ].map(csvEscape).join(",");
+}
+
+/**
+ * Streams the audit log as CSV. Pages through listAuditEvents in chunks of
+ * `pageSize` to keep memory bounded regardless of total export size.
+ */
+export async function* streamAuditCsv(
+  db: AnyDb,
+  filters: ListAuditEventsFilters,
+  pageSize = 1000,
+): AsyncIterable<string> {
+  yield HEADER + "\n";
+  let cursor: string | null = null;
+  do {
+    const { events, nextCursor } = await listAuditEvents(db, { ...filters, limit: pageSize, cursor: cursor ?? undefined });
+    for (const e of events) yield rowFor(e) + "\n";
+    cursor = nextCursor;
+  } while (cursor);
+}
+```
+
+Add `export * from "./csv.js";` to `audit/index.ts`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/csv.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/audit/csv.ts packages/core/src/audit/index.ts packages/core/src/__tests__/audit/csv.test.ts
+git commit -m "feat(audit): streaming CSV export"
+```
+
+---
+
+## Task 9: Immutability lint test
+
+**Files:**
+- Create: `packages/core/src/__tests__/audit-immutability.test.ts`
+
+- [ ] **Step 1: Create the lint test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+describe("audit_events immutability", () => {
+  it("only audit/retention.ts may delete or update audit_events rows", () => {
+    const repoRoot = path.resolve(__dirname, "../../../..");
+    const allowed = [
+      "packages/core/src/audit/retention.ts",
+      "packages/core/src/__tests__/audit/retention.test.ts",
+      "packages/core/src/__tests__/audit-immutability.test.ts",
+    ];
+
+    const patterns = [
+      "\\.delete\\s*\\(\\s*auditEvents",
+      "\\.update\\s*\\(\\s*auditEvents",
+    ];
+
+    let matches: string[] = [];
+    for (const pat of patterns) {
+      try {
+        const out = execFileSync("git", [
+          "grep", "-nE", pat, "--", "packages/**/*.ts",
+        ], { cwd: repoRoot, encoding: "utf8" });
+        matches.push(...out.trim().split("\n").filter(Boolean));
+      } catch {
+        // git grep exits non-zero when no matches; safe to ignore
+      }
+    }
+
+    const offenders = matches
+      .map(line => line.split(":")[0])
+      .filter(file => !allowed.some(a => file.endsWith(a) || file === a));
+
+    expect(offenders, `Unauthorized audit_events mutation in:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect pass (nothing should be violating)**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit-immutability.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/core/src/__tests__/audit-immutability.test.ts
+git commit -m "test(audit): immutability lint"
+```
+
+---
+
+## Task 10: Wire `budget.run_refused` in scheduler
+
+Recover the `ScopeBudget[]` data currently dropped in `pm/scheduler.ts` budgetGuard.
+
+**Files:**
+- Modify: `packages/core/src/pm/scheduler.ts`
+- Test: `packages/core/src/__tests__/pm-budget-refused-event.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/__tests__/pm-budget-refused-event.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { runTick } from "../pm/scheduler.js";
+
+describe("budget.run_refused audit event", () => {
+  it("writes one event per blocked scope from evaluateBudget", async () => {
+    const { db } = await createDb("sqlite::memory:") as any;
+
+    const fakeEvaluateBudget = async () => ({
+      scopes: [
+        { scope: { kind: "global" }, scopeLabel: "global", limit: 100, used: 100, percent: 100, tier: "blocked-100" },
+        { scope: { kind: "team", teamId: "T1" }, scopeLabel: "team T1", limit: 50, used: 60, percent: 120, tier: "blocked-100" },
+        { scope: { kind: "repo", repoUrl: "x" }, scopeLabel: "repo x", limit: 100, used: 10, percent: 10, tier: "ok" },
+      ],
+      worstTier: "blocked-100",
+      promoteBlocked: true,
+      blockReason: "global at 100%",
+      activeCount: 0,
+    });
+
+    await runTick({
+      db, config: { maxInFlight: 5, budgets: {} } as any, linear: {} as any,
+    }, { evaluateBudget: fakeEvaluateBudget } as any);
+
+    const rows = await db.select().from(auditEvents);
+    const refused = rows.filter((r: any) => r.eventType === "budget.run_refused");
+    expect(refused).toHaveLength(2); // global + team T1
+    const scopes = refused.map((r: any) => r.scope).sort();
+    expect(scopes).toEqual(["global", "team:T1"]);
+  });
+});
+```
+
+Note: adapt the exact `runTick` call to whatever `scheduler.ts` actually exports — inspect the file before writing the test. If `runTick` is not directly exported, use whatever tick entry point is exported.
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm-budget-refused-event.test.ts
+```
+Expected: FAIL (no `budget.run_refused` rows written).
+
+- [ ] **Step 3: Modify `pm/scheduler.ts`**
+
+Find the block around line 160 where `tick.budgetGuard` is derived. After firing the existing threshold alerts, add:
+
+```ts
+// Emit budget.run_refused audit events for every scope at blocked-100
+if (evaluation.promoteBlocked) {
+  const { logAuditEvent, budgetRefusedEvent } = await import("../audit/index.js");
+  for (const s of evaluation.scopes) {
+    if (s.tier !== "blocked-100") continue;
+    const scopeKey =
+      s.scope.kind === "global" ? "global" :
+      s.scope.kind === "team" ? `team:${s.scope.teamId}` :
+      `repo:${s.scope.repoUrl}`;
+    void logAuditEvent(db, budgetRefusedEvent({
+      scope: scopeKey,
+      scopeType: s.scope.kind as "global" | "team" | "repo",
+      tokensUsed: s.used, limit: s.limit, utilization: s.percent,
+    }));
+  }
+}
+```
+
+Use a dynamic import only if a static import would create a cycle; otherwise prefer a top-of-file `import { logAuditEvent, budgetRefusedEvent } from "../audit/index.js";`. Check for circular imports first.
+
+- [ ] **Step 4: Run test, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm-budget-refused-event.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the broader scheduler test suite to catch regressions**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm
+```
+Expected: all existing scheduler tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/pm/scheduler.ts packages/core/src/__tests__/pm-budget-refused-event.test.ts
+git commit -m "feat(audit): write budget.run_refused with per-scope breakdown"
+```
+
+---
+
+## Task 11: Wire PM action audit events
+
+Emit `pm.issue_promoted`, `pm.issue_deprioritized`, `pm.issue_cancelled`, `pm.triage_classified`.
+
+**Files:**
+- Modify: `packages/core/src/pm/actions/promote.ts`
+- Modify: `packages/core/src/pm/actions/deprioritize.ts`
+- Modify: `packages/core/src/pm/actions/cancel.ts`
+- Modify: `packages/core/src/pm/actions/triage.ts`
+- Test: `packages/core/src/__tests__/pm-action-audit-events.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/__tests__/pm-action-audit-events.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+// Import the action under test; stub Linear / Slack clients minimally.
+
+describe("pm action audit events", () => {
+  it.todo("emits pm.issue_promoted when promote.ts moves issue to Todo");
+  it.todo("emits pm.issue_deprioritized after approval resolves");
+  it.todo("emits pm.issue_cancelled after approval resolves");
+  it.todo("emits pm.triage_classified after Haiku classifies");
+});
+```
+
+The exact test shape depends on how each action currently stubs its dependencies. **Before writing the test bodies**, read each action file and its existing tests (`src/__tests__/pm-*.test.ts`) to match the existing stubbing pattern, then replace each `it.todo` with a real test that:
+1. Invokes the action with a fake Linear client
+2. Asserts that a row appears in `audit_events` with the expected `eventType`, `issueId`, and payload
+
+- [ ] **Step 2: Run test, confirm the new assertions fail**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm-action-audit-events.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Add `logAuditEvent` calls to each action file**
+
+In `promote.ts`, after the successful Linear state update:
+```ts
+import { logAuditEvent, pmPromotedEvent } from "../../audit/index.js";
+// ...
+void logAuditEvent(deps.db, pmPromotedEvent({
+  issueId: issue.id,
+  fromState: fromStateName,
+  toState: "Todo",
+  priority: issue.priority,
+  reason: "top-of-queue",
+}));
+```
+
+In `deprioritize.ts`, after the approval resolves and priority changes:
+```ts
+void logAuditEvent(deps.db, pmDeprioritizedEvent({
+  issueId: issue.id, oldPriority: prevPriority, newPriority: newPriority, approvalId: approval.id,
+}));
+```
+
+In `cancel.ts`, after the cancellation completes:
+```ts
+void logAuditEvent(deps.db, pmCancelledEvent({
+  issueId: issue.id, approvalId: approval.id, reason: reason,
+}));
+```
+
+In `triage.ts`, after the Haiku classification succeeds and the label is applied:
+```ts
+void logAuditEvent(deps.db, pmTriageClassifiedEvent({
+  issueId: issue.id, label: classifiedLabel, rationale: classifiedRationale,
+}));
+```
+
+Pass `db` through the action's `deps` object if it's not already there (check each action's current signature).
+
+- [ ] **Step 4: Run the new test file + existing PM action tests**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm-action-audit-events.test.ts
+cd packages/core && npx vitest run src/__tests__/pm-promote src/__tests__/pm-triage src/__tests__/pm-cancel src/__tests__/pm-deprioritize
+```
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/pm/actions packages/core/src/__tests__/pm-action-audit-events.test.ts
+git commit -m "feat(audit): emit pm action events"
+```
+
+---
+
+## Task 12: Wire license + config audit events
+
+**Files:**
+- Modify: `packages/core/src/license.ts`
+- Modify: config loader in `packages/cli/src/index.ts` (or wherever `AppConfig` is first loaded)
+- Test: `packages/core/src/__tests__/license-audit-event.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/core/src/__tests__/license-audit-event.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { checkLicenseWithAudit, _resetLicenseCache } from "../license.js";
+
+describe("license validation audit event", () => {
+  it("writes license.validation_failed when the JWT is invalid", async () => {
+    const { db } = await createDb("sqlite::memory:") as any;
+    _resetLicenseCache();
+    process.env.URATEAM_LICENSE_KEY = "not-a-jwt";
+    await checkLicenseWithAudit(db);
+    const rows = await db.select().from(auditEvents);
+    const evts = rows.filter((r: any) => r.eventType === "license.validation_failed");
+    expect(evts.length).toBeGreaterThan(0);
+    delete process.env.URATEAM_LICENSE_KEY;
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/license-audit-event.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Add an audit-emitting wrapper in `license.ts`**
+
+```ts
+import { logAuditEvent, licenseValidationFailedEvent } from "./audit/index.js";
+import type { AnyDb } from "./db/client.js";
+
+export async function checkLicenseWithAudit(db: AnyDb | null): Promise<LicenseStatus> {
+  const status = checkLicense();
+  if (status.invalidReason && db) {
+    await logAuditEvent(db, licenseValidationFailedEvent({
+      invalidReason: status.invalidReason,
+      expiredAt: status.expiresAt,
+    }));
+  }
+  return status;
+}
+```
+
+Also add `"audit-log"` to the Enterprise feature set (wherever the tier-to-feature mapping lives in `license.ts`).
+
+Call `checkLicenseWithAudit(db)` from the startup path (CLI `index.ts` and dashboard server boot) once `db` is available. `checkLicense()` remains the cache-only accessor.
+
+- [ ] **Step 4: Emit `config.loaded` at startup**
+
+In the config loader (`packages/cli/src/index.ts`), after the config is loaded and validated:
+```ts
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { logAuditEvent, configLoadedEvent } from "@urateam/core/audit";
+
+// ...
+const sha256 = createHash("sha256").update(fs.readFileSync(configPath)).digest("hex");
+void logAuditEvent(db, configLoadedEvent({
+  path: configPath, sha256, tier: licenseStatus.tier,
+}));
+```
+
+If `@urateam/core/audit` isn't an existing export path, use the package's existing export structure — typically `from "@urateam/core"` re-exported via the core package `index.ts`. Check `packages/core/src/index.ts` and add `export * from "./audit/index.js";` if not present.
+
+- [ ] **Step 5: Run tests**
+
+```
+cd packages/core && npx vitest run src/__tests__/license-audit-event.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/license.ts packages/core/src/index.ts packages/cli/src/index.ts packages/core/src/__tests__/license-audit-event.test.ts
+git commit -m "feat(audit): license + config startup events"
+```
+
+---
+
+## Task 13: Scheduler retention sweep step
+
+Add `pruneAuditLog` as the final step of the PM tick.
+
+**Files:**
+- Modify: `packages/core/src/pm/scheduler.ts`
+- Test: `packages/core/src/__tests__/pm-audit-retention-step.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { runTick } from "../pm/scheduler.js";
+
+describe("pm tick retention sweep", () => {
+  it("deletes audit_events older than retentionDays", async () => {
+    const { db } = await createDb("sqlite::memory:") as any;
+    await db.insert(auditEvents).values({
+      id: "old", timestamp: new Date(Date.now() - 400 * 86400000),
+      eventType: "pm.issue_promoted", actor: "pm-agent", actorType: "pm-agent", payload: "{}",
+    } as any);
+    await runTick({
+      db, config: { maxInFlight: 5, auditLog: { retentionDays: 365 } } as any,
+      linear: {} as any,
+    });
+    const rows = await db.select().from(auditEvents);
+    expect(rows.find((r: any) => r.id === "old")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm-audit-retention-step.test.ts
+```
+
+- [ ] **Step 3: Add the step to `scheduler.ts`**
+
+After the `digest` step, before the tick completes:
+```ts
+// Audit log retention sweep (no-op if unlicensed or not configured)
+try {
+  if (isFeatureLicensed("audit-log")) {
+    const { pruneAuditLog } = await import("../audit/index.js");
+    const days = config.auditLog?.retentionDays ?? 365;
+    await pruneAuditLog(db, days);
+  }
+} catch (err) {
+  log.warn({ err }, "audit retention sweep failed");
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm-audit-retention-step.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/pm/scheduler.ts packages/core/src/__tests__/pm-audit-retention-step.test.ts
+git commit -m "feat(audit): retention sweep in pm tick"
+```
+
+---
+
+## Task 14: Dashboard audit route + view
+
+**Files:**
+- Create: `packages/dashboard/src/routes/audit.ts`
+- Create: `packages/dashboard/src/views/audit.ts`
+- Modify: `packages/dashboard/src/views/layout.ts`
+- Modify: `packages/dashboard/src/server.ts` (register route)
+- Test: `packages/dashboard/src/__tests__/audit.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/dashboard/src/__tests__/audit.test.ts`:
+```ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { buildServer } from "../server.js";
+import { createDb } from "@urateam/core";
+import { logAuditEvent, pmPromotedEvent } from "@urateam/core";
+
+describe("/audit routes", () => {
+  let app: any;
+  let db: any;
+
+  beforeEach(async () => {
+    vi.stubEnv("URATEAM_LICENSE_KEY", ""); // unlicensed by default
+    db = (await createDb("sqlite::memory:")).db;
+    app = buildServer({ db });
+  });
+
+  it("returns 404 when audit-log feature is not licensed", async () => {
+    const res = await app.request("/audit");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 and renders page when licensed", async () => {
+    vi.stubEnv("FORCE_LICENSE", "enterprise"); // or use license test hook
+    app = buildServer({ db });
+    await logAuditEvent(db, pmPromotedEvent({ issueId: "BEC-1", fromState: "B", toState: "T" }));
+    const res = await app.request("/audit");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Audit");
+    expect(body).toContain("pm.issue_promoted");
+  });
+
+  it("exports CSV when licensed", async () => {
+    vi.stubEnv("FORCE_LICENSE", "enterprise");
+    app = buildServer({ db });
+    await logAuditEvent(db, pmPromotedEvent({ issueId: "BEC-1", fromState: "B", toState: "T" }));
+    const res = await app.request("/audit/export.csv");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/csv");
+    const body = await res.text();
+    expect(body).toContain("timestamp_utc,event_type");
+    expect(body).toContain("pm.issue_promoted");
+  });
+});
+```
+
+Adjust the license-bypass mechanism (`FORCE_LICENSE` or equivalent) to match whatever test hook the existing license tests use. If none exists, use `_resetLicenseCache()` + a minted test JWT.
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/audit.test.ts
+```
+
+- [ ] **Step 3: Create the route**
+
+Create `packages/dashboard/src/routes/audit.ts`:
+```ts
+import { Hono } from "hono";
+import { isFeatureLicensed, listAuditEvents, streamAuditCsv } from "@urateam/core";
+import { renderAuditPage } from "../views/audit.js";
+
+export function auditRoutes(deps: { db: any }) {
+  const app = new Hono();
+
+  app.use("*", async (c, next) => {
+    if (!isFeatureLicensed("audit-log")) return c.notFound();
+    await next();
+  });
+
+  app.get("/", async (c) => {
+    const url = new URL(c.req.url);
+    const filters = parseFilters(url.searchParams);
+    const { events, nextCursor } = await listAuditEvents(deps.db, filters);
+    return c.html(renderAuditPage({ events, nextCursor, filters }));
+  });
+
+  app.get("/page", async (c) => {
+    const url = new URL(c.req.url);
+    const filters = parseFilters(url.searchParams);
+    const { events, nextCursor } = await listAuditEvents(deps.db, filters);
+    return c.html(renderAuditPage({ events, nextCursor, filters, partial: true }));
+  });
+
+  app.get("/export.csv", async (c) => {
+    const url = new URL(c.req.url);
+    const filters = parseFilters(url.searchParams);
+    const stream = streamAuditCsv(deps.db, filters);
+    const readable = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of stream) controller.enqueue(new TextEncoder().encode(chunk));
+        controller.close();
+      },
+    });
+    const from = filters.from?.toISOString().slice(0, 10) ?? "all";
+    const to = filters.to?.toISOString().slice(0, 10) ?? "all";
+    return new Response(readable, {
+      headers: {
+        "content-type": "text/csv; charset=utf-8",
+        "content-disposition": `attachment; filename="audit-${from}-${to}.csv"`,
+      },
+    });
+  });
+
+  return app;
+}
+
+function parseFilters(params: URLSearchParams) {
+  const from = params.get("from"); const to = params.get("to");
+  return {
+    from: from ? new Date(from) : undefined,
+    to: to ? new Date(to) : undefined,
+    scope: params.get("scope") ?? undefined,
+    eventTypes: params.getAll("type") as any,
+    actor: params.get("actor") ?? undefined,
+    runId: params.get("runId") ?? undefined,
+    q: params.get("q") ?? undefined,
+    cursor: params.get("cursor") ?? undefined,
+    limit: 50,
+  };
+}
+```
+
+- [ ] **Step 4: Create the view**
+
+Create `packages/dashboard/src/views/audit.ts`:
+```ts
+import { html } from "hono/html";
+import { layout } from "./layout.js";
+import type { AuditEvent } from "@urateam/core";
+
+interface AuditPageProps {
+  events: AuditEvent[];
+  nextCursor: string | null;
+  filters: any;
+  partial?: boolean;
+}
+
+export function renderAuditPage(props: AuditPageProps) {
+  const rows = props.events.map(e => html`
+    <tr>
+      <td>${e.timestamp.toISOString()}</td>
+      <td>${e.eventType}</td>
+      <td>${e.actor}</td>
+      <td>${e.scope ?? ""}</td>
+      <td>${e.runId ? html`<a href="/runs/${e.runId}">${e.runId}</a>` : ""}</td>
+      <td>${e.inputTokens + e.outputTokens}</td>
+      <td><code>${JSON.stringify(e.payload).slice(0, 80)}</code></td>
+    </tr>
+  `);
+
+  const table = html`
+    <table class="audit">
+      <thead><tr>
+        <th>Timestamp</th><th>Event</th><th>Actor</th><th>Scope</th>
+        <th>Run</th><th>Tokens</th><th>Payload</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    ${props.nextCursor
+      ? html`<button hx-get="/audit/page?cursor=${props.nextCursor}" hx-swap="outerHTML">Load more</button>`
+      : html`<p>End of feed.</p>`}
+  `;
+
+  if (props.partial) return table;
+
+  return layout({
+    title: "Audit",
+    body: html`
+      <h1>Audit log</h1>
+      <form hx-get="/audit" hx-trigger="change">
+        <input type="date" name="from" />
+        <input type="date" name="to" />
+        <input type="text" name="scope" placeholder="scope (team:T1)" />
+        <input type="text" name="actor" placeholder="actor" />
+        <input type="text" name="q" placeholder="search payload" />
+        <a href="/audit/export.csv" class="button">Export CSV</a>
+      </form>
+      ${table}
+    `,
+  });
+}
+```
+
+- [ ] **Step 5: Wire the route in `server.ts`**
+
+Import and mount: `app.route("/audit", auditRoutes({ db }))`.
+
+- [ ] **Step 6: Add "Audit" nav entry to `layout.ts`**
+
+Find the nav list and add `<a href="/audit">Audit</a>` after "Errors".
+
+- [ ] **Step 7: Run tests, verify pass**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/audit.test.ts
+```
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/dashboard
+git commit -m "feat(audit): dashboard route view and csv export"
+```
+
+---
+
+## Task 15: Integration test (end-to-end)
+
+**Files:**
+- Create: `packages/core/src/__tests__/integration/audit-e2e.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents, pipelineRuns } from "../../db/schema.js";
+import { listAuditEvents } from "../../audit/reader.js";
+
+describe("audit log e2e", () => {
+  it("projected run events appear alongside native PM events in the feed", async () => {
+    const { db } = await createDb("sqlite::memory:") as any;
+
+    // Seed a completed run
+    await db.insert(pipelineRuns).values({
+      id: "run_int_1", issueId: "BEC-42", issueTitle: "t", pipelineKey: "auto-implement",
+      repoUrl: "https://github.com/a/b", status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+      totalInputTokens: 1000, totalOutputTokens: 500,
+      runType: "standard", linearTeamId: "T-int",
+      autoMerged: true, autoMergeReason: "small diff",
+    } as any);
+
+    // Seed a native audit event
+    await db.insert(auditEvents).values({
+      id: "evt_int_1", timestamp: new Date("2026-04-01T10:06:00Z"),
+      eventType: "pm.issue_promoted", actor: "pm-agent", actorType: "pm-agent",
+      issueId: "BEC-42", payload: JSON.stringify({ reason: "top-of-queue" }),
+      scope: "team:T-int",
+    } as any);
+
+    const { events } = await listAuditEvents(db, { limit: 100 });
+    const types = events.map(e => e.eventType);
+    expect(types).toContain("run.started");
+    expect(types).toContain("run.completed");
+    expect(types).toContain("run.auto_merged");
+    expect(types).toContain("pm.issue_promoted");
+
+    // Filter by run id — should get only run events
+    const byRun = await listAuditEvents(db, { runId: "run_int_1", limit: 100 });
+    expect(byRun.events.every(e => e.runId === "run_int_1")).toBe(true);
+  });
+});
+```
+
+Note: this test belongs in the integration suite only if it actually needs the heavier fixtures. As written, it's fast enough to live in the unit tests. Place it in `src/__tests__/audit/audit-e2e.test.ts` instead if it runs under 1s.
+
+- [ ] **Step 2: Run test**
+
+```
+cd packages/core && npx vitest run src/__tests__/audit/audit-e2e.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/core/src/__tests__/audit/audit-e2e.test.ts
+git commit -m "test(audit): end-to-end projection + native merge"
+```
+
+---
+
+## Task 16: Full build + test sweep + holistic review
+
+- [ ] **Step 1: Build everything**
+
+```
+pnpm build
+```
+Expected: zero errors.
+
+- [ ] **Step 2: Run the full unit test suite**
+
+```
+pnpm test
+```
+Expected: all pass.
+
+- [ ] **Step 3: Run integration tests**
+
+```
+pnpm test:integration
+```
+Expected: all pass.
+
+- [ ] **Step 4: Dispatch holistic external review**
+
+Launch a fresh `feature-dev:code-reviewer` subagent with:
+- Spec path: `docs/superpowers/specs/2026-04-14-audit-log-design.md`
+- Plan path: `docs/superpowers/plans/2026-04-14-audit-log-and-export.md`
+- Diff: `git diff main...HEAD`
+- Ask it to flag: missing spec coverage, unauthorized audit_events mutations, projection bugs, prompt injection in `payload` rendering on the dashboard (HTML-escape check), missing license gate anywhere, regressions in existing PM action tests.
+
+Address any high-confidence findings. Re-run `pnpm test`.
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+Append a short section under "Key Patterns" in `/private/tmp/urateam/CLAUDE.md`:
+```
+### Audit log (Enterprise feature 4.2)
+- Append-only `audit_events` table + read-time projection from `pipeline_runs`, `pm_approvals`, `budget_alerts`
+- Only `packages/core/src/audit/retention.ts` may delete/update rows — enforced by `audit-immutability.test.ts`
+- Event builders in `audit/events.ts`, fire-and-forget via `logAuditEvent(db, evt)`
+- Reader: `listAuditEvents(db, filters)` with cursor pagination; CSV via `streamAuditCsv(db, filters)`
+- Dashboard route `/audit` + `/audit/export.csv`, both gated by `isFeatureLicensed("audit-log")`
+- Retention sweep runs in PM tick after `digest` (default 365 days)
+```
+
+- [ ] **Step 6: Commit CLAUDE.md update and open PR**
+
+```
+git add CLAUDE.md
+git commit -m "docs: claude.md notes for audit log feature"
+git push -u origin <branch>
+gh pr create --title "feat: audit log + export (enterprise 4.2)" --body "$(cat <<'EOF'
+## Summary
+- Append-only audit_events table + read-time projection from existing tables
+- Dashboard /audit page with filters and streaming CSV export
+- Recovers per-scope ScopeBudget[] data from PR #39 (budget.run_refused events)
+- Retention sweep in PM tick (default 365 days)
+- Immutability enforced by grep-based lint test
+
+Spec: docs/superpowers/specs/2026-04-14-audit-log-design.md
+Plan: docs/superpowers/plans/2026-04-14-audit-log-and-export.md
+
+## Test plan
+- [ ] pnpm test (unit)
+- [ ] pnpm test:integration
+- [ ] Manual: /audit page renders, filters work, CSV export downloads
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** All 16 event types, write sites, read path, projection, retention, CSV, lint test, dashboard, config, migration, license gate, nav — each has a task.
+- **Placeholders:** None. `it.todo` in Task 11 is deliberate — the pre-step instruction tells the implementer to replace them after reading the existing stub pattern, rather than guessing at dependencies that vary by action.
+- **Types:** `AuditEvent`, `AuditEventType`, `AuditActorType`, `ListAuditEventsFilters` defined once, used consistently. `logAuditEvent(db, evt)` signature is stable. Event builder names match the event type strings (`pm.issue_promoted` → `pmPromotedEvent`).
+- **Scope:** Plan produces one PR covering the full v1 feature. Phase 1.5 PR #39 follow-ups deliberately excluded per context.
+- **Deferred assumptions:** Task 14 assumes a test-only license bypass hook exists or can be added; Task 12 assumes the existing `checkLicense()` signature can be wrapped without breaking other callers. Both should be verified in the first 10 minutes of implementation and the plan adjusted in-flight if they turn out wrong.

--- a/docs/superpowers/specs/2026-04-14-audit-log-design.md
+++ b/docs/superpowers/specs/2026-04-14-audit-log-design.md
@@ -1,0 +1,326 @@
+# Design: Audit log + export (Enterprise feature 4.2)
+
+**Date**: 2026-04-14
+**Status**: Draft for review
+**Parent strategy**: `docs/superpowers/specs/2026-04-13-enterprise-tier-design.md` § 4.2
+**Scope**: Append-only audit event log with dashboard view and CSV export. Enterprise-tier feature, gated by `isFeatureLicensed("audit-log")`.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+- Record every meaningful action across the urateam system (pipeline runs, PM agent decisions, budget events, license events, config loads) as a queryable event stream.
+- Give a compliance/security reviewer a single page and a single CSV export that answers: *what happened, who/what triggered it, when, at what cost, in which scope*.
+- Surface the per-scope `ScopeBudget[]` data from `evaluateBudget` that is currently dropped on the floor in `pm/tick.ts` `budgetGuard`.
+- First-class events for actions that have no existing table today (config loads, license validation failures, budget refusals, PM promote decisions).
+- Reuse existing run data via read-time projection rather than duplicating rows, to avoid bloating the hottest table.
+
+### Non-goals
+- Splunk / Datadog / SIEM push integrations (HTTP export is v2).
+- Cryptographic tamper-evidence (hash chains, signed events). The buyer profile in the parent spec explicitly excludes regulated enterprise; convention-only immutability is sufficient for v1.
+- Per-stage (`stage_runs`) or per-agent-log-line (`agent_logs`) events in the audit feed. Those tables already exist and are the right place to drill in.
+- Webhook-received events. Noisy and already covered by `webhookDedup`.
+- RBAC-aware attribution of manual dashboard actions. Reserved event type only; nothing writes it in v1 because there are no authenticated dashboard users yet (feature 4.4).
+- Changes to `pipeline_runs` retention. The audit feed projects from it; retention of the source table is out of scope.
+- PR #39 Phase 1.5 follow-ups (per-scope data in PM digest, UTC day-boundary test, `hasOwn` check, Postgres parity dedup test). Tracked separately.
+
+## 2. Event taxonomy
+
+Fifteen event types in v1, split by whether they're stored in the new table or projected from existing tables at read time.
+
+### 2.1 Projected at read time (no new writes)
+Read adapter in `audit/reader.ts` queries existing tables and maps rows into `AuditEvent` shape:
+
+| Event type | Source table | Notes |
+|---|---|---|
+| `run.started` | `pipeline_runs` | Timestamp = `started_at`. Actor derived from `run_type` + `parent_run_id` (webhook, pm-agent, review-feedback). |
+| `run.completed` | `pipeline_runs` | Only emitted when `status = 'completed'`. Timestamp = `completed_at`. |
+| `run.failed` | `pipeline_runs` | `status in ('failed','retriable')`. Payload includes `error_message`. |
+| `run.auto_merged` | `pipeline_runs` | `auto_merged = true`. Payload includes `auto_merge_reason`. |
+| `run.auto_merge_skipped` | `pipeline_runs` | `auto_merged = false` but `auto_merge_reason` set. |
+| `pm.approval_requested` | `pm_approvals` | Timestamp = `created_at`. |
+| `pm.approval_resolved` | `pm_approvals` | `resolved_at not null`. Payload includes final `status`. |
+| `budget.alert_fired` | `budget_alerts` | Timestamp = `fired_at`. Payload = `{date, scope, threshold}`. |
+
+Projection is centralized: a single `projectEvents(rows, sourceTable)` helper in `audit/reader.ts` keeps the mapping testable in isolation.
+
+### 2.2 Written to `audit_events` table
+New write sites emit these directly:
+
+| Event type | Write site | Payload |
+|---|---|---|
+| `pm.issue_promoted` | `pm/actions/promote.ts` | `{issueId, fromState, toState, priority, reason}` |
+| `pm.issue_deprioritized` | `pm/actions/deprioritize.ts` | `{issueId, oldPriority, newPriority, approvalId}` |
+| `pm.issue_cancelled` | `pm/actions/cancel.ts` | `{issueId, approvalId, reason}` |
+| `pm.triage_classified` | `pm/actions/triage.ts` | `{issueId, label, rationale (≤500 chars)}` |
+| `budget.run_refused` | `pm/tick.ts` `budgetGuard` | `{scope, scopeType, tokensUsed, limit, utilization, refusedRunId?}` — **this is the `ScopeBudget` data currently dropped** |
+| `license.validation_failed` | `license.ts` `checkLicense()` | `{invalidReason, expiredAt?}` |
+| `config.loaded` | config loader in `cli`/`core` startup | `{path, sha256, tier}` |
+| `dashboard.manual_action` | *reserved* | v1 writes nothing; placeholder for feature 4.4 |
+
+### 2.3 Explicitly excluded from v1
+- Per-stage lifecycle events (`stage_runs` is already the right surface).
+- Per-agent-log-line events (`agent_logs` is the drill-down).
+- Webhook-received / webhook-deduped events.
+- Git push/PR creation events (derivable from `run.completed` + `pr_url`).
+
+## 3. Data model
+
+### 3.1 New table `audit_events`
+
+Added to `packages/core/src/db/schema.ts`, `MIGRATION_COLUMNS` (for ALTER-style migrations), `getCreateTablesDDL()` (for fresh installs), and a new file-based migration in `db/migrations/{sqlite,postgres}/`:
+
+```ts
+export const auditEvents = sqliteTable("audit_events", {
+  id: text("id").primaryKey(),
+  timestamp: crossTimestamp("timestamp").notNull().$defaultFn(() => new Date()),
+  eventType: text("event_type").notNull(),
+  actor: text("actor").notNull(),           // 'system' | pm-agent | linear-webhook | github-webhook | cli:<user> | dashboard:<user>
+  actorType: text("actor_type").notNull(),  // 'system' | 'pm-agent' | 'webhook' | 'dashboard-user' | 'cli'
+  scope: text("scope"),                     // null | 'global' | 'team:<linearTeamId>' | 'repo:<repoUrl>'
+  runId: text("run_id"),                    // nullable FK-ish to pipeline_runs.id; no hard constraint so projected events don't break
+  issueId: text("issue_id"),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  payload: text("payload").notNull().default("{}"), // JSON
+});
+```
+
+Indexes (declared in the migration, not on the Drizzle table object — matches existing convention):
+- `idx_audit_events_timestamp` on `(timestamp DESC)`
+- `idx_audit_events_type_ts` on `(event_type, timestamp DESC)`
+- `idx_audit_events_scope_ts` on `(scope, timestamp DESC)`
+- `idx_audit_events_run_id` on `(run_id)`
+
+Timestamp type uses `crossTimestamp` for driver parity (SQLite integer / Postgres TIMESTAMPTZ).
+
+### 3.2 Zod schema
+
+Added to `packages/core/src/types.ts`:
+
+```ts
+export const AuditEventTypeSchema = z.enum([
+  "run.started", "run.completed", "run.failed",
+  "run.auto_merged", "run.auto_merge_skipped",
+  "pm.approval_requested", "pm.approval_resolved",
+  "pm.issue_promoted", "pm.issue_deprioritized", "pm.issue_cancelled",
+  "pm.triage_classified",
+  "budget.alert_fired", "budget.run_refused",
+  "license.validation_failed", "config.loaded",
+  "dashboard.manual_action",
+]);
+
+export const AuditActorTypeSchema = z.enum([
+  "system", "pm-agent", "webhook", "dashboard-user", "cli",
+]);
+
+export const AuditEventSchema = z.object({
+  id: z.string(),
+  timestamp: z.date(),
+  eventType: AuditEventTypeSchema,
+  actor: z.string(),
+  actorType: AuditActorTypeSchema,
+  scope: z.string().nullable(),
+  runId: z.string().nullable(),
+  issueId: z.string().nullable(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  payload: z.record(z.unknown()),
+});
+```
+
+## 4. Module layout
+
+New directory `packages/core/src/audit/`:
+
+```
+audit/
+  index.ts            — barrel export
+  writer.ts           — logAuditEvent(db, event): fire-and-forget insert, pino warn on failure
+  events.ts           — typed event builders (runStartedEvent, pmPromotedEvent, budgetRefusedEvent, …)
+  reader.ts           — listAuditEvents({from,to,scope,eventType,actor,runId,limit,cursor}) with projection
+  retention.ts        — pruneAuditLog(db, retentionDays): the only authorized mutation on audit_events
+  csv.ts              — streamAuditCsv(reader, filters): AsyncIterable<string> row emitter
+```
+
+### 4.1 Writer semantics
+- `logAuditEvent` is `async` but callers use `void logAuditEvent(...)` — **fire-and-forget**. It wraps the insert in try/catch and logs a pino warning on failure. Audit write failures never crash the caller. This matches the principle that audit is observational, not load-bearing.
+- No write buffering in v1. If volume becomes a problem, add a batched writer in v2 modeled on the existing `agent_logs` batcher.
+
+### 4.2 Reader semantics
+- `listAuditEvents(filters)` returns `{events: AuditEvent[], nextCursor: string | null}`.
+- Implementation:
+  1. Query `audit_events` with filters → rows.
+  2. Query `pipeline_runs`, `pm_approvals`, `budget_alerts` for the same window → project into events via `projectEvents`.
+  3. Merge the four streams by `(timestamp DESC, id DESC)`.
+  4. Apply post-merge filters that couldn't be pushed to SQL (e.g. free-text search on payload).
+  5. Truncate to `limit` (default 50, max 500).
+- Cursor encoding: `base64url(JSON.stringify({ts: isoString, id}))`. Next-page query adds `WHERE timestamp < :ts OR (timestamp = :ts AND id < :id)`.
+- Filters supported in v1: `from`, `to` (date window), `scope` (exact match), `eventType` (in-list), `actor` (prefix match), `runId`, `issueId`, `q` (free-text on payload JSON — applied in-process after merge).
+
+### 4.3 Retention
+- `pruneAuditLog(db, retentionDays)` deletes rows where `timestamp < now() - retentionDays days`.
+- Called from the PM scheduler tick, after `digest`, in a new `pruneAuditLog` step (see § 6).
+- Default `auditLog.retentionDays = 365`. Configurable per-deployment.
+- Projected events from `pipeline_runs` / `pm_approvals` / `budget_alerts` are not touched — their retention belongs to those tables.
+- `retention.ts` is the **sole authorized mutation** on `audit_events`. Documented inline and enforced by the lint test in § 7.
+
+### 4.4 CSV stream
+- `streamAuditCsv(db, filters)` is an `AsyncIterable<string>` that yields header row then data rows.
+- Internally calls `listAuditEvents` in a pagination loop (1000 rows per page) so memory stays bounded regardless of export size.
+- Columns:
+  `timestamp_utc, event_type, actor, actor_type, scope, run_id, issue_id, input_tokens, output_tokens, payload_json`
+- `payload_json` is the raw JSON column with CSV-escaping applied (wraps in `"..."`, doubles embedded quotes). Keeps schema stable as event types evolve.
+
+## 5. Write-site integration
+
+Every new write site becomes a 1–2 line addition next to the existing logic. Example from `pm/actions/promote.ts`:
+
+```ts
+await linear.updateIssue(issue.id, { stateId: todoStateId });
+log.info({ issueId: issue.id }, "promoted");
+void logAuditEvent(db, pmPromotedEvent({
+  issueId: issue.id, fromState, toState: "Todo",
+  priority: issue.priority, reason: "top-of-queue",
+}));
+```
+
+### 5.1 `budget.run_refused` — recovering the dropped `ScopeBudget` data
+
+In `pm/tick.ts` `budgetGuard`, the current code discards the per-scope breakdown from `evaluateBudget`. The fix:
+
+```ts
+const result = await evaluateBudget(db, config);
+if (!result.allowed) {
+  for (const scope of result.scopes.filter(s => s.refused)) {
+    void logAuditEvent(db, budgetRefusedEvent({
+      scope: scope.id, scopeType: scope.type,
+      tokensUsed: scope.tokensUsed, limit: scope.limit,
+      utilization: scope.utilization,
+    }));
+  }
+  return { allowed: false, reason: "budget" };
+}
+```
+
+This is the single place the `ScopeBudget[]` breakdown becomes visible downstream.
+
+### 5.2 Actor derivation
+- Linear webhook → `actor="linear-webhook"`, `actorType="webhook"`
+- GitHub webhook → `actor="github-webhook"`, `actorType="webhook"`
+- PM Agent → `actor="pm-agent"`, `actorType="pm-agent"`
+- CLI (`ura start`, `ura dev`) → `actor="cli:<os_user>"`, `actorType="cli"`
+- Dashboard manual action → `actor="dashboard:<username>"`, `actorType="dashboard-user"` (reserved; v1 writes nothing)
+- System startup (license, config) → `actor="system"`, `actorType="system"`
+
+## 6. PM scheduler tick integration
+
+Update `pm/scheduler.ts` tick sequence. Current:
+
+> budget check → recover retriable → recover stuck → startTodoIssues → triage → resolve approvals → promote → deprioritize → cancel → digest
+
+New:
+
+> budget check → recover retriable → recover stuck → startTodoIssues → triage → resolve approvals → promote → deprioritize → cancel → digest → **pruneAuditLog**
+
+`pruneAuditLog` is a no-op if audit log is disabled or unlicensed.
+
+## 7. Immutability enforcement
+
+Convention-only (per brainstorm decision): a lint test guards it.
+
+New file `packages/core/src/__tests__/audit-immutability.test.ts`, modeled on `prompt-injection.test.ts`:
+- Greps all `.ts` files under `packages/` for `update(auditEvents)` and `delete(auditEvents)`.
+- Test passes iff the **only** matching files are:
+  - `packages/core/src/audit/retention.ts` (the sole authorized deleter)
+  - The test file itself
+
+If a future change introduces an unauthorized mutation, CI fails with a clear error pointing at the offending file. The test file's docstring explains the reasoning so a future engineer sees the intent.
+
+## 8. Config
+
+New section in `AppConfig` (in `types.ts`):
+
+```ts
+auditLog: z.object({
+  enabled: z.boolean().optional(),        // defaults to true when audit-log feature is licensed
+  retentionDays: z.number().int().positive().optional().default(365),
+}).optional(),
+```
+
+Gating:
+- `isFeatureLicensed("audit-log")` → write sites call `logAuditEvent`, reader works, dashboard page + export enabled.
+- Unlicensed → write sites are no-ops, reader returns empty feed, dashboard route returns 404, export returns 404.
+
+The feature flag `audit-log` is added to the Enterprise tier feature set in `license.ts`.
+
+## 9. Dashboard
+
+### 9.1 Routes
+New file `packages/dashboard/src/routes/audit.ts`:
+
+- `GET /audit` — HTML page. Renders filter bar + first page of results (default window: last 7 days).
+- `GET /audit/page` — HTMX partial for pagination. Returns table rows + next-page HTMX hook.
+- `GET /audit/event/:id` — HTMX partial for the expanded payload view.
+- `GET /audit/export.csv` — streams CSV. Uses Hono's `c.body(new ReadableStream(...))`. Filters read from query string, identical to the list endpoint. Filename: `audit-<from>-<to>.csv`.
+
+All four routes return 404 if `!isFeatureLicensed("audit-log")`.
+
+### 9.2 Views
+New file `packages/dashboard/src/views/audit.ts`:
+
+- Filter bar: date range picker, scope dropdown (populated from distinct scopes seen in last 30d), event type multi-select, actor free-text search, payload free-text search.
+- Table: `timestamp · event · actor · scope · run (→ /runs/:id when set) · cost · payload preview (first 80 chars)`.
+- Row click expands payload via `GET /audit/event/:id`.
+- Footer: pagination via HTMX `hx-get="/audit/page"` with cursor preserved.
+- Export button top-right, `hx-boost="false"`, href built from current filter state.
+
+### 9.3 Navigation
+`packages/dashboard/src/views/layout.ts` — add "Audit" nav entry after "Errors".
+
+## 10. Testing strategy
+
+### 10.1 Unit tests (`packages/core/src/__tests__/audit/`)
+- `writer.test.ts` — insert happy path, failure path logs but doesn't throw, payload serialized correctly.
+- `events.test.ts` — each event builder produces valid schema (zod parse round-trip).
+- `reader.test.ts` — each filter (from/to/scope/eventType/actor/runId/q), cursor pagination, limit cap, merge ordering.
+- `projection.test.ts` — `projectEvents` maps `pipeline_runs`, `pm_approvals`, `budget_alerts` rows to correct event shapes.
+- `retention.test.ts` — deletes only rows older than cutoff, leaves `pipeline_runs` untouched.
+- `csv.test.ts` — header row correct, escaping correct (quotes, commas, newlines in payload), streams without buffering (assertion: memory doesn't grow with row count).
+
+### 10.2 Integration tests (`packages/core/src/__tests__/integration/audit-e2e.test.ts`)
+- Webhook → run start → `run.started` appears in feed and in CSV export.
+- `evaluateBudget` refuses → `budget.run_refused` row contains the `ScopeBudget` fields.
+- PM promote → `pm.issue_promoted` row.
+
+### 10.3 Lint test
+- `audit-immutability.test.ts` — see § 7.
+
+### 10.4 Dashboard tests (`packages/dashboard/src/__tests__/audit.test.ts`)
+- Unlicensed → 404 on all four routes.
+- Licensed → `GET /audit` returns page, HTMX pagination preserves filters across pages, CSV export streams with correct `Content-Type: text/csv` and `Content-Disposition` header.
+
+### 10.5 Explicitly deferred
+- Per-scope digest surfacing in PM Slack digest (PR #39 Phase 1.5 follow-up).
+- Postgres parity test for the audit insert + read path (the existing test suite covers both drivers through the shared schema; no audit-specific parity test planned unless a driver-specific bug surfaces).
+
+## 11. Migration + rollout
+
+### 11.1 Schema migration
+- New file `db/migrations/sqlite/0007_audit_events.sql` and `db/migrations/postgres/0007_audit_events.sql` containing `CREATE TABLE` + indexes.
+- `MIGRATION_COLUMNS` entry: not applicable (new table, not a column add). Migration runs via file-based migration runner.
+- `getCreateTablesDDL(driver)` extended to include the new table for fresh installs.
+- Drizzle schema in `schema.ts` gets the new `auditEvents` table declaration.
+
+### 11.2 Backfill
+None. Audit log starts empty on first boot after the migration. Historical runs remain queryable through the projected read path — they surface in the audit feed as `run.started/completed/failed` events derived from existing `pipeline_runs` rows, retroactively.
+
+### 11.3 Feature flag
+- `audit-log` added to Enterprise feature set in `license.ts`.
+- OSS / Pro deployments see no audit routes, no writes, no retention sweep — no behavior change.
+
+## 12. Open questions (deferred, not blockers)
+- Whether to add a `correlationId` for multi-event causality chains (e.g. linking a `pm.approval_requested` to the subsequent `pm.issue_cancelled`). Not needed in v1 because `payload.approvalId` already threads through.
+- Whether the retention sweep should be soft-delete (archive to cold storage) for Enterprise-Plus in future. v1 is hard-delete only.
+- Whether `dashboard.manual_action` should be written in v1 for the existing unauthenticated "retry run" button. Currently the dashboard has no user identity, so this would produce `actor="dashboard:anonymous"` rows with limited value. Deferred until feature 4.4 (RBAC).

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -311,6 +311,27 @@ export const runCommand = new Command("run")
         process.env.DATABASE_URL ?? ":memory:",
     });
 
+    // --- Startup audit events (license + config fingerprint) ---------------
+    try {
+      const {
+        checkLicense,
+        computeConfigFingerprint,
+        logAuditEvent,
+        configLoadedEvent,
+      } = await import("@urateam/core");
+      const status = checkLicense(db);
+      const sha = await computeConfigFingerprint(configPath);
+      if (sha) {
+        void logAuditEvent(
+          db,
+          configLoadedEvent({ path: configPath, sha256: sha, tier: status.tier }),
+        );
+      }
+    } catch (err) {
+      // audit must never crash startup
+      console.warn(`[lag run] startup audit emit failed: ${(err as Error).message}`);
+    }
+
     const consoleNotifier = createConsoleNotifier();
 
     // Completion promise — resolves when pipeline finishes or rejects on failure

--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Audit log immutability lint test.
+ *
+ * The audit_events table is append-only by design. Only the retention sweep
+ * (`audit/retention.ts`) may delete rows, and nothing should ever update them.
+ *
+ * This test greps the source tree for `.delete(auditEvents)` / `.update(auditEvents)`
+ * calls and fails if any non-allowlisted file is found.
+ */
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+describe("audit_events immutability", () => {
+  it("only audit/retention.ts may delete or update audit_events rows", () => {
+    const repoRoot = path.resolve(__dirname, "../../../..");
+    const allowed = [
+      "packages/core/src/audit/retention.ts",
+      "packages/core/src/__tests__/audit/retention.test.ts",
+      "packages/core/src/__tests__/audit-immutability.test.ts",
+    ];
+
+    const patterns = [
+      "\\.delete\\s*\\(\\s*auditEvents",
+      "\\.update\\s*\\(\\s*auditEvents",
+    ];
+
+    const matches: string[] = [];
+    for (const pat of patterns) {
+      try {
+        const out = execFileSync(
+          "git",
+          ["grep", "-nE", pat, "--", "packages/**/*.ts"],
+          { cwd: repoRoot, encoding: "utf8" },
+        );
+        matches.push(...out.trim().split("\n").filter(Boolean));
+      } catch {
+        // git grep exits non-zero when no matches; safe to ignore
+      }
+    }
+
+    const offenders = matches
+      .map((line) => line.split(":")[0]!)
+      .filter((file) => !allowed.some((a) => file.endsWith(a) || file === a));
+
+    expect(
+      offenders,
+      `Unauthorized audit_events mutation in:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/audit-types.test.ts
+++ b/packages/core/src/__tests__/audit-types.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { AuditEventSchema, AuditEventTypeSchema, AuditActorTypeSchema } from "../types.js";
+
+describe("audit event zod schemas", () => {
+  it("accepts all v1 event types", () => {
+    const types = [
+      "run.started","run.completed","run.failed","run.auto_merged","run.auto_merge_skipped",
+      "pm.approval_requested","pm.approval_resolved",
+      "pm.issue_promoted","pm.issue_deprioritized","pm.issue_cancelled","pm.triage_classified",
+      "budget.alert_fired","budget.run_refused",
+      "license.validation_failed","config.loaded","dashboard.manual_action",
+    ];
+    for (const t of types) expect(AuditEventTypeSchema.parse(t)).toBe(t);
+  });
+
+  it("rejects unknown event type", () => {
+    expect(() => AuditEventTypeSchema.parse("nope")).toThrow();
+  });
+
+  it("parses a minimal valid audit event", () => {
+    const evt = AuditEventSchema.parse({
+      id: "evt_1",
+      timestamp: new Date(),
+      eventType: "pm.issue_promoted",
+      actor: "pm-agent",
+      actorType: "pm-agent",
+      scope: null,
+      runId: null,
+      issueId: "BEC-1",
+      inputTokens: 0,
+      outputTokens: 0,
+      payload: { issueId: "BEC-1" },
+    });
+    expect(evt.eventType).toBe("pm.issue_promoted");
+  });
+});

--- a/packages/core/src/__tests__/audit/audit-e2e.test.ts
+++ b/packages/core/src/__tests__/audit/audit-e2e.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns } from "../../db/schema.js";
 import { logAuditEvent } from "../../audit/writer.js";
 import { pmPromotedEvent } from "../../audit/events.js";
 import { listAuditEvents } from "../../audit/reader.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
 
 let db: any;
 
 beforeEach(async () => {
+  await installTestProLicense("enterprise");
   db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
 });
 
 describe("audit log end-to-end", () => {

--- a/packages/core/src/__tests__/audit/audit-e2e.test.ts
+++ b/packages/core/src/__tests__/audit/audit-e2e.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns } from "../../db/schema.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent } from "../../audit/events.js";
+import { listAuditEvents } from "../../audit/reader.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+describe("audit log end-to-end", () => {
+  it("surfaces projected pipeline_runs events and native audit_events through listAuditEvents", async () => {
+    // Seed completed pipeline run with autoMerged=true
+    await db.insert(pipelineRuns).values({
+      id: "run_int_1",
+      issueId: "BEC-INT",
+      issueTitle: "integration test issue",
+      pipelineKey: "auto-implement",
+      repoUrl: "https://example.com/org/repo",
+      status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+      totalInputTokens: 1000,
+      totalOutputTokens: 500,
+      runType: "standard",
+      linearTeamId: "T-int",
+      autoMerged: true,
+      autoMergeReason: "trivial diff",
+    });
+
+    // Seed native audit event with team scope
+    const promoted = pmPromotedEvent({
+      issueId: "BEC-INT",
+      fromState: "Backlog",
+      toState: "Todo",
+    });
+    promoted.scope = "team:T-int";
+    await logAuditEvent(db, promoted);
+
+    const { events } = await listAuditEvents(db, { limit: 100 });
+    const types = events.map(e => e.eventType);
+    expect(types).toContain("run.started");
+    expect(types).toContain("run.completed");
+    expect(types).toContain("run.auto_merged");
+    expect(types).toContain("pm.issue_promoted");
+
+    const { events: byRun } = await listAuditEvents(db, { runId: "run_int_1", limit: 100 });
+    expect(byRun.length).toBeGreaterThan(0);
+    for (const e of byRun) {
+      expect(e.runId).toBe("run_int_1");
+    }
+  });
+});

--- a/packages/core/src/__tests__/audit/csv.test.ts
+++ b/packages/core/src/__tests__/audit/csv.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { logAuditEvent } from "../../audit/writer.js";
 import { pmPromotedEvent, budgetRefusedEvent } from "../../audit/events.js";
 import { streamAuditCsv } from "../../audit/csv.js";
 import type { AuditEvent } from "../../types.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
 
 let db: any;
 
 beforeEach(async () => {
+  await installTestProLicense("enterprise");
   db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
 });
 
 async function collect(gen: AsyncIterable<string>): Promise<string[]> {

--- a/packages/core/src/__tests__/audit/csv.test.ts
+++ b/packages/core/src/__tests__/audit/csv.test.ts
@@ -53,6 +53,8 @@ describe("streamAuditCsv", () => {
     // `has "quotes", commas` value must be CSV-escaped: wrap in quotes,
     // double internal quotes → `"has ""quotes"", commas"`.
     await logAuditEvent(db, {
+      id: "evt_csv_1",
+      timestamp: new Date(),
       eventType: "pm.issue_promoted",
       actor: "pm-agent",
       actorType: "system",
@@ -62,7 +64,7 @@ describe("streamAuditCsv", () => {
       inputTokens: 0,
       outputTokens: 0,
       payload: {},
-    } as Omit<AuditEvent, "id" | "timestamp">);
+    });
     const rows = await collect(streamAuditCsv(db, {}));
     const dataRow = rows.find((r) => r.includes("pm.issue_promoted"));
     expect(dataRow).toBeDefined();
@@ -74,6 +76,8 @@ describe("streamAuditCsv", () => {
 
   it("escapes fields containing newlines", async () => {
     await logAuditEvent(db, {
+      id: "evt_csv_2",
+      timestamp: new Date(),
       eventType: "pm.issue_promoted",
       actor: "pm-agent",
       actorType: "system",
@@ -83,7 +87,7 @@ describe("streamAuditCsv", () => {
       inputTokens: 0,
       outputTokens: 0,
       payload: {},
-    } as Omit<AuditEvent, "id" | "timestamp">);
+    });
     const rows = await collect(streamAuditCsv(db, {}));
     const dataRow = rows.find((r) => r.includes("pm.issue_promoted"));
     expect(dataRow).toContain('"line1\nline2"');

--- a/packages/core/src/__tests__/audit/csv.test.ts
+++ b/packages/core/src/__tests__/audit/csv.test.ts
@@ -99,6 +99,48 @@ describe("streamAuditCsv", () => {
     expect(dataRow).toContain('"line1\nline2"');
   });
 
+  it("neutralizes formula-injection prefixes in user-controlled fields", async () => {
+    // Excel/Sheets interpret cells starting with =, +, -, @, or \t as formulas.
+    // RFC 4180 quoting alone does NOT defeat this — we must prefix with a single quote.
+    for (const [id, actor] of [
+      ["evt_eq", '=HYPERLINK("http://evil.com","Click")'],
+      ["evt_plus", "+1+2"],
+      ["evt_minus", "-2+3"],
+      ["evt_at", "@SUM(A1:A2)"],
+      ["evt_tab", "\tinjected"],
+    ] as const) {
+      await logAuditEvent(db, {
+        id,
+        timestamp: new Date(),
+        eventType: "dashboard.manual_action",
+        actor,
+        actorType: "dashboard-user",
+        scope: null,
+        runId: null,
+        issueId: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        payload: {},
+      });
+    }
+    const rows = await collect(streamAuditCsv(db, {}));
+    const dataRows = rows.filter((r) => r.includes("dash"));
+    // Every row's actor field must begin with a literal single quote AFTER any wrapping quotes.
+    // For RFC-4180-quoted cells: `"'=HYPERLINK..."`; for unquoted: `'+1+2`.
+    for (const row of dataRows) {
+      // The actor cell is field index 2 (timestamp,event_type,actor,...). Find the third comma-separated field.
+      // Easier assertion: the row must contain the literal escape prefix.
+      expect(
+        row.includes(",'=") ||
+          row.includes(",'+") ||
+          row.includes(",'-") ||
+          row.includes(",'@") ||
+          row.includes(",'\t") ||
+          row.includes(',"\'='),
+      ).toBe(true);
+    }
+  });
+
   it("pages through events via pageSize", async () => {
     for (let i = 0; i < 6; i++) {
       await logAuditEvent(

--- a/packages/core/src/__tests__/audit/csv.test.ts
+++ b/packages/core/src/__tests__/audit/csv.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent, budgetRefusedEvent } from "../../audit/events.js";
+import { streamAuditCsv } from "../../audit/csv.js";
+import type { AuditEvent } from "../../types.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+async function collect(gen: AsyncIterable<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const row of gen) out.push(row);
+  return out;
+}
+
+describe("streamAuditCsv", () => {
+  it("yields header row first", async () => {
+    const rows = await collect(streamAuditCsv(db, {}));
+    expect(rows[0]).toBe(
+      "timestamp_utc,event_type,actor,actor_type,scope,run_id,issue_id,input_tokens,output_tokens,payload_json",
+    );
+  });
+
+  it("streams data rows after header", async () => {
+    await logAuditEvent(
+      db,
+      pmPromotedEvent({ issueId: "BEC-1", fromState: "Backlog", toState: "Todo" }),
+    );
+    await logAuditEvent(
+      db,
+      budgetRefusedEvent({
+        scope: "team:T1",
+        scopeType: "team",
+        tokensUsed: 100,
+        limit: 100,
+        utilization: 100,
+      }),
+    );
+    const rows = await collect(streamAuditCsv(db, {}));
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+    expect(rows[0]).toMatch(/^timestamp_utc,/);
+    // data rows should have 10 fields (allowing embedded escaped quotes)
+    const dataRow = rows[1];
+    expect(dataRow).toContain(",");
+  });
+
+  it("escapes fields containing commas, quotes, and newlines", async () => {
+    // scope is written as-is (not JSON-stringified), so a raw
+    // `has "quotes", commas` value must be CSV-escaped: wrap in quotes,
+    // double internal quotes → `"has ""quotes"", commas"`.
+    await logAuditEvent(db, {
+      eventType: "pm.issue_promoted",
+      actor: "pm-agent",
+      actorType: "system",
+      scope: 'has "quotes", commas',
+      runId: null,
+      issueId: "BEC-1",
+      inputTokens: 0,
+      outputTokens: 0,
+      payload: {},
+    } as Omit<AuditEvent, "id" | "timestamp">);
+    const rows = await collect(streamAuditCsv(db, {}));
+    const dataRow = rows.find((r) => r.includes("pm.issue_promoted"));
+    expect(dataRow).toBeDefined();
+    // scope field should have escaped doubled quotes around "quotes"
+    expect(dataRow).toContain('""quotes""');
+    // and the scope cell should be wrapped in quotes
+    expect(dataRow).toContain('"has ""quotes"", commas"');
+  });
+
+  it("escapes fields containing newlines", async () => {
+    await logAuditEvent(db, {
+      eventType: "pm.issue_promoted",
+      actor: "pm-agent",
+      actorType: "system",
+      scope: "line1\nline2",
+      runId: null,
+      issueId: "BEC-1",
+      inputTokens: 0,
+      outputTokens: 0,
+      payload: {},
+    } as Omit<AuditEvent, "id" | "timestamp">);
+    const rows = await collect(streamAuditCsv(db, {}));
+    const dataRow = rows.find((r) => r.includes("pm.issue_promoted"));
+    expect(dataRow).toContain('"line1\nline2"');
+  });
+
+  it("pages through events via pageSize", async () => {
+    for (let i = 0; i < 6; i++) {
+      await logAuditEvent(
+        db,
+        pmPromotedEvent({ issueId: `BEC-${i}`, fromState: "Backlog", toState: "Todo" }),
+      );
+    }
+    const rows = await collect(streamAuditCsv(db, {}, 3));
+    // 1 header + 6 data rows across 2 pages
+    expect(rows.length).toBe(7);
+    expect(rows[0]).toMatch(/^timestamp_utc,/);
+  });
+});

--- a/packages/core/src/__tests__/audit/events.test.ts
+++ b/packages/core/src/__tests__/audit/events.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  pmPromotedEvent, pmDeprioritizedEvent, pmCancelledEvent, pmTriageClassifiedEvent,
+  budgetRefusedEvent, licenseValidationFailedEvent, configLoadedEvent,
+} from "../../audit/events.js";
+import { AuditEventSchema } from "../../types.js";
+
+describe("audit event builders", () => {
+  it("pmPromotedEvent produces a valid event", () => {
+    const evt = pmPromotedEvent({
+      issueId: "BEC-1", fromState: "Backlog", toState: "Todo",
+      priority: 2, reason: "top-of-queue",
+    });
+    const parsed = AuditEventSchema.parse(evt);
+    expect(parsed.eventType).toBe("pm.issue_promoted");
+    expect(parsed.actor).toBe("pm-agent");
+    expect(parsed.actorType).toBe("pm-agent");
+    expect(parsed.issueId).toBe("BEC-1");
+    expect(parsed.payload).toMatchObject({ fromState: "Backlog", toState: "Todo" });
+  });
+
+  it("budgetRefusedEvent includes scope breakdown", () => {
+    const evt = budgetRefusedEvent({
+      scope: "team:T1", scopeType: "team",
+      tokensUsed: 100000, limit: 100000, utilization: 100,
+    });
+    const parsed = AuditEventSchema.parse(evt);
+    expect(parsed.eventType).toBe("budget.run_refused");
+    expect(parsed.scope).toBe("team:T1");
+    expect(parsed.payload).toMatchObject({ tokensUsed: 100000, limit: 100000 });
+  });
+
+  it("licenseValidationFailedEvent sets actor=system", () => {
+    const evt = licenseValidationFailedEvent({ invalidReason: "expired" });
+    expect(evt.actor).toBe("system");
+    expect(evt.actorType).toBe("system");
+    expect(evt.eventType).toBe("license.validation_failed");
+  });
+
+  it("configLoadedEvent includes path + sha256 + tier", () => {
+    const evt = configLoadedEvent({ path: "/tmp/ura.yaml", sha256: "abc123", tier: "enterprise" });
+    expect(evt.eventType).toBe("config.loaded");
+    expect(evt.payload).toMatchObject({ path: "/tmp/ura.yaml", sha256: "abc123", tier: "enterprise" });
+  });
+
+  it("all builders return new ids and recent timestamps", () => {
+    const a = pmCancelledEvent({ issueId: "BEC-1", approvalId: "a1", reason: "stale" });
+    const b = pmCancelledEvent({ issueId: "BEC-2", approvalId: "a2", reason: "dup" });
+    expect(a.id).not.toBe(b.id);
+    expect(Date.now() - a.timestamp.getTime()).toBeLessThan(1000);
+  });
+});

--- a/packages/core/src/__tests__/audit/projection.test.ts
+++ b/packages/core/src/__tests__/audit/projection.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  projectPipelineRun, projectPmApproval, projectBudgetAlert,
+} from "../../audit/projection.js";
+
+describe("projection", () => {
+  it("projects a completed run into started + completed events", () => {
+    const startedAt = new Date("2026-04-01T10:00:00Z");
+    const completedAt = new Date("2026-04-01T10:05:00Z");
+    const events = projectPipelineRun({
+      id: "run_1", issueId: "BEC-1", pipelineKey: "auto-implement",
+      status: "completed", startedAt, completedAt,
+      totalInputTokens: 500, totalOutputTokens: 200,
+      runType: "standard", parentRunId: null, linearTeamId: "T1",
+      repoUrl: "https://github.com/x/y", autoMerged: null, autoMergeReason: null,
+      errorMessage: null,
+    } as any);
+    expect(events.map(e => e.eventType)).toEqual(["run.started", "run.completed"]);
+    expect(events[0].timestamp).toEqual(startedAt);
+    expect(events[1].timestamp).toEqual(completedAt);
+    expect(events[1].inputTokens).toBe(500);
+    expect(events[1].outputTokens).toBe(200);
+    expect(events[0].scope).toBe("team:T1");
+  });
+
+  it("projects a failed run into started + failed", () => {
+    const events = projectPipelineRun({
+      id: "run_2", issueId: "BEC-2", status: "failed",
+      startedAt: new Date(), completedAt: new Date(),
+      totalInputTokens: 0, totalOutputTokens: 0,
+      runType: "standard", parentRunId: null, linearTeamId: null,
+      repoUrl: "https://github.com/x/y", autoMerged: null, autoMergeReason: null,
+      errorMessage: "boom",
+    } as any);
+    expect(events.map(e => e.eventType)).toEqual(["run.started", "run.failed"]);
+    expect(events[1].payload.errorMessage).toBe("boom");
+  });
+
+  it("adds run.auto_merged when autoMerged=true", () => {
+    const events = projectPipelineRun({
+      id: "run_3", issueId: "BEC-3", status: "completed",
+      startedAt: new Date(), completedAt: new Date(),
+      totalInputTokens: 0, totalOutputTokens: 0,
+      runType: "standard", parentRunId: null, linearTeamId: null,
+      repoUrl: "x", autoMerged: true, autoMergeReason: "PR auto-merged",
+      errorMessage: null,
+    } as any);
+    expect(events.map(e => e.eventType)).toContain("run.auto_merged");
+  });
+
+  it("adds run.auto_merge_skipped when autoMerged=false with reason", () => {
+    const events = projectPipelineRun({
+      id: "run_4", issueId: "BEC-4", status: "completed",
+      startedAt: new Date(), completedAt: new Date(),
+      totalInputTokens: 0, totalOutputTokens: 0,
+      runType: "standard", parentRunId: null, linearTeamId: null,
+      repoUrl: "x", autoMerged: false, autoMergeReason: "diff too large",
+      errorMessage: null,
+    } as any);
+    expect(events.map(e => e.eventType)).toContain("run.auto_merge_skipped");
+  });
+
+  it("projects a pm approval into requested + resolved when resolvedAt set", () => {
+    const events = projectPmApproval({
+      id: "a1", issueId: "BEC-9", action: "cancel",
+      reason: "stale", slackMessageTs: "ts", status: "approved",
+      createdAt: new Date("2026-04-01"), resolvedAt: new Date("2026-04-02"),
+    } as any);
+    expect(events.map(e => e.eventType)).toEqual([
+      "pm.approval_requested", "pm.approval_resolved",
+    ]);
+  });
+
+  it("projects a budget alert", () => {
+    const ev = projectBudgetAlert({
+      id: "ba1", date: "2026-04-01", scope: "team:T1", threshold: 80,
+      firedAt: new Date("2026-04-01T10:00:00Z"),
+    } as any);
+    expect(ev.eventType).toBe("budget.alert_fired");
+    expect(ev.scope).toBe("team:T1");
+    expect(ev.payload).toMatchObject({ threshold: 80, date: "2026-04-01" });
+  });
+});

--- a/packages/core/src/__tests__/audit/reader.test.ts
+++ b/packages/core/src/__tests__/audit/reader.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { auditEvents, pipelineRuns, pmApprovals, budgetAlerts } from "../../db/schema.js";
 import { logAuditEvent } from "../../audit/writer.js";
 import { pmPromotedEvent, budgetRefusedEvent } from "../../audit/events.js";
 import { listAuditEvents } from "../../audit/reader.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
 
 let db: any;
 
 beforeEach(async () => {
+  await installTestProLicense("enterprise");
   db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
 });
 
 async function seed() {

--- a/packages/core/src/__tests__/audit/reader.test.ts
+++ b/packages/core/src/__tests__/audit/reader.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents, pipelineRuns, pmApprovals, budgetAlerts } from "../../db/schema.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent, budgetRefusedEvent } from "../../audit/events.js";
+import { listAuditEvents } from "../../audit/reader.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+async function seed() {
+  // native audit events
+  await logAuditEvent(db, pmPromotedEvent({ issueId: "BEC-1", fromState: "Backlog", toState: "Todo" }));
+  await logAuditEvent(db, budgetRefusedEvent({
+    scope: "team:T1", scopeType: "team", tokensUsed: 100, limit: 100, utilization: 100,
+  }));
+  // projectable: pipeline run
+  await db.insert(pipelineRuns).values({
+    id: "run_1", issueId: "BEC-9", issueTitle: "t", pipelineKey: "auto-implement",
+    repoUrl: "https://x.y/z", status: "completed",
+    startedAt: new Date("2026-04-01T10:00:00Z"),
+    completedAt: new Date("2026-04-01T10:05:00Z"),
+    totalInputTokens: 100, totalOutputTokens: 50, runType: "standard",
+    linearTeamId: "T1",
+  });
+}
+
+describe("listAuditEvents", () => {
+  it("returns native + projected events merged by time", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { limit: 100 });
+    const types = events.map(e => e.eventType).sort();
+    expect(types).toContain("pm.issue_promoted");
+    expect(types).toContain("budget.run_refused");
+    expect(types).toContain("run.started");
+    expect(types).toContain("run.completed");
+  });
+
+  it("filters by event type", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { eventTypes: ["run.completed"], limit: 100 });
+    expect(events.map(e => e.eventType)).toEqual(["run.completed"]);
+  });
+
+  it("filters by scope prefix-exact", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { scope: "team:T1", limit: 100 });
+    for (const e of events) expect(e.scope === "team:T1" || e.scope === null).toBeTruthy();
+    expect(events.some(e => e.scope === "team:T1")).toBe(true);
+  });
+
+  it("filters by date window", async () => {
+    await seed();
+    const from = new Date("2026-04-01T09:00:00Z");
+    const to = new Date("2026-04-01T10:10:00Z");
+    const { events } = await listAuditEvents(db, { from, to, limit: 100 });
+    for (const e of events) {
+      expect(e.timestamp >= from && e.timestamp <= to).toBe(true);
+    }
+  });
+
+  it("filters by runId", async () => {
+    await seed();
+    const { events } = await listAuditEvents(db, { runId: "run_1", limit: 100 });
+    expect(events.length).toBeGreaterThan(0);
+    for (const e of events) expect(e.runId).toBe("run_1");
+  });
+
+  it("paginates via cursor", async () => {
+    // seed 5 promoted events
+    for (let i = 0; i < 5; i++) {
+      await logAuditEvent(db, pmPromotedEvent({ issueId: `BEC-${i}`, fromState: "Backlog", toState: "Todo" }));
+      await new Promise(r => setTimeout(r, 10));
+    }
+    const page1 = await listAuditEvents(db, { limit: 2 });
+    expect(page1.events).toHaveLength(2);
+    expect(page1.nextCursor).not.toBeNull();
+    const page2 = await listAuditEvents(db, { limit: 2, cursor: page1.nextCursor! });
+    expect(page2.events).toHaveLength(2);
+    const seen = new Set([...page1.events, ...page2.events].map(e => e.id));
+    expect(seen.size).toBe(4);
+  });
+});

--- a/packages/core/src/__tests__/audit/retention.test.ts
+++ b/packages/core/src/__tests__/audit/retention.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents, pipelineRuns } from "../../db/schema.js";
+import { pruneAuditLog } from "../../audit/retention.js";
+
+describe("pruneAuditLog", () => {
+  it("deletes rows older than retentionDays", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const now = Date.now();
+    await (db as any).insert(auditEvents).values([
+      {
+        id: "old",
+        timestamp: new Date(now - 400 * 86400000),
+        eventType: "pm.issue_promoted",
+        actor: "pm-agent",
+        actorType: "pm-agent",
+        payload: "{}",
+      },
+      {
+        id: "new",
+        timestamp: new Date(now - 10 * 86400000),
+        eventType: "pm.issue_promoted",
+        actor: "pm-agent",
+        actorType: "pm-agent",
+        payload: "{}",
+      },
+    ]);
+    const deleted = await pruneAuditLog(db, 365);
+    expect(deleted).toBe(1);
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows.map((r: any) => r.id)).toEqual(["new"]);
+  });
+
+  it("does not touch pipeline_runs", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(pipelineRuns).values({
+      id: "r1",
+      issueId: "BEC-1",
+      issueTitle: "t",
+      pipelineKey: "auto-implement",
+      repoUrl: "x",
+      status: "completed",
+      startedAt: new Date(Date.now() - 400 * 86400000),
+    });
+    await pruneAuditLog(db, 365);
+    const rows = await (db as any).select().from(pipelineRuns);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/core/src/__tests__/audit/writer.test.ts
+++ b/packages/core/src/__tests__/audit/writer.test.ts
@@ -1,46 +1,82 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { auditEvents } from "../../db/schema.js";
 import { logAuditEvent } from "../../audit/writer.js";
 import { pmPromotedEvent } from "../../audit/events.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+import { _resetLicenseCache } from "../../license.js";
 
 describe("logAuditEvent", () => {
-  it("persists an event row", async () => {
-    const db = await createDb({ connectionString: ":memory:" });
-    await logAuditEvent(
-      db,
-      pmPromotedEvent({
-        issueId: "BEC-1",
-        fromState: "Backlog",
-        toState: "Todo",
-      }),
-    );
-    const rows = await (db as any).select().from(auditEvents);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].eventType).toBe("pm.issue_promoted");
-    expect(JSON.parse(rows[0].payload)).toMatchObject({
-      fromState: "Backlog",
-      toState: "Todo",
+  describe("with enterprise license", () => {
+    beforeEach(async () => {
+      await installTestProLicense("enterprise");
     });
-  });
+    afterEach(async () => {
+      await restoreLicense();
+    });
 
-  it("does not throw when the db insert fails", async () => {
-    const fakeDb = {
-      insert: () => ({
-        values: () => {
-          throw new Error("db down");
-        },
-      }),
-    } as any;
-    await expect(
-      logAuditEvent(
-        fakeDb,
+    it("persists an event row", async () => {
+      const db = await createDb({ connectionString: ":memory:" });
+      await logAuditEvent(
+        db,
         pmPromotedEvent({
           issueId: "BEC-1",
           fromState: "Backlog",
           toState: "Todo",
         }),
-      ),
-    ).resolves.toBeUndefined();
+      );
+      const rows = await (db as any).select().from(auditEvents);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].eventType).toBe("pm.issue_promoted");
+      expect(JSON.parse(rows[0].payload)).toMatchObject({
+        fromState: "Backlog",
+        toState: "Todo",
+      });
+    });
+
+    it("does not throw when the db insert fails", async () => {
+      const fakeDb = {
+        insert: () => ({
+          values: () => {
+            throw new Error("db down");
+          },
+        }),
+      } as any;
+      await expect(
+        logAuditEvent(
+          fakeDb,
+          pmPromotedEvent({
+            issueId: "BEC-1",
+            fromState: "Backlog",
+            toState: "Todo",
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("without a license (OSS mode)", () => {
+    beforeEach(() => {
+      _resetLicenseCache();
+      delete process.env.URATEAM_LICENSE_KEY;
+    });
+    afterEach(() => {
+      _resetLicenseCache();
+      delete process.env.URATEAM_LICENSE_KEY;
+    });
+
+    it("is a no-op when the audit-log feature is not licensed", async () => {
+      const db = await createDb({ connectionString: ":memory:" });
+      await logAuditEvent(
+        db,
+        pmPromotedEvent({
+          issueId: "BEC-1",
+          fromState: "Backlog",
+          toState: "Todo",
+        }),
+      );
+      const rows = await (db as any).select().from(auditEvents);
+      expect(rows).toHaveLength(0);
+    });
   });
 });

--- a/packages/core/src/__tests__/audit/writer.test.ts
+++ b/packages/core/src/__tests__/audit/writer.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { auditEvents } from "../../db/schema.js";
+import { logAuditEvent } from "../../audit/writer.js";
+import { pmPromotedEvent } from "../../audit/events.js";
+
+describe("logAuditEvent", () => {
+  it("persists an event row", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await logAuditEvent(
+      db,
+      pmPromotedEvent({
+        issueId: "BEC-1",
+        fromState: "Backlog",
+        toState: "Todo",
+      }),
+    );
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe("pm.issue_promoted");
+    expect(JSON.parse(rows[0].payload)).toMatchObject({
+      fromState: "Backlog",
+      toState: "Todo",
+    });
+  });
+
+  it("does not throw when the db insert fails", async () => {
+    const fakeDb = {
+      insert: () => ({
+        values: () => {
+          throw new Error("db down");
+        },
+      }),
+    } as any;
+    await expect(
+      logAuditEvent(
+        fakeDb,
+        pmPromotedEvent({
+          issueId: "BEC-1",
+          fromState: "Backlog",
+          toState: "Todo",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/db-audit-schema.test.ts
+++ b/packages/core/src/__tests__/db-audit-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("audit_events schema", () => {
+  it("creates the table with required columns on fresh SQLite db", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const cols = (db as any).all(sql`PRAGMA table_info(audit_events)`) as Array<{name: string}>;
+    const names = cols.map(c => c.name).sort();
+    expect(names).toEqual([
+      "actor", "actor_type", "event_type", "id", "input_tokens",
+      "issue_id", "output_tokens", "payload", "run_id", "scope", "timestamp",
+    ]);
+  });
+
+  it("inserts and reads back an audit event", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(auditEvents).values({
+      id: "evt_1",
+      eventType: "pm.issue_promoted",
+      actor: "pm-agent",
+      actorType: "pm-agent",
+      scope: "team:T1",
+      runId: null,
+      issueId: "BEC-1",
+      inputTokens: 0,
+      outputTokens: 0,
+      payload: JSON.stringify({ test: true }),
+    });
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe("pm.issue_promoted");
+    expect(rows[0].timestamp).toBeInstanceOf(Date);
+  });
+});

--- a/packages/core/src/__tests__/license-audit-event.test.ts
+++ b/packages/core/src/__tests__/license-audit-event.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { checkLicense, _resetLicenseCache } from "../license.js";
+
+describe("checkLicense — audit event on invalid license", () => {
+  beforeEach(() => {
+    _resetLicenseCache();
+    delete process.env.URATEAM_LICENSE_KEY;
+  });
+
+  afterEach(() => {
+    _resetLicenseCache();
+    delete process.env.URATEAM_LICENSE_KEY;
+  });
+
+  it("emits license.validation_failed when license key is bad-signature", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    // A syntactically-valid JWT shape (three parts, EdDSA header) but bogus
+    // signature — verifyJwt returns { ok: false, reason: "bad-signature" }.
+    const header = Buffer.from(JSON.stringify({ alg: "EdDSA", typ: "JWT" }))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const payload = Buffer.from(
+      JSON.stringify({
+        iss: "urateam.dev",
+        sub: "cust",
+        tier: "pro",
+        iat: 1,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const sig = "AAAA";
+    process.env.URATEAM_LICENSE_KEY = `${header}.${payload}.${sig}`;
+
+    const status = checkLicense(db as any);
+    expect(status.licensed).toBe(false);
+    expect(status.tier).toBe("oss");
+    expect(status.invalidReason).toBe("bad-signature");
+
+    // void logAuditEvent — flush microtask
+    await new Promise((r) => setImmediate(r));
+
+    const rows = await (db as any).select().from(auditEvents);
+    const failures = rows.filter(
+      (r: any) => r.eventType === "license.validation_failed",
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].actor).toBe("system");
+    expect(failures[0].actorType).toBe("system");
+    const payloadJson = JSON.parse(failures[0].payload);
+    expect(payloadJson.invalidReason).toBe("bad-signature");
+  });
+
+  it("does not emit an audit event when no license key is set (OSS mode)", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const status = checkLicense(db as any);
+    expect(status.tier).toBe("oss");
+    expect(status.invalidReason).toBeUndefined();
+
+    await new Promise((r) => setImmediate(r));
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/pm-action-audit-events.test.ts
+++ b/packages/core/src/__tests__/pm-action-audit-events.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDb } from "../db/client.js";
+import { auditEvents, pmApprovals } from "../db/schema.js";
+import { promoteReadyIssues } from "../pm/actions/promote.js";
+import { triageNewIssues } from "../pm/actions/triage.js";
+import { resolveApprovals } from "../pm/actions/resolve-approvals.js";
+
+async function getAuditRows(db: any) {
+  return await db.select().from(auditEvents);
+}
+
+describe("pm action audit events", () => {
+  it("emits pm.issue_promoted when promote.ts moves issue to Todo", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const linearClient = {
+      issues: vi.fn().mockResolvedValue({
+        nodes: [
+          {
+            id: "issue-1",
+            identifier: "BEC-101",
+            title: "Fix thing",
+            description: "desc",
+            priority: 1,
+            labels: { nodes: [] },
+            team: { id: "team-1" },
+            url: "https://linear.app/BEC-101",
+          },
+        ],
+      }),
+      updateIssue: vi.fn().mockResolvedValue({}),
+      createComment: vi.fn().mockResolvedValue({}),
+    };
+
+    await promoteReadyIssues({
+      linearClient: linearClient as any,
+      teamIds: ["team-1"],
+      slotsAvailable: 1,
+      checkConflict: vi.fn().mockResolvedValue({
+        overlapRisk: "none",
+        likelyFiles: [],
+        reasoning: "",
+      }),
+      stateMap: new Map([["team-1:Todo", "state-todo"]]),
+      db: db as any,
+    });
+
+    // Give the void-logAuditEvent microtask a chance to flush
+    await new Promise((r) => setImmediate(r));
+
+    const rows = await getAuditRows(db);
+    const promoted = rows.filter((r: any) => r.eventType === "pm.issue_promoted");
+    expect(promoted).toHaveLength(1);
+    expect(promoted[0].issueId).toBe("BEC-101");
+    const payload = JSON.parse(promoted[0].payload);
+    expect(payload.fromState).toBe("Backlog");
+    expect(payload.toState).toBe("Todo");
+  });
+
+  it("emits pm.triage_classified after Haiku classifies", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const linearClient = {
+      issues: vi.fn().mockResolvedValue({
+        nodes: [
+          {
+            id: "issue-1",
+            identifier: "BEC-202",
+            title: "Add feature",
+            description: "do the thing",
+            labels: { nodes: [] },
+            team: { id: "team-1" },
+          },
+        ],
+      }),
+      issueLabels: vi.fn().mockResolvedValue({
+        nodes: [
+          { id: "lbl-feature", name: "feature" },
+          { id: "lbl-auto", name: "auto-implement" },
+        ],
+      }),
+      updateIssue: vi.fn().mockResolvedValue({}),
+      createComment: vi.fn().mockResolvedValue({}),
+    };
+
+    const callClaude = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        priority: 2,
+        labels: ["feature"],
+        complexity: "small",
+        rationale: "Standard feature work",
+        acceptanceCriteria: ["a1 integration", "a2 behavior"],
+      }),
+    );
+
+    await triageNewIssues({
+      linearClient: linearClient as any,
+      teamIds: ["team-1"],
+      callClaude,
+      sanitize: (s: string) => s,
+      stateMap: new Map([["team-1:Backlog", "state-backlog"]]),
+      db: db as any,
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    const rows = await getAuditRows(db);
+    const triaged = rows.filter((r: any) => r.eventType === "pm.triage_classified");
+    expect(triaged).toHaveLength(1);
+    expect(triaged[0].issueId).toBe("BEC-202");
+    const payload = JSON.parse(triaged[0].payload);
+    expect(payload.label).toBe("auto-implement");
+    expect(payload.rationale).toBe("Standard feature work");
+  });
+
+  it("emits pm.issue_deprioritized after approval resolves", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    // Insert a pending approval row
+    await (db as any).insert(pmApprovals).values({
+      id: "appr-dep-1",
+      issueId: "BEC-301",
+      action: "deprioritize",
+      reason: "stale",
+      slackMessageTs: "ts-dep",
+      status: "pending",
+    });
+
+    const linearClient = {
+      searchIssues: vi.fn().mockResolvedValue({ nodes: [{ id: "linear-id-301" }] }),
+      updateIssue: vi.fn().mockResolvedValue({}),
+      createComment: vi.fn().mockResolvedValue({}),
+    };
+    const slackNotifier = {
+      checkApprovalReactions: vi.fn().mockResolvedValue("approved"),
+      postApprovalExpired: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await resolveApprovals({
+      linearClient: linearClient as any,
+      slackNotifier: slackNotifier as any,
+      db: db as any,
+      teamIds: ["team-1"],
+      stateMap: new Map([
+        ["team-1:Icebox", "state-icebox"],
+        ["team-1:Canceled", "state-canceled"],
+      ]),
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    const rows = await getAuditRows(db);
+    const dep = rows.filter((r: any) => r.eventType === "pm.issue_deprioritized");
+    expect(dep).toHaveLength(1);
+    expect(dep[0].issueId).toBe("BEC-301");
+    const payload = JSON.parse(dep[0].payload);
+    expect(payload.approvalId).toBe("appr-dep-1");
+  });
+
+  it("emits pm.issue_cancelled after approval resolves", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    await (db as any).insert(pmApprovals).values({
+      id: "appr-can-1",
+      issueId: "BEC-401",
+      action: "cancel",
+      reason: "abandoned 35 days",
+      slackMessageTs: "ts-can",
+      status: "pending",
+    });
+
+    const linearClient = {
+      searchIssues: vi.fn().mockResolvedValue({ nodes: [{ id: "linear-id-401" }] }),
+      updateIssue: vi.fn().mockResolvedValue({}),
+      createComment: vi.fn().mockResolvedValue({}),
+    };
+    const slackNotifier = {
+      checkApprovalReactions: vi.fn().mockResolvedValue("approved"),
+      postApprovalExpired: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await resolveApprovals({
+      linearClient: linearClient as any,
+      slackNotifier: slackNotifier as any,
+      db: db as any,
+      teamIds: ["team-1"],
+      stateMap: new Map([
+        ["team-1:Icebox", "state-icebox"],
+        ["team-1:Canceled", "state-canceled"],
+      ]),
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    const rows = await getAuditRows(db);
+    const canc = rows.filter((r: any) => r.eventType === "pm.issue_cancelled");
+    expect(canc).toHaveLength(1);
+    expect(canc[0].issueId).toBe("BEC-401");
+    const payload = JSON.parse(canc[0].payload);
+    expect(payload.approvalId).toBe("appr-can-1");
+    expect(payload.reason).toBe("abandoned 35 days");
+  });
+});

--- a/packages/core/src/__tests__/pm-action-audit-events.test.ts
+++ b/packages/core/src/__tests__/pm-action-audit-events.test.ts
@@ -1,15 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createDb } from "../db/client.js";
 import { auditEvents, pmApprovals } from "../db/schema.js";
 import { promoteReadyIssues } from "../pm/actions/promote.js";
 import { triageNewIssues } from "../pm/actions/triage.js";
 import { resolveApprovals } from "../pm/actions/resolve-approvals.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
 
 async function getAuditRows(db: any) {
   return await db.select().from(auditEvents);
 }
 
 describe("pm action audit events", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
   it("emits pm.issue_promoted when promote.ts moves issue to Todo", async () => {
     const db = await createDb({ connectionString: ":memory:" });
 

--- a/packages/core/src/__tests__/pm-approvals.test.ts
+++ b/packages/core/src/__tests__/pm-approvals.test.ts
@@ -23,7 +23,7 @@ function mockApprovalDb() {
     rows,
     select: () => ({
       from: () => ({
-        where: () => Promise.resolve(rows),
+        where: () => Promise.resolve([...rows]),
       }),
     }),
     insert: () => ({

--- a/packages/core/src/__tests__/pm-audit-retention-step.test.ts
+++ b/packages/core/src/__tests__/pm-audit-retention-step.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPmScheduler } from "../pm/scheduler.js";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+function stubActions() {
+  return {
+    evaluateBudget: vi.fn().mockResolvedValue({
+      scopes: [
+        {
+          scope: { kind: "global" as const },
+          scopeLabel: "global",
+          limit: 100,
+          used: 0,
+          percent: 0,
+          tier: "ok" as const,
+        },
+      ],
+      worstTier: "ok" as const,
+      promoteBlocked: false,
+      activeCount: 0,
+    }),
+    recoverRetriableRuns: vi.fn().mockResolvedValue({ recovered: [], exhausted: [] }),
+    recoverStuckInProgressIssues: vi.fn().mockResolvedValue([]),
+    triageNewIssues: vi.fn().mockResolvedValue([]),
+    resolveApprovals: vi.fn().mockResolvedValue({ resolved: 0, stillPending: 0 }),
+    promoteReadyIssues: vi.fn().mockResolvedValue([]),
+    deprioritizeStaleIssues: vi.fn().mockResolvedValue([]),
+    cancelAbandonedIssues: vi.fn().mockResolvedValue([]),
+    postDigest: vi.fn().mockResolvedValue(undefined),
+    getActiveFileMaps: vi.fn().mockResolvedValue(new Map()),
+    predictConflict: vi.fn().mockResolvedValue({ overlapRisk: "none", likelyFiles: [], reasoning: "" }),
+  };
+}
+
+function baseConfig(extra: Record<string, unknown> = {}): any {
+  return {
+    enabled: true,
+    cronIntervalMs: 1800000,
+    triageBatchSize: 3,
+    maxInFlight: 3,
+    dailyTokenBudget: 100,
+    slackChannelId: "C123",
+    teamIds: ["team-1"],
+    ...extra,
+  };
+}
+
+describe("pm tick audit retention sweep", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("deletes audit_events older than retentionDays", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const oldTs = new Date(Date.now() - 400 * 86400000);
+    const freshTs = new Date();
+    await (db as any).insert(auditEvents).values([
+      {
+        id: "old",
+        timestamp: oldTs,
+        eventType: "pm.issue_promoted",
+        actor: "pm-agent",
+        actorType: "pm-agent",
+        payload: "{}",
+      },
+      {
+        id: "fresh",
+        timestamp: freshTs,
+        eventType: "pm.issue_promoted",
+        actor: "pm-agent",
+        actorType: "pm-agent",
+        payload: "{}",
+      },
+    ]);
+
+    const scheduler = createPmScheduler({
+      config: baseConfig({ auditLog: { retentionDays: 365 } }),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await scheduler.tick();
+
+    const rows = await (db as any).select().from(auditEvents);
+    const ids = rows.map((r: any) => r.id);
+    expect(ids).not.toContain("old");
+    expect(ids).toContain("fresh");
+  });
+
+  it("uses default retention (365d) when config.auditLog is unset", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    await (db as any).insert(auditEvents).values([
+      {
+        id: "ancient",
+        timestamp: new Date(Date.now() - 400 * 86400000),
+        eventType: "pm.issue_promoted",
+        actor: "pm-agent",
+        actorType: "pm-agent",
+        payload: "{}",
+      },
+    ]);
+
+    const scheduler = createPmScheduler({
+      config: baseConfig(),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await scheduler.tick();
+
+    const rows = await (db as any).select().from(auditEvents);
+    expect(rows.find((r: any) => r.id === "ancient")).toBeUndefined();
+  });
+
+  it("tick does not throw when retention sweep fails", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    // Break the audit_events table so pruneAuditLog throws.
+    await (db as any).run?.("DROP TABLE audit_events");
+
+    const scheduler = createPmScheduler({
+      config: baseConfig({ auditLog: { retentionDays: 30 } }),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/pm-budget-refused-event.test.ts
+++ b/packages/core/src/__tests__/pm-budget-refused-event.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPmScheduler } from "../pm/scheduler.js";
+import { createDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+import type { BudgetEvaluation } from "../pm/types.js";
+
+function mixedBlockedEvaluation(): BudgetEvaluation {
+  return {
+    scopes: [
+      {
+        scope: { kind: "global" as const },
+        scopeLabel: "global",
+        limit: 100,
+        used: 100,
+        percent: 100,
+        tier: "blocked-100" as const,
+      },
+      {
+        scope: { kind: "team" as const, teamId: "T1" },
+        scopeLabel: "team T1",
+        limit: 50,
+        used: 60,
+        percent: 120,
+        tier: "blocked-100" as const,
+      },
+      {
+        scope: { kind: "repo" as const, repoUrl: "https://github.com/x/y" },
+        scopeLabel: "repo x",
+        limit: 100,
+        used: 10,
+        percent: 10,
+        tier: "ok" as const,
+      },
+    ],
+    worstTier: "blocked-100",
+    promoteBlocked: true,
+    blockReason: "global at 100%",
+    activeCount: 0,
+  };
+}
+
+describe("budget.run_refused audit event", () => {
+  beforeEach(async () => {
+    await installTestProLicense();
+  });
+
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("writes one event per blocked scope from evaluateBudget", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const mockActions = {
+      evaluateBudget: vi.fn().mockResolvedValue(mixedBlockedEvaluation()),
+      recoverRetriableRuns: vi.fn().mockResolvedValue({ recovered: [], exhausted: [] }),
+      recoverStuckInProgressIssues: vi.fn().mockResolvedValue([]),
+      triageNewIssues: vi.fn().mockResolvedValue([]),
+      resolveApprovals: vi.fn().mockResolvedValue({ resolved: 0, stillPending: 0 }),
+      promoteReadyIssues: vi.fn().mockResolvedValue([]),
+      deprioritizeStaleIssues: vi.fn().mockResolvedValue([]),
+      cancelAbandonedIssues: vi.fn().mockResolvedValue([]),
+      postDigest: vi.fn().mockResolvedValue(undefined),
+      getActiveFileMaps: vi.fn().mockResolvedValue(new Map()),
+      predictConflict: vi.fn().mockResolvedValue({ overlapRisk: "none", likelyFiles: [], reasoning: "" }),
+    };
+
+    const scheduler = createPmScheduler({
+      config: {
+        enabled: true,
+        cronIntervalMs: 1800000,
+        triageBatchSize: 3,
+        maxInFlight: 3,
+        dailyTokenBudget: 100,
+        slackChannelId: "C123",
+        teamIds: ["team-1"],
+      } as any,
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: mockActions as any,
+    });
+
+    await scheduler.tick();
+
+    const rows = await (db as any).select().from(auditEvents);
+    const refused = rows.filter((r: any) => r.eventType === "budget.run_refused");
+    expect(refused).toHaveLength(2);
+    const scopes = refused.map((r: any) => r.scope).sort();
+    expect(scopes).toEqual(["global", "team:T1"]);
+
+    for (const row of refused) {
+      const payload = JSON.parse(row.payload);
+      expect(payload).toHaveProperty("scopeType");
+      expect(payload).toHaveProperty("tokensUsed");
+      expect(payload).toHaveProperty("limit");
+      expect(payload).toHaveProperty("utilization");
+    }
+  });
+
+  it("does not write audit events when no scopes are blocked", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const mockActions = {
+      evaluateBudget: vi.fn().mockResolvedValue({
+        scopes: [
+          {
+            scope: { kind: "global" as const },
+            scopeLabel: "global",
+            limit: 100,
+            used: 10,
+            percent: 10,
+            tier: "ok" as const,
+          },
+        ],
+        worstTier: "ok",
+        promoteBlocked: false,
+        activeCount: 0,
+      } as BudgetEvaluation),
+      recoverRetriableRuns: vi.fn().mockResolvedValue({ recovered: [], exhausted: [] }),
+      recoverStuckInProgressIssues: vi.fn().mockResolvedValue([]),
+      triageNewIssues: vi.fn().mockResolvedValue([]),
+      resolveApprovals: vi.fn().mockResolvedValue({ resolved: 0, stillPending: 0 }),
+      promoteReadyIssues: vi.fn().mockResolvedValue([]),
+      deprioritizeStaleIssues: vi.fn().mockResolvedValue([]),
+      cancelAbandonedIssues: vi.fn().mockResolvedValue([]),
+      postDigest: vi.fn().mockResolvedValue(undefined),
+      getActiveFileMaps: vi.fn().mockResolvedValue(new Map()),
+      predictConflict: vi.fn().mockResolvedValue({ overlapRisk: "none", likelyFiles: [], reasoning: "" }),
+    };
+
+    const scheduler = createPmScheduler({
+      config: {
+        enabled: true,
+        cronIntervalMs: 1800000,
+        triageBatchSize: 3,
+        maxInFlight: 3,
+        dailyTokenBudget: 100,
+        slackChannelId: "C123",
+        teamIds: ["team-1"],
+      } as any,
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: mockActions as any,
+    });
+
+    await scheduler.tick();
+
+    const rows = await (db as any).select().from(auditEvents);
+    const refused = rows.filter((r: any) => r.eventType === "budget.run_refused");
+    expect(refused).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/pm-budget-refused-event.test.ts
+++ b/packages/core/src/__tests__/pm-budget-refused-event.test.ts
@@ -42,7 +42,7 @@ function mixedBlockedEvaluation(): BudgetEvaluation {
 
 describe("budget.run_refused audit event", () => {
   beforeEach(async () => {
-    await installTestProLicense();
+    await installTestProLicense("enterprise");
   });
 
   afterEach(async () => {

--- a/packages/core/src/audit/config-fingerprint.ts
+++ b/packages/core/src/audit/config-fingerprint.ts
@@ -1,0 +1,21 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+/**
+ * Compute a sha256 fingerprint of a config file on disk. Used to populate
+ * the `config.loaded` audit event payload so operators can tell when a
+ * running process has a different config than what's currently on disk.
+ *
+ * Returns `null` if the file cannot be read (fail-open: config loading
+ * itself should surface the error, we just skip the fingerprint).
+ */
+export async function computeConfigFingerprint(
+  path: string,
+): Promise<string | null> {
+  try {
+    const bytes = await readFile(path);
+    return createHash("sha256").update(bytes).digest("hex");
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/audit/csv.ts
+++ b/packages/core/src/audit/csv.ts
@@ -5,7 +5,13 @@ import { listAuditEvents, type ListAuditEventsFilters } from "./reader.js";
 const CSV_HEADER =
   "timestamp_utc,event_type,actor,actor_type,scope,run_id,issue_id,input_tokens,output_tokens,payload_json";
 
+// Cells starting with these characters are interpreted as formulas by Excel
+// and Google Sheets when the CSV is opened. Prefix with a single quote to
+// neutralize — RFC 4180 quoting alone does not defeat formula injection.
+const FORMULA_PREFIX = /^[=+\-@\t]/;
+
 function escapeCsvField(value: string): string {
+  if (FORMULA_PREFIX.test(value)) value = "'" + value;
   if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
     return `"${value.replace(/"/g, '""')}"`;
   }

--- a/packages/core/src/audit/csv.ts
+++ b/packages/core/src/audit/csv.ts
@@ -39,7 +39,6 @@ export async function* streamAuditCsv(
 ): AsyncGenerator<string, void, void> {
   yield CSV_HEADER;
   let cursor: string | null = null;
-  const seen = new Set<string>();
   // safety bound to prevent infinite loops from broken cursors
   let pages = 0;
   const maxPages = 100000;
@@ -51,8 +50,6 @@ export async function* streamAuditCsv(
         cursor: cursor ?? undefined,
       });
     for (const e of events) {
-      if (seen.has(e.id)) continue;
-      seen.add(e.id);
       yield eventToCsvRow(e);
     }
     if (!nextCursor || events.length === 0) break;

--- a/packages/core/src/audit/csv.ts
+++ b/packages/core/src/audit/csv.ts
@@ -1,0 +1,62 @@
+import type { AnyDb } from "../db/client.js";
+import type { AuditEvent } from "../types.js";
+import { listAuditEvents, type ListAuditEventsFilters } from "./reader.js";
+
+const CSV_HEADER =
+  "timestamp_utc,event_type,actor,actor_type,scope,run_id,issue_id,input_tokens,output_tokens,payload_json";
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function eventToCsvRow(e: AuditEvent): string {
+  const fields = [
+    e.timestamp.toISOString(),
+    e.eventType,
+    e.actor,
+    e.actorType,
+    e.scope ?? "",
+    e.runId ?? "",
+    e.issueId ?? "",
+    String(e.inputTokens ?? 0),
+    String(e.outputTokens ?? 0),
+    JSON.stringify(e.payload ?? {}),
+  ];
+  return fields.map(escapeCsvField).join(",");
+}
+
+/**
+ * Streams audit events as CSV rows. Yields the header row first, then data
+ * rows, paging through `listAuditEvents` via cursor to keep memory bounded.
+ */
+export async function* streamAuditCsv(
+  db: AnyDb,
+  filters: ListAuditEventsFilters = {},
+  pageSize = 500,
+): AsyncGenerator<string, void, void> {
+  yield CSV_HEADER;
+  let cursor: string | null = null;
+  const seen = new Set<string>();
+  // safety bound to prevent infinite loops from broken cursors
+  let pages = 0;
+  const maxPages = 100000;
+  while (true) {
+    const { events, nextCursor }: { events: AuditEvent[]; nextCursor: string | null } =
+      await listAuditEvents(db, {
+        ...filters,
+        limit: pageSize,
+        cursor: cursor ?? undefined,
+      });
+    for (const e of events) {
+      if (seen.has(e.id)) continue;
+      seen.add(e.id);
+      yield eventToCsvRow(e);
+    }
+    if (!nextCursor || events.length === 0) break;
+    cursor = nextCursor;
+    if (++pages > maxPages) break;
+  }
+}

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import type { AuditEvent } from "../types.js";
+
+function base(
+  partial: Partial<AuditEvent> & Pick<AuditEvent, "eventType" | "actor" | "actorType">,
+): AuditEvent {
+  return {
+    id: `evt_${randomUUID()}`,
+    timestamp: new Date(),
+    scope: partial.scope ?? null,
+    runId: partial.runId ?? null,
+    issueId: partial.issueId ?? null,
+    inputTokens: partial.inputTokens ?? 0,
+    outputTokens: partial.outputTokens ?? 0,
+    payload: partial.payload ?? {},
+    ...partial,
+  };
+}
+
+export function pmPromotedEvent(args: {
+  issueId: string;
+  fromState: string;
+  toState: string;
+  priority?: number;
+  reason?: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.issue_promoted",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: {
+      fromState: args.fromState,
+      toState: args.toState,
+      priority: args.priority,
+      reason: args.reason,
+    },
+  });
+}
+
+export function pmDeprioritizedEvent(args: {
+  issueId: string;
+  oldPriority: number | null;
+  newPriority: number;
+  approvalId: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.issue_deprioritized",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: {
+      oldPriority: args.oldPriority,
+      newPriority: args.newPriority,
+      approvalId: args.approvalId,
+    },
+  });
+}
+
+export function pmCancelledEvent(args: {
+  issueId: string;
+  approvalId: string;
+  reason: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.issue_cancelled",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: { approvalId: args.approvalId, reason: args.reason },
+  });
+}
+
+export function pmTriageClassifiedEvent(args: {
+  issueId: string;
+  label: string;
+  rationale: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.triage_classified",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    issueId: args.issueId,
+    payload: { label: args.label, rationale: args.rationale.slice(0, 500) },
+  });
+}
+
+export function budgetRefusedEvent(args: {
+  scope: string;
+  scopeType: "global" | "team" | "repo";
+  tokensUsed: number;
+  limit: number;
+  utilization: number;
+  refusedRunId?: string;
+}): AuditEvent {
+  return base({
+    eventType: "budget.run_refused",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    scope: args.scope,
+    runId: args.refusedRunId ?? null,
+    payload: {
+      scopeType: args.scopeType,
+      tokensUsed: args.tokensUsed,
+      limit: args.limit,
+      utilization: args.utilization,
+    },
+  });
+}
+
+export function licenseValidationFailedEvent(args: {
+  invalidReason: "missing" | "expired" | "bad-signature" | "wrong-issuer";
+  expiredAt?: Date;
+}): AuditEvent {
+  return base({
+    eventType: "license.validation_failed",
+    actor: "system",
+    actorType: "system",
+    payload: {
+      invalidReason: args.invalidReason,
+      expiredAt: args.expiredAt?.toISOString(),
+    },
+  });
+}
+
+export function configLoadedEvent(args: {
+  path: string;
+  sha256: string;
+  tier: string;
+}): AuditEvent {
+  return base({
+    eventType: "config.loaded",
+    actor: "system",
+    actorType: "system",
+    payload: { path: args.path, sha256: args.sha256, tier: args.tier },
+  });
+}

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,0 +1,1 @@
+export * from "./events.js";

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,2 +1,3 @@
 export * from "./events.js";
 export * from "./writer.js";
+export * from "./projection.js";

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,3 +1,4 @@
 export * from "./events.js";
 export * from "./writer.js";
 export * from "./projection.js";
+export * from "./reader.js";

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -2,3 +2,4 @@ export * from "./events.js";
 export * from "./writer.js";
 export * from "./projection.js";
 export * from "./reader.js";
+export * from "./retention.js";

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,1 +1,2 @@
 export * from "./events.js";
+export * from "./writer.js";

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -3,3 +3,4 @@ export * from "./writer.js";
 export * from "./projection.js";
 export * from "./reader.js";
 export * from "./retention.js";
+export * from "./csv.js";

--- a/packages/core/src/audit/projection.ts
+++ b/packages/core/src/audit/projection.ts
@@ -1,0 +1,136 @@
+import type { AuditEvent, AuditActorType } from "../types.js";
+
+// Row types left loose-typed because drizzle-infer varies by driver;
+// projection consumers pass through `select().from(table)` results.
+type PipelineRunRow = {
+  id: string; issueId: string; status: string;
+  startedAt: Date; completedAt: Date | null;
+  totalInputTokens: number; totalOutputTokens: number;
+  runType: string; parentRunId: string | null;
+  linearTeamId: string | null; repoUrl: string;
+  autoMerged: boolean | null; autoMergeReason: string | null;
+  errorMessage: string | null;
+};
+
+function scopeForRun(row: PipelineRunRow): string | null {
+  if (row.linearTeamId) return `team:${row.linearTeamId}`;
+  return `repo:${row.repoUrl}`;
+}
+
+function actorForRun(row: PipelineRunRow): { actor: string; actorType: AuditActorType } {
+  if (row.runType === "review-feedback") return { actor: "github-webhook", actorType: "webhook" };
+  if (row.parentRunId) return { actor: "pm-agent", actorType: "pm-agent" };
+  return { actor: "linear-webhook", actorType: "webhook" };
+}
+
+export function projectPipelineRun(row: PipelineRunRow): AuditEvent[] {
+  const events: AuditEvent[] = [];
+  const { actor, actorType } = actorForRun(row);
+  const scope = scopeForRun(row);
+
+  events.push({
+    id: `proj_run_started_${row.id}`,
+    timestamp: row.startedAt,
+    eventType: "run.started",
+    actor, actorType, scope,
+    runId: row.id, issueId: row.issueId,
+    inputTokens: 0, outputTokens: 0,
+    payload: { runType: row.runType, repoUrl: row.repoUrl },
+  });
+
+  if (row.completedAt && row.status === "completed") {
+    events.push({
+      id: `proj_run_completed_${row.id}`,
+      timestamp: row.completedAt,
+      eventType: "run.completed",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: row.totalInputTokens,
+      outputTokens: row.totalOutputTokens,
+      payload: {},
+    });
+  }
+
+  if (row.completedAt && (row.status === "failed" || row.status === "retriable")) {
+    events.push({
+      id: `proj_run_failed_${row.id}`,
+      timestamp: row.completedAt,
+      eventType: "run.failed",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: row.totalInputTokens,
+      outputTokens: row.totalOutputTokens,
+      payload: { errorMessage: row.errorMessage, status: row.status },
+    });
+  }
+
+  if (row.autoMerged === true) {
+    events.push({
+      id: `proj_run_auto_merged_${row.id}`,
+      timestamp: row.completedAt ?? row.startedAt,
+      eventType: "run.auto_merged",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: 0, outputTokens: 0,
+      payload: { reason: row.autoMergeReason },
+    });
+  } else if (row.autoMerged === false && row.autoMergeReason) {
+    events.push({
+      id: `proj_run_auto_merge_skipped_${row.id}`,
+      timestamp: row.completedAt ?? row.startedAt,
+      eventType: "run.auto_merge_skipped",
+      actor, actorType, scope,
+      runId: row.id, issueId: row.issueId,
+      inputTokens: 0, outputTokens: 0,
+      payload: { reason: row.autoMergeReason },
+    });
+  }
+
+  return events;
+}
+
+type PmApprovalRow = {
+  id: string; issueId: string; action: string; reason: string;
+  status: string; createdAt: Date; resolvedAt: Date | null;
+};
+
+export function projectPmApproval(row: PmApprovalRow): AuditEvent[] {
+  const events: AuditEvent[] = [{
+    id: `proj_approval_requested_${row.id}`,
+    timestamp: row.createdAt,
+    eventType: "pm.approval_requested",
+    actor: "pm-agent", actorType: "pm-agent",
+    scope: null, runId: null, issueId: row.issueId,
+    inputTokens: 0, outputTokens: 0,
+    payload: { approvalId: row.id, action: row.action, reason: row.reason },
+  }];
+  if (row.resolvedAt) {
+    events.push({
+      id: `proj_approval_resolved_${row.id}`,
+      timestamp: row.resolvedAt,
+      eventType: "pm.approval_resolved",
+      actor: "pm-agent", actorType: "pm-agent",
+      scope: null, runId: null, issueId: row.issueId,
+      inputTokens: 0, outputTokens: 0,
+      payload: { approvalId: row.id, action: row.action, status: row.status },
+    });
+  }
+  return events;
+}
+
+type BudgetAlertRow = {
+  id: string; date: string; scope: string; threshold: number; firedAt: Date;
+};
+
+export function projectBudgetAlert(row: BudgetAlertRow): AuditEvent {
+  return {
+    id: `proj_budget_alert_${row.id}`,
+    timestamp: row.firedAt,
+    eventType: "budget.alert_fired",
+    actor: "pm-agent", actorType: "pm-agent",
+    scope: row.scope,
+    runId: null, issueId: null,
+    inputTokens: 0, outputTokens: 0,
+    payload: { threshold: row.threshold, date: row.date },
+  };
+}

--- a/packages/core/src/audit/reader.ts
+++ b/packages/core/src/audit/reader.ts
@@ -89,7 +89,7 @@ export async function listAuditEvents(
     .from(auditEvents)
     .where(nativeConditions.length ? and(...nativeConditions) : undefined)
     .orderBy(desc(auditEvents.timestamp))
-    .limit(limit * 2);
+    .limit(limit * 4);
 
   // Projected: pipeline_runs
   const runConditions: any[] = [];
@@ -97,26 +97,37 @@ export async function listAuditEvents(
   if (filters.to) runConditions.push(lte(pipelineRuns.startedAt, filters.to));
   if (filters.runId) runConditions.push(eq(pipelineRuns.id, filters.runId));
   if (filters.issueId) runConditions.push(eq(pipelineRuns.issueId, filters.issueId));
+  if (cursorTs) runConditions.push(lte(pipelineRuns.startedAt, cursorTs));
   const runRows = await (db as any)
     .select()
     .from(pipelineRuns)
     .where(runConditions.length ? and(...runConditions) : undefined)
     .orderBy(desc(pipelineRuns.startedAt))
-    .limit(limit * 2);
+    .limit(limit * 4);
 
-  // Projected: pm_approvals
+  // Projected: pm_approvals (filter by createdAt)
+  const apprConditions: any[] = [];
+  if (filters.from) apprConditions.push(gte(pmApprovals.createdAt, filters.from));
+  if (filters.to) apprConditions.push(lte(pmApprovals.createdAt, filters.to));
+  if (cursorTs) apprConditions.push(lte(pmApprovals.createdAt, cursorTs));
   const apprRows = await (db as any)
     .select()
     .from(pmApprovals)
+    .where(apprConditions.length ? and(...apprConditions) : undefined)
     .orderBy(desc(pmApprovals.createdAt))
-    .limit(limit * 2);
+    .limit(limit * 4);
 
-  // Projected: budget_alerts
+  // Projected: budget_alerts (filter by firedAt)
+  const alertConditions: any[] = [];
+  if (filters.from) alertConditions.push(gte(budgetAlerts.firedAt, filters.from));
+  if (filters.to) alertConditions.push(lte(budgetAlerts.firedAt, filters.to));
+  if (cursorTs) alertConditions.push(lte(budgetAlerts.firedAt, cursorTs));
   const alertRows = await (db as any)
     .select()
     .from(budgetAlerts)
+    .where(alertConditions.length ? and(...alertConditions) : undefined)
     .orderBy(desc(budgetAlerts.firedAt))
-    .limit(limit * 2);
+    .limit(limit * 4);
 
   const merged: AuditEvent[] = [
     ...nativeRows.map(parseNativeRow),

--- a/packages/core/src/audit/reader.ts
+++ b/packages/core/src/audit/reader.ts
@@ -1,0 +1,166 @@
+import { and, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { auditEvents, pipelineRuns, pmApprovals, budgetAlerts } from "../db/schema.js";
+import type { AuditEvent, AuditEventType } from "../types.js";
+import { projectPipelineRun, projectPmApproval, projectBudgetAlert } from "./projection.js";
+
+export interface ListAuditEventsFilters {
+  from?: Date;
+  to?: Date;
+  scope?: string;
+  eventTypes?: AuditEventType[];
+  actor?: string;
+  runId?: string;
+  issueId?: string;
+  q?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListAuditEventsResult {
+  events: AuditEvent[];
+  nextCursor: string | null;
+}
+
+interface Cursor {
+  ts: string;
+  id: string;
+}
+
+function encodeCursor(c: Cursor): string {
+  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
+}
+
+function decodeCursor(s: string): Cursor {
+  return JSON.parse(Buffer.from(s, "base64url").toString("utf8"));
+}
+
+function parseNativeRow(row: any): AuditEvent {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    eventType: row.eventType,
+    actor: row.actor,
+    actorType: row.actorType,
+    scope: row.scope ?? null,
+    runId: row.runId ?? null,
+    issueId: row.issueId ?? null,
+    inputTokens: row.inputTokens ?? 0,
+    outputTokens: row.outputTokens ?? 0,
+    payload: (() => {
+      try {
+        return JSON.parse(row.payload ?? "{}");
+      } catch {
+        return {};
+      }
+    })(),
+  };
+}
+
+/**
+ * Lists audit events by merging native `audit_events` rows with events
+ * projected from `pipeline_runs`, `pm_approvals`, and `budget_alerts`.
+ *
+ * Supports filtering by time window, scope, event type, actor prefix, run/issue id,
+ * and full-text search on payload/actor. Paginates via opaque cursor, sorted desc
+ * by (timestamp, id).
+ */
+export async function listAuditEvents(
+  db: AnyDb,
+  filters: ListAuditEventsFilters = {},
+): Promise<ListAuditEventsResult> {
+  const limit = Math.min(filters.limit ?? 50, 500);
+  const cursor = filters.cursor ? decodeCursor(filters.cursor) : null;
+  const cursorTs = cursor ? new Date(cursor.ts) : null;
+
+  // Native audit_events query
+  const nativeConditions: any[] = [];
+  if (filters.from) nativeConditions.push(gte(auditEvents.timestamp, filters.from));
+  if (filters.to) nativeConditions.push(lte(auditEvents.timestamp, filters.to));
+  if (filters.scope) nativeConditions.push(eq(auditEvents.scope, filters.scope));
+  if (filters.eventTypes?.length)
+    nativeConditions.push(inArray(auditEvents.eventType, filters.eventTypes));
+  if (filters.runId) nativeConditions.push(eq(auditEvents.runId, filters.runId));
+  if (filters.issueId) nativeConditions.push(eq(auditEvents.issueId, filters.issueId));
+  if (cursorTs) nativeConditions.push(lte(auditEvents.timestamp, cursorTs));
+
+  const nativeRows = await (db as any)
+    .select()
+    .from(auditEvents)
+    .where(nativeConditions.length ? and(...nativeConditions) : undefined)
+    .orderBy(desc(auditEvents.timestamp))
+    .limit(limit * 2);
+
+  // Projected: pipeline_runs
+  const runConditions: any[] = [];
+  if (filters.from) runConditions.push(gte(pipelineRuns.startedAt, filters.from));
+  if (filters.to) runConditions.push(lte(pipelineRuns.startedAt, filters.to));
+  if (filters.runId) runConditions.push(eq(pipelineRuns.id, filters.runId));
+  if (filters.issueId) runConditions.push(eq(pipelineRuns.issueId, filters.issueId));
+  const runRows = await (db as any)
+    .select()
+    .from(pipelineRuns)
+    .where(runConditions.length ? and(...runConditions) : undefined)
+    .orderBy(desc(pipelineRuns.startedAt))
+    .limit(limit * 2);
+
+  // Projected: pm_approvals
+  const apprRows = await (db as any)
+    .select()
+    .from(pmApprovals)
+    .orderBy(desc(pmApprovals.createdAt))
+    .limit(limit * 2);
+
+  // Projected: budget_alerts
+  const alertRows = await (db as any)
+    .select()
+    .from(budgetAlerts)
+    .orderBy(desc(budgetAlerts.firedAt))
+    .limit(limit * 2);
+
+  const merged: AuditEvent[] = [
+    ...nativeRows.map(parseNativeRow),
+    ...runRows.flatMap((r: any) => projectPipelineRun(r)),
+    ...apprRows.flatMap((r: any) => projectPmApproval(r)),
+    ...alertRows.map((r: any) => projectBudgetAlert(r)),
+  ];
+
+  // Apply filters that weren't pushed to SQL (actor prefix, q, eventType on projected,
+  // scope on projected, and the cursor tiebreak).
+  const filtered = merged.filter((e) => {
+    if (filters.from && e.timestamp < filters.from) return false;
+    if (filters.to && e.timestamp > filters.to) return false;
+    if (filters.scope && e.scope !== filters.scope) return false;
+    if (filters.eventTypes?.length && !filters.eventTypes.includes(e.eventType)) return false;
+    if (filters.actor && !e.actor.startsWith(filters.actor)) return false;
+    if (filters.runId && e.runId !== filters.runId) return false;
+    if (filters.issueId && e.issueId !== filters.issueId) return false;
+    if (filters.q) {
+      const hay = JSON.stringify(e.payload) + " " + e.actor;
+      if (!hay.toLowerCase().includes(filters.q.toLowerCase())) return false;
+    }
+    if (cursor) {
+      const cTs = new Date(cursor.ts).getTime();
+      if (e.timestamp.getTime() > cTs) return false;
+      if (e.timestamp.getTime() === cTs && e.id >= cursor.id) return false;
+    }
+    return true;
+  });
+
+  // Sort desc by (timestamp, id)
+  filtered.sort((a, b) => {
+    const d = b.timestamp.getTime() - a.timestamp.getTime();
+    return d !== 0 ? d : b.id > a.id ? 1 : -1;
+  });
+
+  const page = filtered.slice(0, limit);
+  const nextCursor =
+    filtered.length > limit
+      ? encodeCursor({
+          ts: page[page.length - 1].timestamp.toISOString(),
+          id: page[page.length - 1].id,
+        })
+      : null;
+
+  return { events: page, nextCursor };
+}

--- a/packages/core/src/audit/retention.ts
+++ b/packages/core/src/audit/retention.ts
@@ -1,0 +1,32 @@
+import { lt } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "audit.retention" });
+
+/**
+ * Deletes audit_events rows older than `retentionDays`.
+ *
+ * This is the SOLE authorized mutation on the audit_events table. The
+ * audit-immutability lint test grep-checks that no other file in the
+ * codebase calls `update(auditEvents)` or `delete(auditEvents)`.
+ *
+ * Returns the number of rows deleted.
+ */
+export async function pruneAuditLog(
+  db: AnyDb,
+  retentionDays: number,
+): Promise<number> {
+  const cutoff = new Date(Date.now() - retentionDays * 86400_000);
+  const result = await (db as any)
+    .delete(auditEvents)
+    .where(lt(auditEvents.timestamp, cutoff));
+  const n =
+    (result as any)?.changes ?? (result as any)?.rowCount ?? 0;
+  log.info(
+    { retentionDays, cutoff, deleted: n },
+    "audit log pruned",
+  );
+  return n;
+}

--- a/packages/core/src/audit/writer.ts
+++ b/packages/core/src/audit/writer.ts
@@ -1,0 +1,38 @@
+import type { AnyDb } from "../db/client.js";
+import { auditEvents } from "../db/schema.js";
+import { createLogger } from "../logger.js";
+import type { AuditEvent } from "../types.js";
+
+const log = createLogger({ component: "audit.writer" });
+
+/**
+ * Fire-and-forget insert of an audit event. Write failures are logged but
+ * never propagated — audit writes must not crash the caller.
+ *
+ * Callers should use `void logAuditEvent(...)` when they don't await.
+ */
+export async function logAuditEvent(
+  db: AnyDb,
+  event: AuditEvent,
+): Promise<void> {
+  try {
+    await (db as any).insert(auditEvents).values({
+      id: event.id,
+      timestamp: event.timestamp,
+      eventType: event.eventType,
+      actor: event.actor,
+      actorType: event.actorType,
+      scope: event.scope,
+      runId: event.runId,
+      issueId: event.issueId,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      payload: JSON.stringify(event.payload ?? {}),
+    });
+  } catch (err) {
+    log.warn(
+      { err, eventType: event.eventType, id: event.id },
+      "audit event write failed",
+    );
+  }
+}

--- a/packages/core/src/audit/writer.ts
+++ b/packages/core/src/audit/writer.ts
@@ -5,16 +5,7 @@ import type { AuditEvent } from "../types.js";
 
 const log = createLogger({ component: "audit.writer" });
 
-/**
- * Fire-and-forget insert of an audit event. Write failures are logged but
- * never propagated — audit writes must not crash the caller.
- *
- * Callers should use `void logAuditEvent(...)` when they don't await.
- */
-export async function logAuditEvent(
-  db: AnyDb,
-  event: AuditEvent,
-): Promise<void> {
+async function insertAuditEvent(db: AnyDb, event: AuditEvent): Promise<void> {
   try {
     await (db as any).insert(auditEvents).values({
       id: event.id,
@@ -35,4 +26,41 @@ export async function logAuditEvent(
       "audit event write failed",
     );
   }
+}
+
+/**
+ * Fire-and-forget insert of an audit event. Write failures are logged but
+ * never propagated — audit writes must not crash the caller.
+ *
+ * Gated on the `audit-log` enterprise feature (spec §8): when unlicensed,
+ * this is a no-op so OSS/Pro deployments do not accumulate audit_events rows
+ * indefinitely (retention sweep is also gated).
+ *
+ * Uses a dynamic import of `../license.js` to avoid a circular-import cycle
+ * (license.ts calls into this module to record license-validation failures
+ * via `logAuditEventUnchecked`).
+ *
+ * Callers should use `void logAuditEvent(...)` when they don't await.
+ */
+export async function logAuditEvent(
+  db: AnyDb,
+  event: AuditEvent,
+): Promise<void> {
+  const { isFeatureLicensed } = await import("../license.js");
+  if (!isFeatureLicensed("audit-log")) return;
+  await insertAuditEvent(db, event);
+}
+
+/**
+ * Unchecked writer used by the license-validation failure path itself.
+ * Bypasses the `audit-log` feature gate because (a) recording why a license
+ * was rejected must not depend on that license being valid, and (b) the
+ * event is emitted at most once per process (license status is cached).
+ * Do not use this from other call sites.
+ */
+export async function logAuditEventUnchecked(
+  db: AnyDb,
+  event: AuditEvent,
+): Promise<void> {
+  await insertAuditEvent(db, event);
 }

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -164,6 +164,24 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
   );
 
   CREATE INDEX IF NOT EXISTS idx_budget_alerts_date_scope ON budget_alerts(date, scope);
+
+  CREATE TABLE IF NOT EXISTS audit_events (
+    id TEXT PRIMARY KEY,
+    timestamp ${ts} NOT NULL,
+    event_type TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    actor_type TEXT NOT NULL,
+    scope TEXT,
+    run_id TEXT,
+    issue_id TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    payload TEXT NOT NULL DEFAULT '{}'
+  );
+  CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);
 `;
 }
 

--- a/packages/core/src/db/migrations/postgres/007_audit_events.sql
+++ b/packages/core/src/db/migrations/postgres/007_audit_events.sql
@@ -1,0 +1,19 @@
+-- Enterprise feature 4.2: audit log + export
+CREATE TABLE IF NOT EXISTS audit_events (
+  id TEXT PRIMARY KEY,
+  timestamp TIMESTAMPTZ NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  actor_type TEXT NOT NULL,
+  scope TEXT,
+  run_id TEXT,
+  issue_id TEXT,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  payload TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);

--- a/packages/core/src/db/migrations/sqlite/006_audit_events.sql
+++ b/packages/core/src/db/migrations/sqlite/006_audit_events.sql
@@ -1,0 +1,19 @@
+-- Enterprise feature 4.2: audit log + export
+CREATE TABLE IF NOT EXISTS audit_events (
+  id TEXT PRIMARY KEY,
+  timestamp INTEGER NOT NULL,
+  event_type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  actor_type TEXT NOT NULL,
+  scope TEXT,
+  run_id TEXT,
+  issue_id TEXT,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  payload TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -162,3 +162,19 @@ export const budgetAlerts = sqliteTable(
     unique().on(t.date, t.scope, t.threshold),
   ],
 );
+
+export const auditEvents = sqliteTable("audit_events", {
+  id: text("id").primaryKey(),
+  timestamp: crossTimestamp("timestamp")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  eventType: text("event_type").notNull(),
+  actor: text("actor").notNull(),
+  actorType: text("actor_type").notNull(),
+  scope: text("scope"),
+  runId: text("run_id"),
+  issueId: text("issue_id"),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  payload: text("payload").notNull().default("{}"),
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./types.js";
 export { checkLicense, isFeatureLicensed, type LicenseStatus } from "./license.js";
+export * from "./audit/index.js";
+export { computeConfigFingerprint } from "./audit/config-fingerprint.js";
 export { rootLogger, createLogger, addLogStream } from "./logger.js";
 export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db } from "./db/index.js";
 export { pipelineRuns, stageRuns, agentLogs, activeWork, pmApprovals } from "./db/index.js";

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -1,6 +1,9 @@
 import { createPublicKey, verify } from "node:crypto";
 import { createLogger } from "./logger.js";
 import * as publicKeyMod from "./license-public-key.js";
+import type { AnyDb } from "./db/client.js";
+import { logAuditEvent } from "./audit/writer.js";
+import { licenseValidationFailedEvent } from "./audit/events.js";
 
 const log = createLogger({ component: "license" });
 
@@ -69,8 +72,11 @@ function ossStatus(invalidReason?: LicenseStatus["invalidReason"]): LicenseStatu
 /**
  * Check the license status from URATEAM_LICENSE_KEY env var.
  * Result is cached for the lifetime of the process.
+ *
+ * Pass `db` to emit a `license.validation_failed` audit event on the failure
+ * path. Only the first call with a db argument will emit (thanks to caching).
  */
-export function checkLicense(): LicenseStatus {
+export function checkLicense(db?: AnyDb): LicenseStatus {
   if (cachedStatus) return cachedStatus;
 
   const key = process.env.URATEAM_LICENSE_KEY;
@@ -84,6 +90,12 @@ export function checkLicense(): LicenseStatus {
   if (!result.ok) {
     cachedStatus = ossStatus(result.reason);
     log.warn({ reason: result.reason }, "license key invalid — running in OSS mode");
+    if (db && result.reason !== "malformed") {
+      void logAuditEvent(
+        db,
+        licenseValidationFailedEvent({ invalidReason: result.reason }),
+      );
+    }
     return cachedStatus;
   }
 

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -2,7 +2,7 @@ import { createPublicKey, verify } from "node:crypto";
 import { createLogger } from "./logger.js";
 import * as publicKeyMod from "./license-public-key.js";
 import type { AnyDb } from "./db/client.js";
-import { logAuditEvent } from "./audit/writer.js";
+import { logAuditEventUnchecked } from "./audit/writer.js";
 import { licenseValidationFailedEvent } from "./audit/events.js";
 
 const log = createLogger({ component: "license" });
@@ -91,7 +91,7 @@ export function checkLicense(db?: AnyDb): LicenseStatus {
     cachedStatus = ossStatus(result.reason);
     log.warn({ reason: result.reason }, "license key invalid — running in OSS mode");
     if (db && result.reason !== "malformed") {
-      void logAuditEvent(
+      void logAuditEventUnchecked(
         db,
         licenseValidationFailedEvent({ invalidReason: result.reason }),
       );

--- a/packages/core/src/pm/actions/promote.ts
+++ b/packages/core/src/pm/actions/promote.ts
@@ -1,6 +1,8 @@
 import type { PromoteResult, ConflictCheckResult } from "../types.js";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
+import type { AnyDb } from "../../db/client.js";
+import { logAuditEvent, pmPromotedEvent } from "../../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:promote" });
 
@@ -11,6 +13,8 @@ export interface PromoteInput {
   checkConflict: (description: string) => Promise<ConflictCheckResult>;
   /** Pre-fetched workflow state map. Falls back to fetching if not provided. */
   stateMap?: Map<string, string>;
+  /** Optional DB handle. When present, successful promotions write audit events. */
+  db?: AnyDb;
 }
 
 export async function promoteReadyIssues(input: PromoteInput): Promise<PromoteResult[]> {
@@ -77,6 +81,18 @@ export async function promoteReadyIssues(input: PromoteInput): Promise<PromoteRe
     }
 
     await linearClient.updateIssue(candidate.id, { stateId: todoStateId });
+
+    if (input.db) {
+      void logAuditEvent(input.db, pmPromotedEvent({
+        issueId: candidate.identifier,
+        fromState: "Backlog",
+        toState: "Todo",
+        priority: candidate.priority,
+        reason: conflict.overlapRisk === "low"
+          ? `highest priority, low overlap: ${conflict.reasoning}`
+          : "highest priority, no conflict",
+      }));
+    }
 
     const overlapNote = conflict.overlapRisk === "low"
       ? `\n⚠️ *Low overlap risk:* ${conflict.reasoning}`

--- a/packages/core/src/pm/actions/resolve-approvals.ts
+++ b/packages/core/src/pm/actions/resolve-approvals.ts
@@ -4,6 +4,7 @@ import { pmApprovals } from "../../db/schema.js";
 import { eq } from "drizzle-orm";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
+import { logAuditEvent, pmDeprioritizedEvent, pmCancelledEvent } from "../../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:approvals" });
 
@@ -108,6 +109,20 @@ export async function resolveApprovals(input: ResolveApprovalsInput): Promise<Re
       if (!actionExecuted) {
         log.error({ issueId: approval.issueId, action: approval.action }, "approved in DB but Linear action failed — manual intervention needed");
       } else {
+        if (approval.action === "deprioritize") {
+          void logAuditEvent(db, pmDeprioritizedEvent({
+            issueId: approval.issueId,
+            oldPriority: null,
+            newPriority: 4,
+            approvalId: approval.id,
+          }));
+        } else if (approval.action === "cancel") {
+          void logAuditEvent(db, pmCancelledEvent({
+            issueId: approval.issueId,
+            approvalId: approval.id,
+            reason: approval.reason,
+          }));
+        }
         log.info({ issueId: approval.issueId, action: approval.action }, "approval executed");
       }
     } catch (err) {

--- a/packages/core/src/pm/actions/triage.ts
+++ b/packages/core/src/pm/actions/triage.ts
@@ -2,6 +2,8 @@ import type { TriageResult } from "../types.js";
 import { parseJsonObject } from "../../executor/agent-stream.js";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
+import type { AnyDb } from "../../db/client.js";
+import { logAuditEvent, pmTriageClassifiedEvent } from "../../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:triage" });
 
@@ -17,6 +19,8 @@ export interface TriageInput {
   batchSize?: number;
   /** Pre-fetched workflow state map (teamId:stateName → stateId). Fetched once per scheduler tick. */
   stateMap?: Map<string, string>;
+  /** Optional DB handle. When present, successful classifications write audit events. */
+  db?: AnyDb;
 }
 
 /**
@@ -133,6 +137,13 @@ export async function triageNewIssues(input: TriageInput): Promise<TriageResult[
         });
 
         const result: TriageResult = { issueId: issue.identifier, priority, labels: issueLabels, complexity, rationale, acceptanceCriteria };
+        if (input.db) {
+          void logAuditEvent(input.db, pmTriageClassifiedEvent({
+            issueId: issue.identifier,
+            label: pipelineLabel,
+            rationale: String(rationale),
+          }));
+        }
         log.info({ issueId: issue.identifier, priority, labels: issueLabels, pipelineLabel, complexity }, "triaged issue");
         return result;
       } catch (err) {

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -318,6 +318,7 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
                 sanitize,
                 batchSize: config.triageBatchSize,
                 stateMap,
+                db,
               });
         } catch (err) {
           log.error({ err }, "triage failed");
@@ -392,6 +393,7 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
                 slotsAvailable,
                 checkConflict,
                 stateMap,
+                db,
               });
             }
           } catch (err) {

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -190,6 +190,18 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
         if (evaluation.activeCount >= config.maxInFlight && !tick.budgetGuard.promoteBlocked) {
           tick.budgetGuard.promoteBlocked = true;
           tick.budgetGuard.reason = `maxInFlight reached (${evaluation.activeCount}/${config.maxInFlight})`;
+          // Emit a budget.run_refused event so operators can trace "why didn't
+          // this run start?" when capacity (not token spend) is the blocker.
+          void logAuditEvent(
+            db,
+            budgetRefusedEvent({
+              scope: "global",
+              scopeType: "global",
+              tokensUsed: evaluation.activeCount,
+              limit: config.maxInFlight,
+              utilization: 100,
+            }),
+          );
         }
 
         // Fire threshold alerts for newly-crossed scopes (deduped in budget_alerts).

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -22,7 +22,7 @@ import { sanitize } from "../executor/prompt/sanitizer.js";
 import { resolveWorkflowStates } from "./linear-helpers.js";
 import { sql } from "drizzle-orm";
 import { createLogger } from "../logger.js";
-import { logAuditEvent, budgetRefusedEvent } from "../audit/index.js";
+import { logAuditEvent, budgetRefusedEvent, pruneAuditLog } from "../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:scheduler" });
 
@@ -451,6 +451,17 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           }
         } catch (err) {
           log.error({ err }, "digest failed");
+        }
+
+        // Audit log retention sweep (no-op if unlicensed or not configured).
+        // Wrapped in try/catch — retention failure must not crash the tick.
+        try {
+          if (isFeatureLicensed("audit-log")) {
+            const days = (config as any).auditLog?.retentionDays ?? 365;
+            await pruneAuditLog(db, days);
+          }
+        } catch (err) {
+          log.warn({ err }, "audit retention sweep failed");
         }
 
       log.info({

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -22,6 +22,7 @@ import { sanitize } from "../executor/prompt/sanitizer.js";
 import { resolveWorkflowStates } from "./linear-helpers.js";
 import { sql } from "drizzle-orm";
 import { createLogger } from "../logger.js";
+import { logAuditEvent, budgetRefusedEvent } from "../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:scheduler" });
 
@@ -158,6 +159,31 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           tokenSpendPercent: globalScope?.percent ?? 0,
           dailyTokensUsed: globalScope?.used ?? 0,
         };
+
+        // Emit budget.run_refused audit events for every scope at blocked-100.
+        // Recovers the per-scope breakdown that is otherwise dropped when we
+        // collapse the evaluation into tick.budgetGuard.
+        if (evaluation.promoteBlocked) {
+          for (const s of evaluation.scopes) {
+            if (s.tier !== "blocked-100") continue;
+            const scopeKey =
+              s.scope.kind === "global"
+                ? "global"
+                : s.scope.kind === "team"
+                  ? `team:${s.scope.teamId}`
+                  : `repo:${s.scope.repoUrl}`;
+            void logAuditEvent(
+              db,
+              budgetRefusedEvent({
+                scope: scopeKey,
+                scopeType: s.scope.kind,
+                tokensUsed: s.used,
+                limit: s.limit,
+                utilization: s.percent,
+              }),
+            );
+          }
+        }
 
         // Preserve legacy maxInFlight block: if we're at capacity, treat as blocked
         // (existing promoters already check tick.budgetGuard.promoteBlocked).

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -368,3 +368,49 @@ export interface SandboxConfig {
   denyRead: string[];
   denyWrite: string[];
 }
+
+// --- Audit Log ---
+export const AuditEventTypeSchema = z.enum([
+  "run.started", "run.completed", "run.failed",
+  "run.auto_merged", "run.auto_merge_skipped",
+  "pm.approval_requested", "pm.approval_resolved",
+  "pm.issue_promoted", "pm.issue_deprioritized", "pm.issue_cancelled",
+  "pm.triage_classified",
+  "budget.alert_fired", "budget.run_refused",
+  "license.validation_failed", "config.loaded",
+  "dashboard.manual_action",
+]);
+export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
+
+export const AuditActorTypeSchema = z.enum([
+  "system", "pm-agent", "webhook", "dashboard-user", "cli",
+]);
+export type AuditActorType = z.infer<typeof AuditActorTypeSchema>;
+
+export const AuditEventSchema = z.object({
+  id: z.string(),
+  timestamp: z.date(),
+  eventType: AuditEventTypeSchema,
+  actor: z.string(),
+  actorType: AuditActorTypeSchema,
+  scope: z.string().nullable(),
+  runId: z.string().nullable(),
+  issueId: z.string().nullable(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  payload: z.record(z.string(), z.unknown()),
+});
+export type AuditEvent = z.infer<typeof AuditEventSchema>;
+
+/**
+ * Top-level application config schema. Currently only scopes the audit log
+ * section introduced with the audit-log feature; additional sections can be
+ * added here as the rest of the config is migrated to zod.
+ */
+export const AppConfigSchema = z.object({
+  auditLog: z.object({
+    enabled: z.boolean().optional(),
+    retentionDays: z.number().int().positive().optional().default(365),
+  }).optional(),
+});
+export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/dashboard/src/__tests__/audit.test.ts
+++ b/packages/dashboard/src/__tests__/audit.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { createDashboard } from "../server.js";
+import { createDb } from "@urateam/core";
+import type { Db } from "@urateam/core";
+import { auditEvents } from "@urateam/core/dist/db/schema.js";
+import { _resetLicenseCache } from "@urateam/core/dist/license.js";
+
+// ---------------- license test helper (inlined) ----------------
+function b64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(privateKey: KeyObject, payload: object): string {
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const headerB64 = b64url(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = sign(null, Buffer.from(signingInput), privateKey);
+  return `${signingInput}.${b64url(sig)}`;
+}
+
+let savedPublicKey: string | undefined;
+let savedEnv: string | undefined;
+
+async function installEnterpriseLicense(): Promise<void> {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyB64 = Buffer.from(
+    publicKey.export({ format: "der", type: "spki" }),
+  ).toString("base64");
+
+  const mod = await import("@urateam/core/dist/license-public-key.js");
+  if (savedPublicKey === undefined) {
+    savedPublicKey = (mod as { LICENSE_PUBLIC_KEY_DER_B64: string })
+      .LICENSE_PUBLIC_KEY_DER_B64;
+  }
+  Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+    value: publicKeyB64,
+    writable: true,
+    configurable: true,
+  });
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = makeJwt(privateKey, {
+    iss: "urateam.dev",
+    sub: "cust_test",
+    tier: "enterprise",
+    seats: 25,
+    iat: now,
+    exp: now + 86_400,
+  });
+
+  if (savedEnv === undefined) savedEnv = process.env.URATEAM_LICENSE_KEY;
+  process.env.URATEAM_LICENSE_KEY = jwt;
+  _resetLicenseCache();
+}
+
+async function restoreLicense(): Promise<void> {
+  if (savedPublicKey !== undefined) {
+    const mod = await import("@urateam/core/dist/license-public-key.js");
+    Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+      value: savedPublicKey,
+      writable: true,
+      configurable: true,
+    });
+    savedPublicKey = undefined;
+  }
+  if (savedEnv === undefined) {
+    delete process.env.URATEAM_LICENSE_KEY;
+  } else {
+    process.env.URATEAM_LICENSE_KEY = savedEnv;
+    savedEnv = undefined;
+  }
+  _resetLicenseCache();
+}
+
+function basicAuthHeader(u: string, p: string): string {
+  return "Basic " + Buffer.from(`${u}:${p}`).toString("base64");
+}
+
+const AUTH = { Authorization: basicAuthHeader("admin", "secret") };
+
+async function seedAuditEvent(db: Db): Promise<void> {
+  await (db as any).insert(auditEvents).values({
+    id: "evt-test-1",
+    timestamp: new Date(),
+    eventType: "pm.issue_promoted",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    scope: "pm",
+    runId: null,
+    issueId: "ISS-1",
+    inputTokens: 0,
+    outputTokens: 0,
+    payload: JSON.stringify({ reason: "ready" }),
+  });
+}
+
+// ---------------- tests ----------------
+describe("audit route — unlicensed", () => {
+  beforeEach(async () => {
+    await restoreLicense(); // ensure no license
+  });
+
+  it("returns 404 for GET /audit when feature is not licensed", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: { username: "admin", password: "secret" },
+    });
+
+    const res = await app.request("/audit", { headers: AUTH });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for GET /audit/export.csv when feature is not licensed", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: { username: "admin", password: "secret" },
+    });
+
+    const res = await app.request("/audit/export.csv", { headers: AUTH });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("audit route — licensed (enterprise)", () => {
+  beforeEach(async () => {
+    await installEnterpriseLicense();
+  });
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("GET /audit returns 200 and renders a seeded event", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await seedAuditEvent(db);
+
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: { username: "admin", password: "secret" },
+    });
+
+    const res = await app.request("/audit", { headers: AUTH });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("pm.issue_promoted");
+    expect(html).toContain("Audit Log");
+  });
+
+  it("GET /audit/export.csv returns 200 text/csv with the header row", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await seedAuditEvent(db);
+
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: { username: "admin", password: "secret" },
+    });
+
+    const res = await app.request("/audit/export.csv", { headers: AUTH });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/csv");
+
+    const body = await res.text();
+    expect(body).toContain(
+      "timestamp_utc,event_type,actor,actor_type,scope,run_id,issue_id,input_tokens,output_tokens,payload_json",
+    );
+    expect(body).toContain("pm.issue_promoted");
+  });
+});

--- a/packages/dashboard/src/routes/audit.ts
+++ b/packages/dashboard/src/routes/audit.ts
@@ -1,0 +1,127 @@
+import { Hono } from "hono";
+import type { Db, AuditEventType } from "@urateam/core";
+import {
+  isFeatureLicensed,
+  listAuditEvents,
+  streamAuditCsv,
+} from "@urateam/core";
+import { layout } from "../views/layout.js";
+import { renderAuditPage, type AuditFilters } from "../views/audit.js";
+
+function parseFilters(query: Record<string, string | undefined>): AuditFilters & {
+  cursor?: string;
+  from?: string;
+  to?: string;
+} {
+  return {
+    from: query.from || undefined,
+    to: query.to || undefined,
+    scope: query.scope || undefined,
+    eventType: query.eventType || undefined,
+    actor: query.actor || undefined,
+    runId: query.runId || undefined,
+    issueId: query.issueId || undefined,
+    q: query.q || undefined,
+    cursor: query.cursor || undefined,
+  };
+}
+
+function buildReaderFilters(q: Record<string, string | undefined>) {
+  const f: {
+    from?: Date;
+    to?: Date;
+    scope?: string;
+    eventTypes?: AuditEventType[];
+    actor?: string;
+    runId?: string;
+    issueId?: string;
+    q?: string;
+    cursor?: string;
+    limit?: number;
+  } = {};
+  if (q.from) {
+    const d = new Date(q.from);
+    if (!isNaN(d.getTime())) f.from = d;
+  }
+  if (q.to) {
+    const d = new Date(q.to);
+    if (!isNaN(d.getTime())) f.to = d;
+  }
+  if (q.scope) f.scope = q.scope;
+  if (q.eventType) f.eventTypes = [q.eventType as AuditEventType];
+  if (q.actor) f.actor = q.actor;
+  if (q.runId) f.runId = q.runId;
+  if (q.issueId) f.issueId = q.issueId;
+  if (q.q) f.q = q.q;
+  if (q.cursor) f.cursor = q.cursor;
+  f.limit = 50;
+  return f;
+}
+
+export function createAuditRouter(db: Db, basePath = ""): Hono {
+  const router = new Hono();
+
+  // Gate every audit route behind the license feature flag.
+  router.use("/audit", async (c, next) => {
+    if (!isFeatureLicensed("audit-log")) return c.notFound();
+    await next();
+  });
+  router.use("/audit/*", async (c, next) => {
+    if (!isFeatureLicensed("audit-log")) return c.notFound();
+    await next();
+  });
+
+  router.get("/audit", async (c) => {
+    const query = c.req.query();
+    const filters = parseFilters(query);
+    const readerFilters = buildReaderFilters(query);
+    const { events, nextCursor } = await listAuditEvents(db as any, readerFilters);
+    const content = renderAuditPage({ events, nextCursor, filters });
+    if (c.req.header("HX-Request")) return c.html(content);
+    return c.html(layout("Audit Log", content, basePath));
+  });
+
+  // HTMX partial used by the "Load more" link to append rows.
+  router.get("/audit/page", async (c) => {
+    const query = c.req.query();
+    const filters = parseFilters(query);
+    const readerFilters = buildReaderFilters(query);
+    const { events, nextCursor } = await listAuditEvents(db as any, readerFilters);
+    return c.html(renderAuditPage({ events, nextCursor, filters, partial: true }));
+  });
+
+  router.get("/audit/export.csv", async (c) => {
+    const query = c.req.query();
+    const readerFilters = buildReaderFilters(query);
+    // Export ignores the paginated limit; streamAuditCsv walks its own cursor.
+    delete (readerFilters as { limit?: number }).limit;
+    delete (readerFilters as { cursor?: string }).cursor;
+
+    const iter = streamAuditCsv(db as any, readerFilters);
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const { value, done } = await iter.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(value + "\n"));
+      },
+      async cancel() {
+        if (typeof iter.return === "function") await iter.return();
+      },
+    });
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="audit-export.csv"',
+        "Cache-Control": "no-store",
+      },
+    });
+  });
+
+  return router;
+}

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -8,6 +8,7 @@ import { createTokensRouter } from "./routes/tokens.js";
 import { createErrorsRouter } from "./routes/errors.js";
 import { createConfigRouter } from "./routes/config.js";
 import { createCoordinationRouter } from "./routes/coordination.js";
+import { createAuditRouter } from "./routes/audit.js";
 
 const logger = createLogger({ component: "dashboard" });
 
@@ -153,6 +154,9 @@ export function createDashboard(config: DashboardConfig): Hono {
 
   const coordinationRouter = createCoordinationRouter(config.db, basePath);
   app.route("/", coordinationRouter);
+
+  const auditRouter = createAuditRouter(config.db, basePath);
+  app.route("/", auditRouter);
 
   return app;
 }

--- a/packages/dashboard/src/views/audit.ts
+++ b/packages/dashboard/src/views/audit.ts
@@ -1,0 +1,131 @@
+import type { AuditEvent } from "@urateam/core";
+import { escapeHtml, getBasePath } from "./layout.js";
+
+export interface AuditFilters {
+  from?: string;
+  to?: string;
+  scope?: string;
+  eventType?: string;
+  actor?: string;
+  runId?: string;
+  issueId?: string;
+  q?: string;
+}
+
+export interface RenderAuditPageArgs {
+  events: AuditEvent[];
+  nextCursor: string | null;
+  filters: AuditFilters;
+  /** When true, render only the table + load-more marker (HTMX partial). */
+  partial?: boolean;
+}
+
+function truncate(s: string, max = 200): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + "...";
+}
+
+function toRelativeTime(date: Date): string {
+  const ms = Date.now() - date.getTime();
+  if (ms < 0) return "just now";
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function renderRow(e: AuditEvent): string {
+  const payloadJson = (() => {
+    try {
+      return JSON.stringify(e.payload ?? {});
+    } catch {
+      return "{}";
+    }
+  })();
+  return `<tr>
+      <td title="${escapeHtml(e.timestamp.toISOString())}">${escapeHtml(toRelativeTime(e.timestamp))}</td>
+      <td><code>${escapeHtml(e.eventType)}</code></td>
+      <td>${escapeHtml(e.actor)}</td>
+      <td>${escapeHtml(e.actorType)}</td>
+      <td>${escapeHtml(e.scope ?? "")}</td>
+      <td>${escapeHtml(e.runId ?? "")}</td>
+      <td>${escapeHtml(e.issueId ?? "")}</td>
+      <td><code>${escapeHtml(truncate(payloadJson))}</code></td>
+    </tr>`;
+}
+
+function buildQueryString(filters: AuditFilters, extra: Record<string, string> = {}): string {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries({ ...filters, ...extra })) {
+    if (v !== undefined && v !== null && v !== "") params.set(k, String(v));
+  }
+  const s = params.toString();
+  return s ? "?" + s : "";
+}
+
+/**
+ * Render the audit log page. When `partial` is true, emits only the table
+ * body rows + load-more marker so HTMX can swap into the tbody.
+ */
+export function renderAuditPage(args: RenderAuditPageArgs): string {
+  const basePath = getBasePath();
+  const { events, nextCursor, filters, partial } = args;
+
+  const rows = events.map(renderRow).join("\n");
+
+  const loadMore = nextCursor
+    ? `<tr id="audit-load-more"><td colspan="8" style="text-align:center;padding:1rem;">
+        <a href="${basePath}/audit${escapeHtml(buildQueryString(filters, { cursor: nextCursor }))}"
+           hx-get="${basePath}/audit/page${escapeHtml(buildQueryString(filters, { cursor: nextCursor }))}"
+           hx-target="#audit-load-more"
+           hx-swap="outerHTML">Load more</a>
+      </td></tr>`
+    : "";
+
+  if (partial) {
+    return rows + loadMore;
+  }
+
+  const exportHref = `${basePath}/audit/export.csv${escapeHtml(buildQueryString(filters))}`;
+
+  const filterBar = `<form method="get" action="${basePath}/audit" class="audit-filters">
+    <input type="text" name="eventType" placeholder="event type" value="${escapeHtml(filters.eventType ?? "")}">
+    <input type="text" name="scope" placeholder="scope" value="${escapeHtml(filters.scope ?? "")}">
+    <input type="text" name="actor" placeholder="actor prefix" value="${escapeHtml(filters.actor ?? "")}">
+    <input type="text" name="runId" placeholder="run id" value="${escapeHtml(filters.runId ?? "")}">
+    <input type="text" name="issueId" placeholder="issue id" value="${escapeHtml(filters.issueId ?? "")}">
+    <input type="text" name="q" placeholder="search payload" value="${escapeHtml(filters.q ?? "")}">
+    <input type="datetime-local" name="from" value="${escapeHtml(filters.from ?? "")}">
+    <input type="datetime-local" name="to" value="${escapeHtml(filters.to ?? "")}">
+    <button type="submit">Filter</button>
+    <a class="btn" href="${exportHref}">Export CSV</a>
+  </form>`;
+
+  return `<div id="audit">
+  ${filterBar}
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Event</th>
+          <th>Actor</th>
+          <th>Actor type</th>
+          <th>Scope</th>
+          <th>Run</th>
+          <th>Issue</th>
+          <th>Payload</th>
+        </tr>
+      </thead>
+      <tbody id="audit-rows">
+        ${rows.length > 0 ? rows : '<tr><td colspan="8" style="text-align:center;color:#999;padding:2rem;">No audit events</td></tr>'}
+        ${loadMore}
+      </tbody>
+    </table>
+  </div>
+</div>`;
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -64,6 +64,7 @@ export function layout(title: string, content: string, basePath?: string): strin
     <a href="${bp}/">Runs</a>
     <a href="${bp}/tokens">Tokens</a>
     <a href="${bp}/errors">Errors</a>
+    <a href="${bp}/audit">Audit</a>
     <a href="${bp}/config">Config</a>
     <a href="${bp}/coordination">Coordination</a>
   </nav>


### PR DESCRIPTION
## Summary
- Append-only `audit_events` table + read-time projection from `pipeline_runs`, `pm_approvals`, `budget_alerts` (no run-data duplication)
- Dashboard `/audit` page with filter bar, HTMX pagination, and streaming `/audit/export.csv` endpoint
- Recovers per-scope `ScopeBudget[]` data from PR #39 via new `budget.run_refused` events (covers token-budget AND `maxInFlight` blocks)
- 16 event types covering runs, PM decisions, budget refusals, license validation, config loads
- Convention-only immutability enforced by grep-based lint test (`audit-immutability.test.ts`); only `audit/retention.ts` may delete rows
- Retention sweep runs in PM tick (default 365 days, configurable)
- Writer is feature-gated (`isFeatureLicensed("audit-log")`) — OSS/Pro deployments are no-ops, no row accumulation
- Reader supports cursor-based SQL filtering across all 4 sources to avoid pagination truncation

Spec: `docs/superpowers/specs/2026-04-14-audit-log-design.md`
Plan: `docs/superpowers/plans/2026-04-14-audit-log-and-export.md`

## Test plan
- [x] `pnpm test` — 945 passed / 11 skipped
- [x] `pnpm build` — clean
- [x] Holistic external review — 2 critical, 2 high, 2 important findings; all critical/high fixed inline
- [ ] Manual: `/audit` page renders on a licensed deployment, filters work, CSV export downloads with correct headers
- [ ] Manual: confirm OSS deployment shows no audit rows accumulating

## Deferred (not blockers)
- `/audit/event/:id` HTMX detail expansion route (table shows truncated payload inline for v1)
- `config.loaded` event from `ura dev` / `ura start` paths (env-var-only configs have no file path)
- PR #39 phase 1.5 follow-ups (per-scope digest output, UTC day-boundary test, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)