### PR TITLE
feat: sso via workos (enterprise 4.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,20 @@ It is a pnpm monorepo with 3 packages:
 - **`config.loaded` event currently only fires from `ura run`** — `ura dev` / `ura start` (production paths) build config from env vars and have no file path to fingerprint. Follow-up to wire those when needed.
 - `/audit/event/:id` HTMX detail expansion route is in the spec but deferred — table shows truncated payload inline
 
+### SSO via WorkOS (Enterprise feature 4.1)
+- Module: `packages/core/src/auth/` — `sso-config.ts` (zod schema, `signState`/`verifyState`/`validateNextPath` HMAC helpers), `user-store.ts` (`upsertUser` via atomic `onConflictDoUpdate`, `getUserById`), `session-store.ts` (`createSession`, `getSession`, `deleteSession`, `pruneExpiredSessions`, `touchSessionLastSeen`), `workos-client.ts` (DI seam over `@workos-inc/node`)
+- Tables: `dashboard_users` and `dashboard_sessions` (both via `crossTimestamp`)
+- Dashboard middleware: `packages/dashboard/src/middleware/sso.ts` — cookie → session → user → `c.set("user", ...)`. Skips `/auth/*` and `/webhooks/*`
+- Routes: `packages/dashboard/src/routes/auth.ts` — `GET /auth/login`, `GET /auth/callback`, `POST /auth/logout`
+- Server wiring: `packages/dashboard/src/server.ts` mounts SSO stack iff `isFeatureLicensed("sso") && config.sso?.enabled === true`. Otherwise basicAuth (or 503). Mutually exclusive
+- CLI bootstrap: `packages/cli/src/sso-bootstrap.ts` reads env vars (`URATEAM_WORKOS_API_KEY`, `URATEAM_WORKOS_CLIENT_ID`, `URATEAM_WORKOS_REDIRECT_URI`, `URATEAM_SSO_STATE_SECRET`, `URATEAM_SSO_ALLOWED_DOMAIN`, `URATEAM_SSO_ENABLED`), validates, instantiates the WorkOS client, returns `{ sso, workos }`. Used from both `start.ts` and `dev.ts`
+- CSRF: `/auth/login` and `/auth/callback` bypass CSRF (GET); `/auth/logout` is CSRF-protected. Sign-out uses `hx-post` with `HX-Request: true` header to satisfy the dashboard CSRF middleware
+- Audit events: `dashboard.login`, `dashboard.logout`, `dashboard.login_denied` flow through the existing license-gated `logAuditEvent`
+- Retention: PM tick calls `pruneExpiredSessions` after `pruneAuditLog`, gated on the SSO feature
+- Setup doc: `deploy/SSO_SETUP.md`
+- **Sign Out link is currently only on the Audit page**; threading user context through `runs`/`tokens`/`errors`/`config` views is a follow-up
+- **Session id MUST NOT be logged** — they're credentials. The `touchSessionLastSeen` warn logs only `idPrefix: id.slice(0,8) + "…"`
+
 ### Coordination (`packages/core/src/pm/coordination.ts`)
 - DB-backed `active_work` table tracks files modified by in-flight pipeline runs
 - `upsertActiveWork` uses atomic `onConflictDoUpdate` (requires UNIQUE on `run_id`)

--- a/deploy/SSO_SETUP.md
+++ b/deploy/SSO_SETUP.md
@@ -1,0 +1,79 @@
+# SSO setup (Enterprise)
+
+urateam supports SSO via WorkOS AuthKit. This routes dashboard authentication
+through your existing IdP (Okta, Azure AD, Google Workspace, OneLogin, ...).
+
+## Prerequisites
+- An Enterprise license
+- A WorkOS account (https://workos.com)
+
+## Steps
+
+### 1. Create a WorkOS project
+- Sign up / log in at https://dashboard.workos.com
+- Create an environment (one per urateam deployment is fine)
+- Note the API key (sk_live_... or sk_test_...) and Client ID (client_...)
+
+### 2. Configure your IdP in WorkOS
+- In the WorkOS dashboard, go to Authentication → AuthKit
+- Add a Connection for your IdP
+- Follow the WorkOS guide for your specific provider — they handle the SAML
+  metadata exchange or OIDC discovery for you
+
+### 3. Set environment variables
+On the urateam host:
+```
+URATEAM_WORKOS_API_KEY=sk_live_...
+URATEAM_SSO_STATE_SECRET=$(openssl rand -hex 32)
+```
+
+`URATEAM_SSO_STATE_SECRET` is used to sign the OAuth state parameter to prevent
+CSRF. Generate a fresh 32-byte random string and keep it secret.
+
+### 4. Update urateam config
+Add the `sso` block to your urateam config (e.g. `config.yaml`):
+```yaml
+sso:
+  enabled: true
+  workosApiKey: ${URATEAM_WORKOS_API_KEY}
+  workosClientId: client_xxxxxxxxxxxxxxxx
+  redirectUri: https://urateam.acme.com/auth/callback
+  allowedDomain: acme.com
+  sessionDurationHours: 24
+  stateSigningSecret: ${URATEAM_SSO_STATE_SECRET}
+```
+
+`allowedDomain` (optional) restricts which email addresses can complete login.
+Omit to allow any email your IdP authenticates.
+
+### 5. Add the redirect URI to WorkOS
+- Back in the WorkOS dashboard, add `https://urateam.acme.com/auth/callback`
+  as an allowed redirect URI for the connection.
+
+### 6. Restart urateam
+- The dashboard should now redirect anonymous visitors to `/auth/login`,
+  which forwards them through WorkOS to your IdP.
+
+### Verification
+- Hit `https://urateam.acme.com/runs` in a browser — you should be redirected
+  through your IdP and back, and land on the dashboard with a session cookie.
+- Check the audit log at `/audit` (if licensed) — you should see a
+  `dashboard.login` event for the user who just logged in.
+
+## Troubleshooting
+- **400 Invalid login state:** the cookie or signing secret was rotated mid-flow.
+  Try again from `/auth/login`.
+- **403 Access denied for <email>:** the email's domain doesn't match
+  `allowedDomain`. Either remove the restriction or use a different account.
+- **503 SSO provider error:** WorkOS API is unreachable or returned an error.
+  Check WorkOS status page and your API key.
+- **Loop between /auth/login and the dashboard:** likely a cookie attribute
+  problem (e.g. Secure=true on a non-HTTPS deployment). Set
+  `sso.cookieSecure: false` in development only.
+
+## Notes
+- SSO replaces Basic Auth entirely when enabled. Make sure SSO is working
+  before disabling your `DASHBOARD_USER`/`DASHBOARD_PASSWORD` fallback.
+- Sessions are stored in the urateam database. Logging out invalidates the
+  server-side session, not the WorkOS / IdP session — re-clicking login may
+  silently reauthenticate via your IdP.

--- a/docs/superpowers/plans/2026-04-14-sso-via-workos.md
+++ b/docs/superpowers/plans/2026-04-14-sso-via-workos.md
@@ -1,0 +1,1785 @@
+# SSO via WorkOS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship enterprise feature 4.1 — replace HTTP Basic Auth on the dashboard with WorkOS-backed SAML/OIDC SSO when licensed and enabled — per `docs/superpowers/specs/2026-04-14-sso-design.md`.
+
+**Architecture:** New `packages/core/src/auth/` module owns session and user storage; `packages/dashboard/src/middleware/sso.ts` and `routes/auth.ts` own the request flow; `server.ts` mounts either the SSO stack OR Basic Auth, never both. Two new tables (`dashboard_users`, `dashboard_sessions`) follow the existing Drizzle + crossTimestamp patterns. Three new audit event types (`dashboard.login`, `dashboard.logout`, `dashboard.login_denied`) are written through the existing license-gated `logAuditEvent`.
+
+**Tech Stack:** `@workos-inc/node`, Hono, Drizzle ORM, Vitest, Zod, pino. WorkOS client is dependency-injectable so tests stub it without network calls.
+
+---
+
+## File Structure
+
+### New files
+- `packages/core/src/auth/index.ts` — barrel export
+- `packages/core/src/auth/sso-config.ts` — zod schema for the `sso` config + `signState` / `verifyState` HMAC helpers + `validateNextPath` open-redirect guard
+- `packages/core/src/auth/user-store.ts` — `upsertUser`, `getUserById` (storage primitive over `dashboardUsers`)
+- `packages/core/src/auth/session-store.ts` — `createSession`, `getSession`, `deleteSession`, `pruneExpiredSessions`, `touchSessionLastSeen`
+- `packages/core/src/auth/workos-client.ts` — lazy-init wrapper over `@workos-inc/node`
+- `packages/core/src/db/migrations/sqlite/007_sso.sql`
+- `packages/core/src/db/migrations/postgres/008_sso.sql`
+- `packages/core/src/__tests__/auth/session-store.test.ts`
+- `packages/core/src/__tests__/auth/user-store.test.ts`
+- `packages/core/src/__tests__/auth/sso-config.test.ts`
+- `packages/core/src/__tests__/auth/sso-audit-events.test.ts`
+- `packages/core/src/__tests__/pm-sso-prune-step.test.ts`
+- `packages/dashboard/src/middleware/sso.ts`
+- `packages/dashboard/src/routes/auth.ts`
+- `packages/dashboard/src/__tests__/sso-middleware.test.ts`
+- `packages/dashboard/src/__tests__/auth-routes.test.ts`
+- `packages/dashboard/src/__tests__/sso-integration.test.ts`
+- `deploy/SSO_SETUP.md`
+
+### Modified files
+- `packages/core/src/db/schema.ts` — add `dashboardUsers`, `dashboardSessions`
+- `packages/core/src/db/client.ts` — extend `getCreateTablesDDL()`
+- `packages/core/src/types.ts` — `SsoConfigSchema`, extend `AppConfigSchema.sso`, add three audit event types
+- `packages/core/src/audit/events.ts` — add `dashboardLoginEvent`, `dashboardLogoutEvent`, `dashboardLoginDeniedEvent`
+- `packages/core/src/license.ts` — add `"sso"` to Enterprise feature set
+- `packages/core/src/pm/scheduler.ts` — call `pruneExpiredSessions` after `pruneAuditLog`
+- `packages/core/src/index.ts` — re-export `./auth/index.js`
+- `packages/dashboard/package.json` — add `@workos-inc/node` dep
+- `packages/dashboard/src/server.ts` — branch on `ssoActive` to mount SSO stack vs Basic Auth
+- `packages/dashboard/src/views/layout.ts` — add "Sign out" link in nav (only when SSO is active)
+- `CLAUDE.md` — new "SSO" section under Key Patterns
+
+---
+
+## Task 1: Schema + migration for dashboard_users and dashboard_sessions
+
+**Files:**
+- Create: `packages/core/src/db/migrations/sqlite/007_sso.sql`
+- Create: `packages/core/src/db/migrations/postgres/008_sso.sql`
+- Modify: `packages/core/src/db/schema.ts`
+- Modify: `packages/core/src/db/client.ts` (`getCreateTablesDDL`)
+- Test: `packages/core/src/__tests__/db-sso-schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { dashboardUsers, dashboardSessions } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("sso schema", () => {
+  it("creates dashboard_users and dashboard_sessions tables on fresh SQLite db", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const userCols = (db as any).all(sql`PRAGMA table_info(dashboard_users)`) as Array<{name: string}>;
+    expect(userCols.map(c => c.name).sort()).toEqual([
+      "created_at", "email", "id", "last_login_at", "name", "workos_user_id",
+    ]);
+    const sessionCols = (db as any).all(sql`PRAGMA table_info(dashboard_sessions)`) as Array<{name: string}>;
+    expect(sessionCols.map(c => c.name).sort()).toEqual([
+      "created_at", "expires_at", "id", "last_seen_at", "user_id",
+    ]);
+  });
+
+  it("inserts and reads back a user + session", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_1", email: "a@b.com", name: "A B", workosUserId: "wu_1",
+    });
+    await (db as any).insert(dashboardSessions).values({
+      id: "s_1", userId: "u_1", expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const users = await (db as any).select().from(dashboardUsers);
+    expect(users).toHaveLength(1);
+    expect(users[0].email).toBe("a@b.com");
+    const sessions = await (db as any).select().from(dashboardSessions);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].userId).toBe("u_1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-sso-schema.test.ts
+```
+Expected: FAIL (tables not exported from schema.ts).
+
+- [ ] **Step 3: Add tables to `db/schema.ts`**
+
+Append at end of `packages/core/src/db/schema.ts`:
+```ts
+export const dashboardUsers = sqliteTable("dashboard_users", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  workosUserId: text("workos_user_id"),
+  createdAt: crossTimestamp("created_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  lastLoginAt: crossTimestamp("last_login_at"),
+});
+
+export const dashboardSessions = sqliteTable("dashboard_sessions", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => dashboardUsers.id),
+  createdAt: crossTimestamp("created_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  expiresAt: crossTimestamp("expires_at").notNull(),
+  lastSeenAt: crossTimestamp("last_seen_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+```
+
+- [ ] **Step 4: Create the SQLite migration file**
+
+Create `packages/core/src/db/migrations/sqlite/007_sso.sql`:
+```sql
+-- Enterprise feature 4.1: SSO via WorkOS
+CREATE TABLE IF NOT EXISTS dashboard_users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  workos_user_id TEXT,
+  created_at INTEGER NOT NULL,
+  last_login_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS dashboard_sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES dashboard_users(id),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);
+```
+
+- [ ] **Step 5: Create the Postgres migration file**
+
+Create `packages/core/src/db/migrations/postgres/008_sso.sql`:
+```sql
+-- Enterprise feature 4.1: SSO via WorkOS
+CREATE TABLE IF NOT EXISTS dashboard_users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  workos_user_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL,
+  last_login_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS dashboard_sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES dashboard_users(id),
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);
+```
+
+- [ ] **Step 6: Extend `getCreateTablesDDL()` in `db/client.ts`**
+
+Find the closing backtick of `getCreateTablesDDL()` and insert before it:
+```sql
+  CREATE TABLE IF NOT EXISTS dashboard_users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT,
+    workos_user_id TEXT,
+    created_at ${ts} NOT NULL,
+    last_login_at ${ts}
+  );
+  CREATE TABLE IF NOT EXISTS dashboard_sessions (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES dashboard_users(id),
+    created_at ${ts} NOT NULL,
+    expires_at ${ts} NOT NULL,
+    last_seen_at ${ts} NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
+  CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);
+```
+
+- [ ] **Step 7: Run the test, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-sso-schema.test.ts
+```
+Expected: PASS (2/2).
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/core/src/db packages/core/src/__tests__/db-sso-schema.test.ts
+git commit -m "feat(sso): add dashboard_users and dashboard_sessions tables"
+```
+
+---
+
+## Task 2: SSO config zod schema + signed state helpers
+
+**Files:**
+- Create: `packages/core/src/auth/sso-config.ts`
+- Create: `packages/core/src/auth/index.ts` (barrel, only this one export at this point)
+- Modify: `packages/core/src/types.ts`
+- Test: `packages/core/src/__tests__/auth/sso-config.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/src/__tests__/auth/sso-config.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { SsoConfigSchema } from "../../types.js";
+import { signState, verifyState, validateNextPath } from "../../auth/sso-config.js";
+
+const validConfig = {
+  enabled: true,
+  workosApiKey: "sk_test_xxx",
+  workosClientId: "client_xxx",
+  redirectUri: "https://example.com/auth/callback",
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+describe("SsoConfigSchema", () => {
+  it("parses a valid config", () => {
+    const parsed = SsoConfigSchema.parse(validConfig);
+    expect(parsed.sessionDurationHours).toBe(24);
+    expect(parsed.cookieName).toBe("urateam_session");
+    expect(parsed.cookieSecure).toBe(true);
+  });
+
+  it("rejects missing apiKey", () => {
+    const bad = { ...validConfig } as any;
+    delete bad.workosApiKey;
+    expect(() => SsoConfigSchema.parse(bad)).toThrow();
+  });
+
+  it("rejects non-url redirectUri", () => {
+    expect(() => SsoConfigSchema.parse({ ...validConfig, redirectUri: "not-a-url" })).toThrow();
+  });
+});
+
+describe("signState / verifyState", () => {
+  const secret = "0123456789abcdef0123456789abcdef";
+
+  it("round-trips a payload", () => {
+    const signed = signState({ next: "/runs", nonce: "abc" }, secret);
+    const verified = verifyState(signed, secret);
+    expect(verified).toEqual({ next: "/runs", nonce: "abc" });
+  });
+
+  it("rejects a tampered payload", () => {
+    const signed = signState({ next: "/runs", nonce: "abc" }, secret);
+    const tampered = signed.replace("/runs", "/evil");
+    expect(verifyState(tampered, secret)).toBeNull();
+  });
+
+  it("rejects a wrong-secret signature", () => {
+    const signed = signState({ next: "/runs", nonce: "abc" }, secret);
+    expect(verifyState(signed, "different-secret-1234567890abcdef")).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(verifyState("garbage", secret)).toBeNull();
+    expect(verifyState("no.dot", secret)).toBeNull();
+    expect(verifyState("", secret)).toBeNull();
+  });
+});
+
+describe("validateNextPath", () => {
+  it("accepts same-origin absolute paths", () => {
+    expect(validateNextPath("/")).toBe("/");
+    expect(validateNextPath("/runs")).toBe("/runs");
+    expect(validateNextPath("/runs/123")).toBe("/runs/123");
+  });
+
+  it("rejects scheme-relative URLs", () => {
+    expect(validateNextPath("//evil.com")).toBe("/");
+    expect(validateNextPath("//evil.com/path")).toBe("/");
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(validateNextPath("https://evil.com")).toBe("/");
+    expect(validateNextPath("http://evil.com")).toBe("/");
+  });
+
+  it("rejects backslash variants", () => {
+    expect(validateNextPath("/\\evil.com")).toBe("/");
+    expect(validateNextPath("\\\\evil.com")).toBe("/");
+  });
+
+  it("falls back to / for empty / nullish", () => {
+    expect(validateNextPath("")).toBe("/");
+    expect(validateNextPath(undefined as any)).toBe("/");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/sso-config.test.ts
+```
+Expected: FAIL (modules don't exist).
+
+- [ ] **Step 3: Add `SsoConfigSchema` to `types.ts`**
+
+Append to `packages/core/src/types.ts`:
+```ts
+export const SsoConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  workosApiKey: z.string().min(1),
+  workosClientId: z.string().min(1),
+  redirectUri: z.string().url(),
+  allowedDomain: z.string().optional(),
+  sessionDurationHours: z.number().int().positive().default(24),
+  cookieName: z.string().default("urateam_session"),
+  cookieSecure: z.boolean().default(true),
+  stateSigningSecret: z.string().min(16),
+});
+export type SsoConfig = z.infer<typeof SsoConfigSchema>;
+```
+
+Also extend `AppConfigSchema` (added by feature 4.2) to include `sso: SsoConfigSchema.optional()`.
+
+Also append three new audit event types to `AuditEventTypeSchema`:
+```ts
+"dashboard.login", "dashboard.logout", "dashboard.login_denied",
+```
+
+- [ ] **Step 4: Create `auth/sso-config.ts`**
+
+```ts
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+interface StatePayload {
+  next: string;
+  nonce: string;
+}
+
+export function signState(payload: StatePayload, secret: string): string {
+  const json = JSON.stringify(payload);
+  const b64 = Buffer.from(json, "utf8").toString("base64url");
+  const hmac = createHmac("sha256", secret).update(b64).digest("base64url");
+  return `${b64}.${hmac}`;
+}
+
+export function verifyState(signed: string, secret: string): StatePayload | null {
+  if (!signed || typeof signed !== "string") return null;
+  const idx = signed.lastIndexOf(".");
+  if (idx <= 0 || idx === signed.length - 1) return null;
+  const b64 = signed.slice(0, idx);
+  const sig = signed.slice(idx + 1);
+  const expected = createHmac("sha256", secret).update(b64).digest("base64url");
+  const sigBuf = Buffer.from(sig, "base64url");
+  const expBuf = Buffer.from(expected, "base64url");
+  if (sigBuf.length !== expBuf.length) return null;
+  if (!timingSafeEqual(sigBuf, expBuf)) return null;
+  try {
+    const json = Buffer.from(b64, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (typeof parsed?.next !== "string" || typeof parsed?.nonce !== "string") return null;
+    return parsed as StatePayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate that `next` is a same-origin absolute path. Reject scheme-relative
+ * (`//evil.com`), absolute (`https://evil.com`), and backslash variants.
+ * Falls back to "/" on any rejection.
+ */
+export function validateNextPath(next: string | undefined | null): string {
+  if (!next || typeof next !== "string") return "/";
+  if (!next.startsWith("/")) return "/";
+  if (next.startsWith("//")) return "/";
+  if (next.startsWith("/\\") || next.includes("\\")) return "/";
+  return next;
+}
+```
+
+- [ ] **Step 5: Create the barrel `auth/index.ts`**
+
+```ts
+export * from "./sso-config.js";
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/sso-config.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/core/src/auth packages/core/src/types.ts packages/core/src/__tests__/auth/sso-config.test.ts
+git commit -m "feat(sso): config schema and signed state helpers"
+```
+
+---
+
+## Task 3: User store
+
+**Files:**
+- Create: `packages/core/src/auth/user-store.ts`
+- Modify: `packages/core/src/auth/index.ts`
+- Test: `packages/core/src/__tests__/auth/user-store.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { upsertUser, getUserById } from "../../auth/user-store.js";
+
+let db: any;
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+describe("upsertUser", () => {
+  it("inserts a new user and returns its id", async () => {
+    const id = await upsertUser(db, { email: "a@b.com", name: "Alice", workosUserId: "wu_1" });
+    expect(id).toBeTruthy();
+    const user = await getUserById(db, id);
+    expect(user?.email).toBe("a@b.com");
+    expect(user?.name).toBe("Alice");
+    expect(user?.workosUserId).toBe("wu_1");
+  });
+
+  it("updates an existing user (matched by email) and returns the same id", async () => {
+    const id1 = await upsertUser(db, { email: "a@b.com", name: "Alice", workosUserId: "wu_1" });
+    const id2 = await upsertUser(db, { email: "a@b.com", name: "Alice Renamed", workosUserId: "wu_1" });
+    expect(id2).toBe(id1);
+    const user = await getUserById(db, id1);
+    expect(user?.name).toBe("Alice Renamed");
+  });
+
+  it("normalizes email to lowercase", async () => {
+    const id = await upsertUser(db, { email: "MIXED@Case.COM", name: null, workosUserId: null });
+    const user = await getUserById(db, id);
+    expect(user?.email).toBe("mixed@case.com");
+  });
+
+  it("getUserById returns null for unknown id", async () => {
+    expect(await getUserById(db, "nope")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/user-store.test.ts
+```
+
+- [ ] **Step 3: Create `auth/user-store.ts`**
+
+```ts
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { dashboardUsers } from "../db/schema.js";
+
+export interface UpsertUserInput {
+  email: string;
+  name: string | null;
+  workosUserId: string | null;
+}
+
+export interface DashboardUser {
+  id: string;
+  email: string;
+  name: string | null;
+  workosUserId: string | null;
+  createdAt: Date;
+  lastLoginAt: Date | null;
+}
+
+export async function upsertUser(db: AnyDb, input: UpsertUserInput): Promise<string> {
+  const email = input.email.toLowerCase();
+  const existing = await db.select().from(dashboardUsers).where(eq(dashboardUsers.email, email));
+  if (existing.length > 0) {
+    const row = existing[0];
+    await db.update(dashboardUsers)
+      .set({
+        name: input.name,
+        workosUserId: input.workosUserId,
+        lastLoginAt: new Date(),
+      })
+      .where(eq(dashboardUsers.id, row.id));
+    return row.id;
+  }
+  const id = `usr_${randomUUID()}`;
+  await db.insert(dashboardUsers).values({
+    id,
+    email,
+    name: input.name,
+    workosUserId: input.workosUserId,
+    lastLoginAt: new Date(),
+  });
+  return id;
+}
+
+export async function getUserById(db: AnyDb, id: string): Promise<DashboardUser | null> {
+  const rows = await db.select().from(dashboardUsers).where(eq(dashboardUsers.id, id));
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    id: r.id,
+    email: r.email,
+    name: r.name ?? null,
+    workosUserId: r.workosUserId ?? null,
+    createdAt: r.createdAt,
+    lastLoginAt: r.lastLoginAt ?? null,
+  };
+}
+```
+
+Add `export * from "./user-store.js";` to `auth/index.ts`.
+
+- [ ] **Step 4: Run, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/user-store.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/auth/user-store.ts packages/core/src/auth/index.ts packages/core/src/__tests__/auth/user-store.test.ts
+git commit -m "feat(sso): user store with upsert by email"
+```
+
+---
+
+## Task 4: Session store
+
+**Files:**
+- Create: `packages/core/src/auth/session-store.ts`
+- Modify: `packages/core/src/auth/index.ts`
+- Test: `packages/core/src/__tests__/auth/session-store.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { upsertUser } from "../../auth/user-store.js";
+import {
+  createSession, getSession, deleteSession, pruneExpiredSessions, touchSessionLastSeen,
+} from "../../auth/session-store.js";
+
+let db: any;
+let userId: string;
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  userId = await upsertUser(db, { email: "a@b.com", name: "A", workosUserId: null });
+});
+
+describe("session-store", () => {
+  it("creates a session and reads it back", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    expect(sid).toBeTruthy();
+    expect(sid.length).toBeGreaterThan(20);
+    const s = await getSession(db, sid);
+    expect(s?.userId).toBe(userId);
+    expect(s?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("returns null for unknown session id", async () => {
+    expect(await getSession(db, "nope")).toBeNull();
+  });
+
+  it("returns null for expired sessions", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    // manually set expires_at into the past via a re-insert
+    await deleteSession(db, sid);
+    const { dashboardSessions } = await import("../../db/schema.js");
+    await (db as any).insert(dashboardSessions).values({
+      id: sid, userId, expiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await getSession(db, sid)).toBeNull();
+  });
+
+  it("deleteSession removes the row", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    await deleteSession(db, sid);
+    expect(await getSession(db, sid)).toBeNull();
+  });
+
+  it("pruneExpiredSessions removes only expired rows", async () => {
+    const live = await createSession(db, { userId, durationHours: 24 });
+    const dead = "sess_dead";
+    const { dashboardSessions } = await import("../../db/schema.js");
+    await (db as any).insert(dashboardSessions).values({
+      id: dead, userId, expiresAt: new Date(Date.now() - 1000),
+    });
+    const deleted = await pruneExpiredSessions(db);
+    expect(deleted).toBe(1);
+    expect(await getSession(db, live)).not.toBeNull();
+  });
+
+  it("touchSessionLastSeen updates lastSeenAt", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    const before = (await getSession(db, sid))!.lastSeenAt;
+    await new Promise(r => setTimeout(r, 50));
+    await touchSessionLastSeen(db, sid);
+    const after = (await getSession(db, sid))!.lastSeenAt;
+    expect(after.getTime()).toBeGreaterThanOrEqual(before.getTime());
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/session-store.test.ts
+```
+
+- [ ] **Step 3: Create `auth/session-store.ts`**
+
+```ts
+import { randomBytes } from "node:crypto";
+import { and, eq, gt, lt } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { dashboardSessions } from "../db/schema.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "auth.session" });
+
+export interface DashboardSession {
+  id: string;
+  userId: string;
+  createdAt: Date;
+  expiresAt: Date;
+  lastSeenAt: Date;
+}
+
+export async function createSession(
+  db: AnyDb,
+  args: { userId: string; durationHours: number },
+): Promise<string> {
+  const id = randomBytes(32).toString("base64url");
+  const expiresAt = new Date(Date.now() + args.durationHours * 3600_000);
+  await db.insert(dashboardSessions).values({
+    id, userId: args.userId, expiresAt, lastSeenAt: new Date(),
+  });
+  return id;
+}
+
+export async function getSession(db: AnyDb, id: string): Promise<DashboardSession | null> {
+  const rows = await db.select().from(dashboardSessions)
+    .where(and(eq(dashboardSessions.id, id), gt(dashboardSessions.expiresAt, new Date())));
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    id: r.id, userId: r.userId, createdAt: r.createdAt,
+    expiresAt: r.expiresAt, lastSeenAt: r.lastSeenAt,
+  };
+}
+
+export async function deleteSession(db: AnyDb, id: string): Promise<void> {
+  await db.delete(dashboardSessions).where(eq(dashboardSessions.id, id));
+}
+
+export async function pruneExpiredSessions(db: AnyDb): Promise<number> {
+  const result = await db.delete(dashboardSessions)
+    .where(lt(dashboardSessions.expiresAt, new Date()));
+  const n = (result as any)?.changes ?? (result as any)?.rowCount ?? 0;
+  log.info({ deleted: n }, "expired sessions pruned");
+  return n;
+}
+
+export async function touchSessionLastSeen(db: AnyDb, id: string): Promise<void> {
+  try {
+    await db.update(dashboardSessions)
+      .set({ lastSeenAt: new Date() })
+      .where(eq(dashboardSessions.id, id));
+  } catch (err) {
+    log.warn({ err, id }, "touchSessionLastSeen failed");
+  }
+}
+```
+
+Add `export * from "./session-store.js";` to `auth/index.ts`.
+
+- [ ] **Step 4: Run, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/session-store.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/auth/session-store.ts packages/core/src/auth/index.ts packages/core/src/__tests__/auth/session-store.test.ts
+git commit -m "feat(sso): session store with prune sweep"
+```
+
+---
+
+## Task 5: Audit event builders for SSO
+
+**Files:**
+- Modify: `packages/core/src/audit/events.ts`
+- Test: `packages/core/src/__tests__/audit/sso-events.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { dashboardLoginEvent, dashboardLogoutEvent, dashboardLoginDeniedEvent } from "../../audit/events.js";
+import { AuditEventSchema } from "../../types.js";
+
+describe("dashboard auth event builders", () => {
+  it("dashboardLoginEvent", () => {
+    const evt = dashboardLoginEvent({ userId: "u_1", email: "a@b.com", workosUserId: "wu_1" });
+    const parsed = AuditEventSchema.parse(evt);
+    expect(parsed.eventType).toBe("dashboard.login");
+    expect(parsed.actorType).toBe("dashboard-user");
+    expect(parsed.actor).toBe("dashboard:a@b.com");
+    expect(parsed.payload).toMatchObject({ userId: "u_1", workosUserId: "wu_1" });
+  });
+
+  it("dashboardLogoutEvent", () => {
+    const evt = dashboardLogoutEvent({ userId: "u_1", email: "a@b.com" });
+    expect(evt.eventType).toBe("dashboard.logout");
+    expect(evt.actor).toBe("dashboard:a@b.com");
+  });
+
+  it("dashboardLoginDeniedEvent uses system actor (no user yet)", () => {
+    const evt = dashboardLoginDeniedEvent({ email: "intruder@evil.com", reason: "domain-mismatch" });
+    expect(evt.eventType).toBe("dashboard.login_denied");
+    expect(evt.actor).toBe("dashboard:intruder@evil.com");
+    expect(evt.payload).toMatchObject({ reason: "domain-mismatch" });
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Append builders to `audit/events.ts`**
+
+```ts
+export function dashboardLoginEvent(args: {
+  userId: string; email: string; workosUserId: string | null;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.login",
+    actor: `dashboard:${args.email}`,
+    actorType: "dashboard-user",
+    payload: { userId: args.userId, workosUserId: args.workosUserId },
+  });
+}
+
+export function dashboardLogoutEvent(args: {
+  userId: string; email: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.logout",
+    actor: `dashboard:${args.email}`,
+    actorType: "dashboard-user",
+    payload: { userId: args.userId },
+  });
+}
+
+export function dashboardLoginDeniedEvent(args: {
+  email: string; reason: "domain-mismatch";
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.login_denied",
+    actor: `dashboard:${args.email}`,
+    actorType: "dashboard-user",
+    payload: { reason: args.reason },
+  });
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/audit/events.ts packages/core/src/__tests__/audit/sso-events.test.ts
+git commit -m "feat(sso): audit event builders for dashboard login/logout/denied"
+```
+
+---
+
+## Task 6: WorkOS client wrapper (with stub-friendly DI)
+
+**Files:**
+- Create: `packages/core/src/auth/workos-client.ts`
+- Modify: `packages/core/src/auth/index.ts`
+- Modify: `packages/dashboard/package.json` (add dep)
+- Test: `packages/core/src/__tests__/auth/workos-client.test.ts`
+
+- [ ] **Step 1: Add the dependency**
+
+```
+cd packages/dashboard && pnpm add @workos-inc/node
+cd ../..
+```
+
+Note: place the dep in `dashboard` not `core` because only the dashboard imports it. The core wrapper accepts an injected client.
+
+- [ ] **Step 2: Write failing test**
+
+The wrapper exposes a `WorkosClient` interface with two methods (`getAuthorizationUrl`, `authenticateWithCode`). The default impl uses the SDK; tests pass a stub. Test:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { type WorkosClient } from "../../auth/workos-client.js";
+
+describe("WorkosClient interface", () => {
+  it("the type allows a stub implementation", () => {
+    const stub: WorkosClient = {
+      async getAuthorizationUrl(args) {
+        return `https://workos.example/authz?state=${args.state}&client=${args.clientId}`;
+      },
+      async authenticateWithCode(args) {
+        return {
+          user: { id: "wu_test", email: "a@b.com", firstName: "A", lastName: "B" },
+        };
+      },
+    };
+    expect(stub).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run, confirm failure**
+
+- [ ] **Step 4: Create `auth/workos-client.ts`**
+
+```ts
+/**
+ * Thin interface over @workos-inc/node so tests can inject a stub
+ * without importing the SDK or hitting the network.
+ */
+export interface WorkosAuthorizeArgs {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+}
+
+export interface WorkosAuthenticateArgs {
+  clientId: string;
+  code: string;
+}
+
+export interface WorkosUserProfile {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+export interface WorkosAuthenticateResult {
+  user: WorkosUserProfile;
+}
+
+export interface WorkosClient {
+  getAuthorizationUrl(args: WorkosAuthorizeArgs): Promise<string>;
+  authenticateWithCode(args: WorkosAuthenticateArgs): Promise<WorkosAuthenticateResult>;
+}
+
+let cached: WorkosClient | null = null;
+
+/**
+ * Default WorkOS client. Lazily instantiates the SDK on first use so test
+ * environments that never call this never need the SDK installed.
+ */
+export async function getDefaultWorkosClient(apiKey: string): Promise<WorkosClient> {
+  if (cached) return cached;
+  // Dynamic import so the dep is loaded only when actually used.
+  const { WorkOS } = await import("@workos-inc/node");
+  const workos = new WorkOS(apiKey);
+  cached = {
+    async getAuthorizationUrl(args) {
+      return workos.userManagement.getAuthorizationUrl({
+        clientId: args.clientId,
+        redirectUri: args.redirectUri,
+        state: args.state,
+        provider: "authkit",
+      });
+    },
+    async authenticateWithCode(args) {
+      const result = await workos.userManagement.authenticateWithCode({
+        clientId: args.clientId,
+        code: args.code,
+      });
+      return {
+        user: {
+          id: result.user.id,
+          email: result.user.email,
+          firstName: result.user.firstName ?? null,
+          lastName: result.user.lastName ?? null,
+        },
+      };
+    },
+  };
+  return cached;
+}
+
+/** Test-only: reset the cached client. */
+export function _resetWorkosClient(): void {
+  cached = null;
+}
+```
+
+Add `export * from "./workos-client.js";` to `auth/index.ts`.
+
+- [ ] **Step 5: Run test, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/auth/workos-client.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/auth/workos-client.ts packages/core/src/auth/index.ts packages/dashboard/package.json packages/dashboard/pnpm-lock.yaml packages/core/src/__tests__/auth/workos-client.test.ts
+git commit -m "feat(sso): workos client interface with DI seam"
+```
+
+(If the lockfile lives at the repo root rather than per-package, adjust the `git add` to `pnpm-lock.yaml`.)
+
+---
+
+## Task 7: Re-export auth + add `sso` to Enterprise feature set
+
+**Files:**
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/core/src/license.ts`
+- Test: `packages/core/src/__tests__/auth/sso-feature-flag.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { _resetLicenseCache, isFeatureLicensed } from "../../license.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+beforeEach(() => { _resetLicenseCache(); });
+
+describe("sso feature flag", () => {
+  it("is licensed at the enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    expect(isFeatureLicensed("sso")).toBe(true);
+    await restoreLicense();
+  });
+
+  it("is not licensed at the pro tier", async () => {
+    await installTestProLicense("pro");
+    expect(isFeatureLicensed("sso")).toBe(false);
+    await restoreLicense();
+  });
+
+  it("is not licensed without a license", async () => {
+    await restoreLicense();
+    expect(isFeatureLicensed("sso")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Add `"sso"` to the enterprise feature set in `license.ts`**
+
+Find `ENTERPRISE_FEATURES` and add `"sso"` to the array. Run grep first to confirm location.
+
+- [ ] **Step 4: Re-export auth from core barrel**
+
+In `packages/core/src/index.ts` add:
+```ts
+export * from "./auth/index.js";
+```
+
+- [ ] **Step 5: Run test, verify pass**
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/license.ts packages/core/src/index.ts packages/core/src/__tests__/auth/sso-feature-flag.test.ts
+git commit -m "feat(sso): add sso to enterprise feature set"
+```
+
+---
+
+## Task 8: Dashboard SSO middleware
+
+**Files:**
+- Create: `packages/dashboard/src/middleware/sso.ts`
+- Test: `packages/dashboard/src/__tests__/sso-middleware.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { createDb, upsertUser, createSession } from "@urateam/core";
+import { createSsoMiddleware } from "../middleware/sso.js";
+
+let db: any;
+let userId: string;
+
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test", workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  sessionDurationHours: 24, cookieName: "urateam_session",
+  cookieSecure: false, stateSigningSecret: "0123456789abcdef0123456789abcdef",
+} as const;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  userId = await upsertUser(db, { email: "a@b.com", name: "A", workosUserId: null });
+});
+
+function appWithSso() {
+  const app = new Hono();
+  app.use("*", createSsoMiddleware({ db, sso: ssoConfig as any }));
+  app.get("/runs", (c) => c.text(`hello ${(c.get("user") as any).email}`));
+  app.post("/webhooks/linear", (c) => c.text("ok"));
+  app.get("/auth/login", (c) => c.text("login page"));
+  return app;
+}
+
+describe("ssoMiddleware", () => {
+  it("redirects to /auth/login when no cookie present", async () => {
+    const res = await appWithSso().request("/runs");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/auth/login");
+    expect(res.headers.get("location")).toContain("next=%2Fruns");
+  });
+
+  it("allows /auth/* paths through without a cookie", async () => {
+    const res = await appWithSso().request("/auth/login");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /webhooks/* paths through without a cookie", async () => {
+    const res = await appWithSso().request("/webhooks/linear", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 with c.get('user') populated when valid session cookie present", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    const res = await appWithSso().request("/runs", {
+      headers: { cookie: `urateam_session=${sid}` },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello a@b.com");
+  });
+
+  it("clears cookie and redirects when session id is unknown", async () => {
+    const res = await appWithSso().request("/runs", {
+      headers: { cookie: `urateam_session=unknown` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("set-cookie")).toContain("urateam_session=;");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `middleware/sso.ts`**
+
+```ts
+import { getCookie, setCookie } from "hono/cookie";
+import type { MiddlewareHandler } from "hono";
+import { getSession, getUserById, deleteSession, touchSessionLastSeen } from "@urateam/core";
+import type { SsoConfig } from "@urateam/core";
+
+interface SsoMiddlewareDeps {
+  db: any;
+  sso: SsoConfig;
+}
+
+export function createSsoMiddleware(deps: SsoMiddlewareDeps): MiddlewareHandler {
+  return async (c, next) => {
+    const path = c.req.path;
+    if (path.startsWith("/auth/")) return next();
+    if (path.startsWith("/webhooks/")) return next();
+
+    const cookie = getCookie(c, deps.sso.cookieName);
+    if (!cookie) {
+      return c.redirect(`/auth/login?next=${encodeURIComponent(path)}`, 302);
+    }
+
+    const session = await getSession(deps.db, cookie);
+    if (!session) {
+      setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+      return c.redirect(`/auth/login?next=${encodeURIComponent(path)}`, 302);
+    }
+
+    const user = await getUserById(deps.db, session.userId);
+    if (!user) {
+      await deleteSession(deps.db, cookie);
+      setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+      return c.redirect(`/auth/login`, 302);
+    }
+
+    c.set("user", user);
+    c.set("session", session);
+    void touchSessionLastSeen(deps.db, cookie);
+    return next();
+  };
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/sso-middleware.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/dashboard/src/middleware/sso.ts packages/dashboard/src/__tests__/sso-middleware.test.ts
+git commit -m "feat(sso): dashboard middleware with cookie/session check"
+```
+
+---
+
+## Task 9: Dashboard auth routes (login / callback / logout)
+
+**Files:**
+- Create: `packages/dashboard/src/routes/auth.ts`
+- Test: `packages/dashboard/src/__tests__/auth-routes.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import {
+  createDb, auditEvents, dashboardSessions,
+  signState,
+} from "@urateam/core";
+import type { WorkosClient } from "@urateam/core";
+import { createAuthRouter } from "../routes/auth.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test", workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  allowedDomain: undefined as string | undefined,
+  sessionDurationHours: 24,
+  cookieName: "urateam_session", cookieSecure: false,
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+const stubWorkos: WorkosClient = {
+  async getAuthorizationUrl(args) {
+    return `https://workos.example/auth?state=${args.state}&client=${args.clientId}`;
+  },
+  async authenticateWithCode(args) {
+    return {
+      user: { id: "wu_test", email: "alice@acme.com", firstName: "Alice", lastName: "X" },
+    };
+  },
+};
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/", createAuthRouter({ db, sso: ssoConfig as any, workos: stubWorkos }));
+  return app;
+}
+
+describe("/auth/login", () => {
+  it("returns 302 to a workos url with a signed state", async () => {
+    const res = await buildApp().request("/auth/login?next=/runs");
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("location")!;
+    expect(loc).toContain("workos.example");
+    expect(loc).toContain("state=");
+  });
+});
+
+describe("/auth/callback", () => {
+  it("creates a session, sets cookie, writes audit event, redirects to next", async () => {
+    const state = signState({ next: "/runs", nonce: "n" }, ssoConfig.stateSigningSecret);
+    const res = await buildApp().request(`/auth/callback?code=abc&state=${encodeURIComponent(state)}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/runs");
+    const setCookie = res.headers.get("set-cookie")!;
+    expect(setCookie).toContain("urateam_session=");
+    expect(setCookie).toContain("HttpOnly");
+    const sessions = await db.select().from(dashboardSessions);
+    expect(sessions).toHaveLength(1);
+    const events = await db.select().from(auditEvents);
+    expect(events.find((e: any) => e.eventType === "dashboard.login")).toBeDefined();
+  });
+
+  it("returns 400 on state mismatch", async () => {
+    const res = await buildApp().request(`/auth/callback?code=abc&state=garbage`);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 + audit event when allowedDomain rejects", async () => {
+    ssoConfig.allowedDomain = "evil.com";
+    const state = signState({ next: "/", nonce: "n" }, ssoConfig.stateSigningSecret);
+    const res = await buildApp().request(`/auth/callback?code=abc&state=${encodeURIComponent(state)}`);
+    expect(res.status).toBe(403);
+    const events = await db.select().from(auditEvents);
+    expect(events.find((e: any) => e.eventType === "dashboard.login_denied")).toBeDefined();
+    ssoConfig.allowedDomain = undefined;
+  });
+});
+
+describe("/auth/logout", () => {
+  it("deletes session, clears cookie, writes logout event", async () => {
+    // first log in
+    const state = signState({ next: "/", nonce: "n" }, ssoConfig.stateSigningSecret);
+    const cb = await buildApp().request(`/auth/callback?code=abc&state=${encodeURIComponent(state)}`);
+    const cookieHeader = cb.headers.get("set-cookie")!;
+    const sid = cookieHeader.match(/urateam_session=([^;]+)/)![1];
+
+    const res = await buildApp().request("/auth/logout", {
+      method: "POST",
+      headers: { cookie: `urateam_session=${sid}` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/auth/login");
+    const sessions = await db.select().from(dashboardSessions);
+    expect(sessions).toHaveLength(0);
+    const events = await db.select().from(auditEvents);
+    expect(events.find((e: any) => e.eventType === "dashboard.logout")).toBeDefined();
+  });
+});
+
+afterEach(async () => { await restoreLicense(); });
+```
+
+Note the import of `installTestProLicense` from a local helper file under `__tests__/helpers/license.ts`. The audit-log feature uses this same pattern; copy/adapt the helper.
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `routes/auth.ts`**
+
+```ts
+import { Hono } from "hono";
+import { setCookie } from "hono/cookie";
+import { randomUUID } from "node:crypto";
+import {
+  signState, verifyState, validateNextPath,
+  upsertUser, createSession, deleteSession, getSession, getUserById,
+  logAuditEvent, dashboardLoginEvent, dashboardLogoutEvent, dashboardLoginDeniedEvent,
+} from "@urateam/core";
+import type { SsoConfig, WorkosClient } from "@urateam/core";
+
+interface AuthRouterDeps {
+  db: any;
+  sso: SsoConfig;
+  workos: WorkosClient;
+}
+
+export function createAuthRouter(deps: AuthRouterDeps): Hono {
+  const app = new Hono();
+
+  app.get("/auth/login", async (c) => {
+    const next = validateNextPath(c.req.query("next"));
+    const state = signState({ next, nonce: randomUUID() }, deps.sso.stateSigningSecret);
+    const url = await deps.workos.getAuthorizationUrl({
+      clientId: deps.sso.workosClientId,
+      redirectUri: deps.sso.redirectUri,
+      state,
+    });
+    return c.redirect(url, 302);
+  });
+
+  app.get("/auth/callback", async (c) => {
+    const code = c.req.query("code");
+    const stateRaw = c.req.query("state");
+    if (!code || !stateRaw) return c.text("Missing code or state", 400);
+    const state = verifyState(stateRaw, deps.sso.stateSigningSecret);
+    if (!state) return c.text("Invalid login state. Please try again.", 400);
+
+    let result;
+    try {
+      result = await deps.workos.authenticateWithCode({
+        clientId: deps.sso.workosClientId,
+        code,
+      });
+    } catch (err) {
+      return c.text("SSO provider error. Try again or contact your administrator.", 503);
+    }
+
+    const email = result.user.email.toLowerCase();
+    if (deps.sso.allowedDomain) {
+      const expected = "@" + deps.sso.allowedDomain.toLowerCase();
+      if (!email.endsWith(expected)) {
+        void logAuditEvent(deps.db, dashboardLoginDeniedEvent({ email, reason: "domain-mismatch" }));
+        return c.text(
+          `Access denied. ${email} is not in the allowed domain. Contact your administrator.`,
+          403,
+        );
+      }
+    }
+
+    const fullName = [result.user.firstName, result.user.lastName].filter(Boolean).join(" ").trim() || null;
+    const userId = await upsertUser(deps.db, {
+      email, name: fullName, workosUserId: result.user.id,
+    });
+    const sessionId = await createSession(deps.db, {
+      userId, durationHours: deps.sso.sessionDurationHours,
+    });
+
+    setCookie(c, deps.sso.cookieName, sessionId, {
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: deps.sso.cookieSecure,
+      path: "/",
+      maxAge: deps.sso.sessionDurationHours * 3600,
+    });
+
+    void logAuditEvent(deps.db, dashboardLoginEvent({
+      userId, email, workosUserId: result.user.id,
+    }));
+
+    return c.redirect(validateNextPath(state.next), 302);
+  });
+
+  app.post("/auth/logout", async (c) => {
+    const cookie = c.req.header("cookie");
+    const match = cookie?.match(new RegExp(`${deps.sso.cookieName}=([^;]+)`));
+    const sid = match?.[1];
+    if (sid) {
+      const session = await getSession(deps.db, sid);
+      if (session) {
+        const user = await getUserById(deps.db, session.userId);
+        await deleteSession(deps.db, sid);
+        if (user) {
+          void logAuditEvent(deps.db, dashboardLogoutEvent({
+            userId: user.id, email: user.email,
+          }));
+        }
+      }
+    }
+    setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+    return c.redirect("/auth/login", 302);
+  });
+
+  return app;
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/auth-routes.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/dashboard/src/routes/auth.ts packages/dashboard/src/__tests__/auth-routes.test.ts packages/dashboard/src/__tests__/helpers
+git commit -m "feat(sso): /auth/login, /auth/callback, /auth/logout routes"
+```
+
+---
+
+## Task 10: Wire SSO stack into `server.ts`
+
+**Files:**
+- Modify: `packages/dashboard/src/server.ts`
+- Modify: `packages/dashboard/src/views/layout.ts` (add Sign Out link when SSO active)
+- Test: `packages/dashboard/src/__tests__/sso-integration.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "@urateam/core";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+import { buildServer } from "../server.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+afterEach(async () => { await restoreLicense(); });
+
+describe("server with SSO", () => {
+  const ssoConfig = {
+    enabled: true,
+    workosApiKey: "sk_test", workosClientId: "client_test",
+    redirectUri: "https://x/auth/callback",
+    sessionDurationHours: 24, cookieName: "urateam_session",
+    cookieSecure: false, stateSigningSecret: "0123456789abcdef0123456789abcdef",
+  };
+
+  it("redirects /runs to /auth/login when SSO is licensed and enabled with no cookie", async () => {
+    await installTestProLicense("enterprise");
+    const app = buildServer({ db, sso: ssoConfig as any });
+    const res = await app.request("/runs");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/auth/login");
+  });
+
+  it("falls back to basic auth when SSO is not licensed even if enabled", async () => {
+    await restoreLicense();
+    const app = buildServer({
+      db,
+      sso: ssoConfig as any,
+      auth: { username: "u", password: "p" },
+    });
+    const res = await app.request("/runs");
+    expect(res.status).toBe(401); // basic auth challenge
+  });
+
+  it("uses basic auth when SSO is licensed but disabled", async () => {
+    await installTestProLicense("enterprise");
+    const app = buildServer({
+      db,
+      sso: { ...ssoConfig, enabled: false } as any,
+      auth: { username: "u", password: "p" },
+    });
+    const res = await app.request("/runs");
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Modify `server.ts`**
+
+Read it first to understand the structure. Then add at the top, before the existing `if (config.auth?.username && config.auth?.password)` block:
+
+```ts
+import { isFeatureLicensed, getDefaultWorkosClient } from "@urateam/core";
+import { createSsoMiddleware } from "./middleware/sso.js";
+import { createAuthRouter } from "./routes/auth.js";
+
+// ... inside buildServer(...)
+const ssoActive = isFeatureLicensed("sso") && config.sso?.enabled === true;
+
+if (ssoActive) {
+  // Lazy-load WorkOS client; SDK is only required when SSO is active.
+  const workos = await getDefaultWorkosClient(config.sso!.workosApiKey);
+  const authRouter = createAuthRouter({ db: config.db, sso: config.sso!, workos });
+  app.route("/", authRouter);
+  app.use("*", createSsoMiddleware({ db: config.db, sso: config.sso! }));
+} else if (config.auth?.username && config.auth?.password) {
+  app.use("*", basicAuth({ username: config.auth.username, password: config.auth.password }));
+} else {
+  app.use("*", async (c) => c.text(
+    "Dashboard authentication is required but not configured. " +
+      "Set DASHBOARD_USER and DASHBOARD_PASSWORD environment variables and restart.",
+    503,
+  ));
+}
+```
+
+Note: `buildServer` may currently be a synchronous function. Making it `async` to allow `await getDefaultWorkosClient(...)` is acceptable; if the existing call sites pass it through `app.fetch` directly (synchronous startup), refactor those call sites to `await buildServer(...)`. Look at `packages/dashboard/src/index.ts` (or wherever the entry point lives) and update the boot sequence accordingly. If turning it async is invasive, an alternative is to instantiate the WorkOS client synchronously by importing the SDK at the top of `server.ts` instead of dynamically — at the cost of always loading the SDK even on Basic Auth deployments.
+
+Pick the dynamic-import async approach if `buildServer` is already async; otherwise switch to the static import.
+
+- [ ] **Step 4: Add Sign Out link to layout**
+
+In `layout.ts`, find the nav block. Add a conditional:
+```ts
+${user ? html`<form method="post" action="${bp}/auth/logout"><button class="link">Sign out (${escapeHtml(user.email)})</button></form>` : ""}
+```
+
+The `user` is read from `c.get("user")` — propagate it through the layout's input props.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/sso-integration.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/dashboard/src/server.ts packages/dashboard/src/views/layout.ts packages/dashboard/src/__tests__/sso-integration.test.ts
+git commit -m "feat(sso): wire sso stack into dashboard server"
+```
+
+---
+
+## Task 11: Scheduler tick — pruneExpiredSessions step
+
+**Files:**
+- Modify: `packages/core/src/pm/scheduler.ts`
+- Test: `packages/core/src/__tests__/pm-sso-prune-step.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb, upsertUser } from "@urateam/core";
+import { dashboardSessions } from "../db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+// ... import the tick entry as in pm-audit-retention-step.test.ts
+
+describe("pm tick prunes expired sessions", () => {
+  it("deletes expired dashboard_sessions when sso licensed", async () => {
+    await installTestProLicense("enterprise");
+    const db = await createDb({ connectionString: ":memory:" }) as any;
+    const userId = await upsertUser(db, { email: "a@b.com", name: null, workosUserId: null });
+    await db.insert(dashboardSessions).values({
+      id: "s_old", userId, expiresAt: new Date(Date.now() - 1000),
+    });
+    await db.insert(dashboardSessions).values({
+      id: "s_live", userId, expiresAt: new Date(Date.now() + 3600_000),
+    });
+
+    // call the tick
+    // ... (mirror pm-audit-retention-step.test.ts pattern)
+
+    const remaining = await db.select().from(dashboardSessions);
+    expect(remaining.find((r: any) => r.id === "s_old")).toBeUndefined();
+    expect(remaining.find((r: any) => r.id === "s_live")).toBeDefined();
+    await restoreLicense();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Add the step to `pm/scheduler.ts`**
+
+After the `pruneAuditLog` step block, add:
+```ts
+try {
+  if (isFeatureLicensed("sso")) {
+    const { pruneExpiredSessions } = await import("../auth/index.js");
+    await pruneExpiredSessions(db);
+  }
+} catch (err) {
+  log.warn({ err }, "session prune failed");
+}
+```
+
+(If a static import is preferable and doesn't create a cycle, use one — match Task 13 style from feature 4.2.)
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/pm/scheduler.ts packages/core/src/__tests__/pm-sso-prune-step.test.ts
+git commit -m "feat(sso): prune expired sessions in pm tick"
+```
+
+---
+
+## Task 12: Operator setup doc
+
+**Files:**
+- Create: `deploy/SSO_SETUP.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# SSO setup (Enterprise)
+
+urateam supports SSO via WorkOS AuthKit. This routes dashboard authentication
+through your existing IdP (Okta, Azure AD, Google Workspace, OneLogin, ...).
+
+## Prerequisites
+- An Enterprise license
+- A WorkOS account (https://workos.com)
+
+## Steps
+
+### 1. Create a WorkOS project
+- Sign up / log in at https://dashboard.workos.com
+- Create an environment (one per urateam deployment is fine)
+- Note the API key (sk_live_... or sk_test_...) and Client ID (client_...)
+
+### 2. Configure your IdP in WorkOS
+- In the WorkOS dashboard, go to Authentication → AuthKit
+- Add a Connection for your IdP
+- Follow the WorkOS guide for your specific provider — they handle the SAML
+  metadata exchange or OIDC discovery for you
+
+### 3. Set environment variables
+On the urateam host:
+```
+URATEAM_WORKOS_API_KEY=sk_live_...
+URATEAM_SSO_STATE_SECRET=$(openssl rand -hex 32)
+```
+
+`URATEAM_SSO_STATE_SECRET` is used to sign the OAuth state parameter to prevent
+CSRF. Generate a fresh 32-byte random string and keep it secret.
+
+### 4. Update urateam config
+Add the `sso` block to your urateam config (e.g. `config.yaml`):
+```yaml
+sso:
+  enabled: true
+  workosApiKey: ${URATEAM_WORKOS_API_KEY}
+  workosClientId: client_xxxxxxxxxxxxxxxx
+  redirectUri: https://urateam.acme.com/auth/callback
+  allowedDomain: acme.com
+  sessionDurationHours: 24
+  stateSigningSecret: ${URATEAM_SSO_STATE_SECRET}
+```
+
+`allowedDomain` (optional) restricts which email addresses can complete login.
+Omit to allow any email your IdP authenticates.
+
+### 5. Add the redirect URI to WorkOS
+- Back in the WorkOS dashboard, add `https://urateam.acme.com/auth/callback`
+  as an allowed redirect URI for the connection.
+
+### 6. Restart urateam
+- The dashboard should now redirect anonymous visitors to `/auth/login`,
+  which forwards them through WorkOS to your IdP.
+
+### Verification
+- Hit `https://urateam.acme.com/runs` in a browser — you should be redirected
+  through your IdP and back, and land on the dashboard with a session cookie.
+- Check the audit log at `/audit` (if licensed) — you should see a
+  `dashboard.login` event for the user who just logged in.
+
+## Troubleshooting
+- **400 Invalid login state:** the cookie or signing secret was rotated mid-flow.
+  Try again from `/auth/login`.
+- **403 Access denied for <email>:** the email's domain doesn't match
+  `allowedDomain`. Either remove the restriction or use a different account.
+- **503 SSO provider error:** WorkOS API is unreachable or returned an error.
+  Check WorkOS status page and your API key.
+- **Loop between /auth/login and the dashboard:** likely a cookie attribute
+  problem (e.g. Secure=true on a non-HTTPS deployment). Set
+  `sso.cookieSecure: false` in development only.
+
+## Notes
+- SSO replaces Basic Auth entirely when enabled. Make sure SSO is working
+  before disabling your `DASHBOARD_USER`/`DASHBOARD_PASSWORD` fallback.
+- Sessions are stored in the urateam database. Logging out invalidates the
+  server-side session, not the WorkOS / IdP session — re-clicking login may
+  silently reauthenticate via your IdP.
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add deploy/SSO_SETUP.md
+git commit -m "docs(sso): operator setup guide"
+```
+
+---
+
+## Task 13: Full build + test sweep + holistic review + CLAUDE.md + PR
+
+- [ ] **Step 1: Build everything**
+
+```
+pnpm build
+```
+Expected: zero errors.
+
+- [ ] **Step 2: Run unit tests**
+
+```
+pnpm test
+```
+Expected: all pass (the known-flaky cli `run.test.ts` may fail under turbo parallel load — verify it passes when run standalone with `cd packages/cli && npx vitest run src/__tests__/run.test.ts`).
+
+- [ ] **Step 3: Run integration tests**
+
+```
+pnpm test:integration
+```
+
+- [ ] **Step 4: Dispatch holistic external review**
+
+Launch a fresh `feature-dev:code-reviewer` subagent with:
+- Spec: `docs/superpowers/specs/2026-04-14-sso-design.md`
+- Plan: `docs/superpowers/plans/2026-04-14-sso-via-workos.md`
+- Diff: `git diff main...HEAD`
+
+Ask it to specifically check:
+- Open redirect bypass (`next` param edge cases)
+- Session cookie attribute correctness (HttpOnly, SameSite, Secure)
+- State HMAC timing-safe comparison
+- Concurrent login: two tabs both completing /auth/callback at once — does upsertUser race correctly?
+- Cookie value injection: a malicious `next` query param can't be reflected unescaped in HTML error pages
+- License gate consistency: every SSO surface (middleware, routes, scheduler step) checks `isFeatureLicensed("sso")`
+- Postgres parity: the new tables / migration / `getCreateTablesDDL` are correct on both drivers
+- Whether the WorkOS dynamic import still works in production (the `buildServer` async refactor lands properly)
+- Whether the dashboard's CSP allows the WorkOS redirect to work
+
+Address any high-confidence findings.
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+Append a new section under "Key Patterns":
+```
+### SSO (Enterprise feature 4.1)
+- Module: `packages/core/src/auth/` — `sso-config.ts` (zod schema, `signState`/`verifyState`/`validateNextPath`), `user-store.ts` (`upsertUser`, `getUserById`), `session-store.ts` (`createSession`, `getSession`, `deleteSession`, `pruneExpiredSessions`, `touchSessionLastSeen`), `workos-client.ts` (DI seam over `@workos-inc/node`)
+- Tables: `dashboard_users` (id, email, name, workos_user_id, created_at, last_login_at) and `dashboard_sessions` (id, user_id, created_at, expires_at, last_seen_at)
+- Dashboard middleware: `packages/dashboard/src/middleware/sso.ts` — cookie → session → user → `c.set("user", ...)`. Skips `/auth/*` and `/webhooks/*`
+- Routes: `packages/dashboard/src/routes/auth.ts` — `GET /auth/login`, `GET /auth/callback`, `POST /auth/logout`
+- Server wiring: `server.ts` mounts SSO stack iff `isFeatureLicensed("sso") && config.sso?.enabled === true`. Otherwise falls back to Basic Auth (or 503 if neither configured). The two auth modes are mutually exclusive
+- Audit events: `dashboard.login`, `dashboard.logout`, `dashboard.login_denied` flow through the existing license-gated `logAuditEvent`
+- Retention: PM tick calls `pruneExpiredSessions` after `pruneAuditLog`, gated on the SSO feature
+- Setup doc: `deploy/SSO_SETUP.md`
+```
+
+- [ ] **Step 6: Commit and open PR**
+
+```
+git add CLAUDE.md
+git commit -m "docs(claude.md): sso feature notes"
+git push -u origin feat/sso
+gh pr create --title "feat: sso via workos (enterprise 4.1)" --body "$(cat <<'EOF'
+## Summary
+- Replaces dashboard HTTP Basic Auth with WorkOS AuthKit SSO when licensed and enabled
+- New tables: dashboard_users, dashboard_sessions
+- Three new audit event types: dashboard.login / .logout / .login_denied
+- Optional domain allowlist (sso.allowedDomain)
+- Server-side sessions = revocable in seconds via /auth/logout or admin DB delete
+- Webhooks bypass SSO middleware (HMAC verification unchanged)
+- OSS / Pro deployments unchanged — Basic Auth path is untouched
+
+Spec: docs/superpowers/specs/2026-04-14-sso-design.md
+Plan: docs/superpowers/plans/2026-04-14-sso-via-workos.md
+
+## Test plan
+- [ ] pnpm test (unit)
+- [ ] pnpm test:integration
+- [ ] Manual: stub WorkOS callback flow end-to-end against a dev instance
+- [ ] Manual: verify Basic Auth still works on a deployment with sso.enabled=false
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Every spec section has a task — § 3 architecture (Tasks 8–10), § 4 module layout (Tasks 2–6), § 5 data model (Task 1), § 6 config (Task 2), § 7 auth flow (Task 9), § 8 server wiring (Task 10), § 9 audit (Task 5), § 10 PM tick (Task 11), § 11 error handling (Tasks 8 + 9 cover all rows), § 12 security considerations (Tasks 2, 4, 8, 9 — open redirect, signed state, session entropy, cookie attributes), § 13 testing (each subsection mapped to a task), § 14 migration + setup doc (Tasks 1 + 12).
+- **Placeholders:** None. Task 11 has one placeholder reference to "mirror pm-audit-retention-step.test.ts pattern" — that's a deliberate pointer because the existing test pattern is the source of truth for tick test setup; the implementer should read it before writing the new test.
+- **Type consistency:** `SsoConfig` zod schema, `WorkosClient` interface, `DashboardUser`/`DashboardSession` row types, `createSsoMiddleware`/`createAuthRouter` factory signatures all defined once and referenced consistently. Audit event builders match the event type strings.
+- **Open dependency:** Task 10 may require flipping `buildServer` to async. The plan calls this out explicitly and offers a static-import fallback. The implementer should make a judgment call after reading the existing entry point.

--- a/docs/superpowers/specs/2026-04-14-sso-design.md
+++ b/docs/superpowers/specs/2026-04-14-sso-design.md
@@ -1,0 +1,380 @@
+# Design: SSO via WorkOS (Enterprise feature 4.1)
+
+**Date**: 2026-04-14
+**Status**: Draft for review
+**Parent strategy**: `docs/superpowers/specs/2026-04-13-enterprise-tier-design.md` § 4.1
+**Scope**: Replace HTTP Basic Auth on the dashboard with a WorkOS-backed SAML/OIDC SSO flow when the SSO feature is licensed and enabled. Enterprise-tier feature, gated by `isFeatureLicensed("sso")`.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+- Pass the customer's identity team review: dashboard access flows through their existing IdP (Okta, Azure AD, Google Workspace, OneLogin, etc.) via SAML or OIDC.
+- One integration covers every IdP — accomplished by routing through WorkOS AuthKit so urateam never parses SAML XML or maintains per-IdP code.
+- Server-side sessions backed by a DB table so an admin disabling a user in WorkOS results in their urateam dashboard session being revocable in seconds, not "whenever a JWT expires."
+- Establish a `dashboard_users` table now so feature 4.4 (RBAC) lands on a real foundation, not a session-only hack.
+- Audit every login, logout, and login-denied event so feature 4.2's compliance feed becomes meaningful for human dashboard activity.
+- Zero behavior change on OSS/Pro deployments: Basic Auth remains exactly as today.
+
+### Non-goals
+- Per-route RBAC scoping. The SSO middleware is a binary gate: logged in or not. Roles ship in feature 4.4.
+- Multi-tenant / multi-org WorkOS Organization mapping. urateam is single-tenant per deployment.
+- SCIM provisioning. Out of the buyer profile per the parent strategy spec.
+- Refresh tokens. 24h absolute session timeout is short enough that re-auth is acceptable and eliminates a class of token-refresh bugs.
+- Idle-timeout distinction. One absolute-timeout knob (`sessionDurationHours`).
+- "Remember me" extended sessions.
+- Webhook authentication. Webhooks (`/webhooks/linear`, `/webhooks/github`, `/webhooks/slack`) keep their existing HMAC signature verification — correct for machine-to-machine.
+- Coexistence with Basic Auth. SSO replaces Basic Auth entirely when enabled (mutually exclusive).
+- Programmatic API auth. There is no `/api` namespace yet; deferred.
+- DIY SAML. WorkOS abstracts it; we never touch XML.
+
+## 2. Provider choice
+
+**WorkOS AuthKit.** The official `@workos-inc/node` SDK exposes `userManagement.getAuthorizationUrl()` and `userManagement.authenticateWithCode()` — a two-call flow that handles SAML and OIDC behind a single API. The customer's IT team configures their IdP in the WorkOS admin UI; urateam sees only verified profiles.
+
+Rationale (per brainstorm):
+- Auth0 is significantly more expensive at the SAML-enabled tier and has a heavier SDK surface for no functional benefit at the buyer profile.
+- Raw OIDC + DIY SAML (`openid-client` + `@node-saml/node-saml`) trades 2-3 days of integration work for an indefinite tail of IdP-compatibility bugs. SAML implementations are notoriously fragile across IdPs; the operational cost of debugging "why doesn't Azure AD's response validate" tickets is the actual price.
+- WorkOS's free tier (1M MAU) covers all expected design-partner traffic; paid pricing folds into Enterprise contracts.
+
+The strategy spec § 4.1 names WorkOS or Auth0 explicitly; we pick WorkOS.
+
+## 3. Architecture
+
+```
+            Anonymous user
+                  │
+                  ▼ GET /runs
+        ┌──────────────────────────────┐
+        │ SSO middleware               │
+        │ (skips /auth/*, /webhooks/*) │
+        └──────────────────────────────┘
+                  │ no cookie
+                  ▼ 302 /auth/login?next=/runs
+        ┌──────────────────────────────┐
+        │ /auth/login                  │
+        │ workos.getAuthorizationUrl() │
+        └──────────────────────────────┘
+                  │
+                  ▼ 302 to WorkOS hosted UI
+            ┌─────────────┐
+            │   WorkOS    │ ── customer's IdP (Okta/Azure AD/Google/…)
+            └─────────────┘
+                  │
+                  ▼ 302 /auth/callback?code=…&state=…
+        ┌──────────────────────────────┐
+        │ /auth/callback               │
+        │ • verify state (CSRF)        │
+        │ • authenticateWithCode()     │
+        │ • domain allowlist check     │
+        │ • upsertUser                 │
+        │ • createSession              │
+        │ • Set-Cookie                 │
+        │ • emit dashboard.login event │
+        └──────────────────────────────┘
+                  │
+                  ▼ 302 to validated `next` URL
+              GET /runs (now with valid session cookie)
+```
+
+Webhooks bypass SSO middleware; their HMAC verification is unchanged.
+
+## 4. Module layout
+
+### 4.1 New core module: `packages/core/src/auth/`
+
+```
+auth/
+  index.ts           — barrel
+  workos-client.ts   — lazy-init wrapper over @workos-inc/node, one client per process
+  session-store.ts   — createSession, getSession, deleteSession, pruneExpiredSessions
+  user-store.ts      — upsertUser, getUserById
+  sso-config.ts      — zod schema for the `sso` config section + signed-state helpers
+```
+
+`session-store.ts` operates on `dashboardSessions`. `user-store.ts` operates on `dashboardUsers`. Neither knows about WorkOS — they're storage primitives. `workos-client.ts` is the only file that imports the WorkOS SDK.
+
+### 4.2 New dashboard surfaces
+
+```
+packages/dashboard/src/middleware/sso.ts   — Hono middleware: cookie → session → user → c.set("user", ...)
+packages/dashboard/src/routes/auth.ts      — GET /auth/login, GET /auth/callback, POST /auth/logout
+```
+
+The existing `server.ts` wires either the SSO stack OR the Basic Auth middleware, never both.
+
+## 5. Data model
+
+### 5.1 Tables
+
+```ts
+export const dashboardUsers = sqliteTable("dashboard_users", {
+  id: text("id").primaryKey(),                 // uuid (urateam-issued; stable across email changes)
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  workosUserId: text("workos_user_id"),
+  createdAt: crossTimestamp("created_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  lastLoginAt: crossTimestamp("last_login_at"),
+});
+
+export const dashboardSessions = sqliteTable("dashboard_sessions", {
+  id: text("id").primaryKey(),                 // 32-byte random, base64url
+  userId: text("user_id")
+    .notNull()
+    .references(() => dashboardUsers.id),
+  createdAt: crossTimestamp("created_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  expiresAt: crossTimestamp("expires_at").notNull(),
+  lastSeenAt: crossTimestamp("last_seen_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+```
+
+Indexes (declared in the migration files):
+- `idx_dashboard_sessions_user_id` on `(user_id)`
+- `idx_dashboard_sessions_expires_at` on `(expires_at)`
+
+Drizzle schema additions in `db/schema.ts`. `getCreateTablesDDL()` in `db/client.ts` extended with both tables. New file-based migrations:
+- `db/migrations/sqlite/007_sso.sql`
+- `db/migrations/postgres/008_sso.sql`
+
+### 5.2 Session lifecycle
+- **Created** in `/auth/callback` after WorkOS verification + domain allowlist + user upsert
+- **Read** on every request to a non-`/auth/*`, non-`/webhooks/*` route. The middleware looks up by cookie, validates `expiresAt > now()`, and updates `lastSeenAt`
+- **Deleted** explicitly via `POST /auth/logout`, or via the periodic prune sweep when expired
+- **Pruned** by `pruneExpiredSessions(db)` running in the PM scheduler tick
+
+`lastSeenAt` updates on every authenticated request. To avoid write amplification, the update is best-effort (ignore failures) and could be batched in v2 if it becomes a hot path. v1 writes per-request — dashboards are not high-QPS.
+
+## 6. Configuration
+
+New `sso` section added to `AppConfig` zod schema in `types.ts`:
+
+```ts
+sso: z.object({
+  enabled: z.boolean().default(false),
+  workosApiKey: z.string(),                    // sk_test_... or sk_live_...
+  workosClientId: z.string(),                  // client_...
+  redirectUri: z.string().url(),               // https://<host>/auth/callback
+  allowedDomain: z.string().optional(),        // "acme.com" — restricts which emails get sessions
+  sessionDurationHours: z.number().int().positive().default(24),
+  cookieName: z.string().default("urateam_session"),
+  cookieSecure: z.boolean().default(true),
+  stateSigningSecret: z.string(),              // 32+ byte random, used to HMAC the OAuth state param
+}).optional()
+```
+
+`workosApiKey` and `stateSigningSecret` must come from environment variables, never from a checked-in config file. The CLI startup validates this and refuses to boot if either is configured but the other is missing.
+
+The `enabled` boolean is independently honored from license: **both** `isFeatureLicensed("sso") === true` AND `config.sso?.enabled === true` must be true to mount the SSO stack. This lets a customer stage their SSO config before flipping it on, and lets ops disable SSO via config without touching their license.
+
+## 7. Auth flow detail
+
+### 7.1 GET /auth/login
+1. Read `next` query param; default `/`
+2. Validate `next` is a same-origin path (starts with `/`, no `//` prefix, no `\`)
+3. Generate signed state: `base64url(JSON.stringify({next, nonce: randomUUID()}))` + HMAC-SHA256 with `stateSigningSecret`. Format: `<payload>.<hmac>`
+4. Call `workos.userManagement.getAuthorizationUrl({clientId, redirectUri, state, provider: "authkit"})`
+5. 302 to the returned URL
+
+### 7.2 GET /auth/callback
+1. Verify the `state` parameter HMAC. Reject with 400 on mismatch (CSRF guard)
+2. Decode `state.next` (default `/`)
+3. Call `workos.userManagement.authenticateWithCode({code, clientId})` → `{user: {id, email, firstName, lastName}, accessToken}`
+4. If `sso.allowedDomain` is set, verify `user.email.toLowerCase().endsWith("@" + allowedDomain.toLowerCase())`. On mismatch:
+   - Emit `dashboard.login_denied` audit event with `{email, reason: "domain-mismatch"}`
+   - Render a 403 page: "Access denied. Your email <email> is not in the allowed domain. Contact your administrator."
+5. `upsertUser({email, name: firstName + " " + lastName, workosUserId: user.id})` → `userId`
+6. `createSession({userId, durationHours: config.sso.sessionDurationHours})` → `sessionId`
+7. Set-Cookie:
+   `<cookieName>=<sessionId>; HttpOnly; SameSite=Lax; Secure (if cookieSecure); Path=/; Max-Age=<seconds>`
+8. Emit `dashboard.login` audit event with `{userId, email, workosUserId}`
+9. 302 to `state.next`
+
+### 7.3 POST /auth/logout
+1. Read session cookie
+2. If present, delete the session row by id
+3. Emit `dashboard.logout` audit event with `{userId}`
+4. Clear the cookie (Set-Cookie with `Max-Age=0`)
+5. 302 to `/auth/login`
+
+The form on the dashboard nav posts here with a CSRF token. The dashboard already has CSRF middleware; the logout form uses it.
+
+### 7.4 SSO middleware
+```ts
+async function ssoMiddleware(c, next) {
+  const path = c.req.path;
+  if (path.startsWith("/auth/")) return next();
+  if (path.startsWith("/webhooks/")) return next();
+
+  const cookie = getCookie(c, config.sso.cookieName);
+  if (!cookie) return c.redirect(`/auth/login?next=${encodeURIComponent(path)}`, 302);
+
+  const session = await getSession(db, cookie);
+  if (!session || session.expiresAt < new Date()) {
+    deleteCookie(c, config.sso.cookieName);
+    return c.redirect(`/auth/login?next=${encodeURIComponent(path)}`, 302);
+  }
+
+  const user = await getUserById(db, session.userId);
+  if (!user) {  // edge case: user deleted but session still exists
+    await deleteSession(db, cookie);
+    deleteCookie(c, config.sso.cookieName);
+    return c.redirect(`/auth/login`, 302);
+  }
+
+  c.set("user", user);
+  c.set("session", session);
+  void touchSessionLastSeen(db, cookie);  // fire-and-forget
+  return next();
+}
+```
+
+## 8. Wiring in `server.ts`
+
+```ts
+const ssoActive = isFeatureLicensed("sso") && config.sso?.enabled === true;
+
+if (ssoActive) {
+  // Mount /auth/* routes (no SSO middleware)
+  const authRouter = createAuthRouter({ db: config.db, sso: config.sso, basePath });
+  app.route("/", authRouter);
+
+  // SSO middleware on everything else (skips /auth/* and /webhooks/* internally)
+  app.use("*", ssoMiddleware({ db: config.db, sso: config.sso }));
+} else if (config.auth?.username && config.auth?.password) {
+  app.use("*", basicAuth({ username: config.auth.username, password: config.auth.password }));
+} else {
+  app.use("*", async (c) => c.text("Dashboard authentication required but not configured.", 503));
+}
+```
+
+Order matters: webhook routes that mount under the same Hono app must be registered **before** the SSO middleware OR the middleware must skip `/webhooks/*` (it does, by path prefix check). Existing dashboard tests that boot the server without `sso.enabled` are unaffected.
+
+## 9. Audit integration
+
+Three new event types added to `AuditEventTypeSchema` in `types.ts`:
+
+| Event | Where | Payload |
+|---|---|---|
+| `dashboard.login` | `/auth/callback` after session created | `{userId, email, workosUserId}` |
+| `dashboard.logout` | `/auth/logout` after session deleted | `{userId}` |
+| `dashboard.login_denied` | `/auth/callback` after domain mismatch | `{email, reason: "domain-mismatch"}` |
+
+These are written via `logAuditEvent` (gated by `isFeatureLicensed("audit-log")` per feature 4.2), so a deployment with SSO licensed but audit-log unlicensed simply has no audit trail — same gating model as the rest of the audit module.
+
+The `dashboard.manual_action` event reserved in feature 4.2 is **still** unwritten in v1. Feature 4.4 (RBAC) will start writing it once there are role-aware actions to attribute.
+
+Actor field: `actor = "dashboard:" + email`, `actorType = "dashboard-user"`.
+
+## 10. PM scheduler tick integration
+
+Add `pruneExpiredSessions(db)` as a new step after `pruneAuditLog`:
+
+> budget check → recover retriable → recover stuck → startTodoIssues → triage → resolve approvals → promote → deprioritize → cancel → digest → pruneAuditLog → **pruneExpiredSessions**
+
+Gated on `isFeatureLicensed("sso")`. No-op otherwise. Wrapped in try/catch — sweep failure must not crash the tick.
+
+## 11. Error handling
+
+| Failure mode | Response |
+|---|---|
+| WorkOS API down at `/auth/login` | Render error page "SSO provider unreachable. Try again or contact your administrator." 503. No fallback to Basic Auth. |
+| WorkOS API down at `/auth/callback` | Same as above. The user re-tries; nothing was persisted. |
+| `state` HMAC mismatch | 400 "Invalid login state. Please try again." |
+| `state` payload malformed | 400 same as above |
+| Domain allowlist mismatch | 403 with the denied-access page; audit event written |
+| Invalid session cookie format | Treat as no cookie (clear it, redirect to login) |
+| Session row not found | Same as above |
+| Session expired | Same as above |
+| User row missing despite valid session (edge case) | Delete session, clear cookie, redirect to login |
+| `pruneExpiredSessions` throws | pino warn; tick continues |
+| `touchSessionLastSeen` throws | pino warn; request continues |
+
+## 12. Security considerations
+
+- **Session id entropy:** 32 bytes from `crypto.randomBytes`, base64url encoded. ~256 bits of entropy. Stored as opaque text in DB; not hashed (the cookie value IS the lookup key — hashing would prevent O(1) lookup and the threat model is database compromise, in which case the rest of the audit data is also exposed).
+- **Cookie attributes:** `HttpOnly` (no JS access), `SameSite=Lax` (allows top-level GET navigation from email links but blocks cross-site POST CSRF), `Secure` (default true; configurable for local dev over plain HTTP), `Path=/`, `Max-Age` matching session duration.
+- **CSRF on logout:** existing dashboard CSRF middleware (BEC-103) handles this. The logout form includes the CSRF token.
+- **Open redirect on `next`:** the `next` param is validated to be a same-origin absolute path (`/foo/bar`), rejecting `//evil.com`, `https://evil.com`, and backslashes. Tested.
+- **State parameter:** HMAC-SHA256 with `stateSigningSecret`. Includes a nonce so reusing a state value (CSRF replay) doesn't validate twice — the nonce isn't tracked server-side in v1; the state is single-use only via the cookie redirect, and short-lived. Sufficient for v1.
+- **Secrets at rest:** `workosApiKey` and `stateSigningSecret` come from env vars. The CLI startup validates presence and refuses to boot if either is missing when `sso.enabled === true`.
+- **Email case sensitivity:** `email` stored lowercase. Lookups normalize to lowercase. The unique constraint is on the lowercase form.
+- **Logout doesn't revoke WorkOS session:** intentional. Logout clears the urateam session only; if the user re-clicks login, WorkOS may return them silently if their IdP session is still active. This is normal SSO UX and matches user expectations.
+
+## 13. Testing strategy
+
+### 13.1 Unit (`packages/core/src/__tests__/auth/`)
+- `session-store.test.ts` — create / get / delete / expire / prune
+- `user-store.test.ts` — upsert (insert + update by email), getById, lowercased email
+- `sso-config.test.ts` — zod parse, missing required fields, signed state HMAC round-trip
+- `workos-client.test.ts` — lazy init, single-instance per process
+
+### 13.2 Middleware (`packages/dashboard/src/__tests__/sso-middleware.test.ts`)
+- No cookie → 302 to `/auth/login?next=<path>`
+- Invalid cookie → cleared, 302
+- Expired session → cleared, 302
+- Valid session → `c.get("user")` populated, next() called
+- `/auth/*` and `/webhooks/*` paths bypass middleware
+- Open-redirect protection: `next=//evil.com`, `next=https://evil.com`, `next=\\evil.com` all rejected
+
+### 13.3 Routes (`packages/dashboard/src/__tests__/auth-routes.test.ts`)
+- `GET /auth/login` returns 302 to a WorkOS URL; state is signed; next param is preserved
+- `GET /auth/callback` with valid stubbed WorkOS response: session created, cookie set, audit event written, 302 to next
+- `GET /auth/callback` with state mismatch: 400
+- `GET /auth/callback` with domain mismatch: 403, `dashboard.login_denied` event written
+- `POST /auth/logout` deletes session, clears cookie, audit event written
+
+WorkOS client is stubbed via dependency injection (`createAuthRouter` accepts a `workos` client param).
+
+### 13.4 Server integration (`packages/dashboard/src/__tests__/sso-integration.test.ts`)
+- Server with `sso.enabled=false` → Basic Auth path unchanged
+- Server with `sso.enabled=true, isFeatureLicensed=false` → 503 (license required)
+- Server with both true: `GET /runs` redirects to `/auth/login`; after stubbed callback, `GET /runs` returns 200
+- Webhooks (`POST /webhooks/linear`) bypass SSO middleware in the licensed+enabled case
+
+### 13.5 Audit (`packages/core/src/__tests__/auth/sso-audit-events.test.ts`)
+- Login flow writes `dashboard.login`
+- Logout writes `dashboard.logout`
+- Domain denial writes `dashboard.login_denied`
+- All three are no-ops when `audit-log` is unlicensed
+
+### 13.6 PM tick
+- `packages/core/src/__tests__/pm-sso-prune-step.test.ts` — `pruneExpiredSessions` runs after `pruneAuditLog`, only when sso licensed, gracefully handles errors
+
+## 14. Migration + rollout
+
+### 14.1 Schema migration
+- New file `db/migrations/sqlite/007_sso.sql` and `db/migrations/postgres/008_sso.sql`
+- `getCreateTablesDDL(driver)` extended with both tables for fresh installs
+- Drizzle schema in `schema.ts` extended
+
+### 14.2 Backfill
+None. Tables start empty. First login creates the user.
+
+### 14.3 Feature flag
+- `sso` added to the Enterprise feature set in `license.ts`
+- OSS / Pro deployments: SSO config is ignored even if present; Basic Auth path unchanged
+- Enterprise deployments without `sso.enabled=true`: also unchanged (Basic Auth)
+- Enterprise deployments with `sso.enabled=true`: SSO replaces Basic Auth
+
+### 14.4 Customer onboarding doc
+A short README section `deploy/SSO_SETUP.md` (created by the implementation plan) walks an operator through:
+1. Create a WorkOS account, get API key + client id
+2. Configure their IdP via WorkOS admin UI
+3. Set `URATEAM_WORKOS_API_KEY` and `URATEAM_SSO_STATE_SECRET` env vars
+4. Add `sso` block to config with `enabled: true`, `redirectUri`, `allowedDomain`
+5. Restart urateam
+6. Verify `/auth/login` redirects to their IdP
+
+## 15. Open questions (deferred)
+- **Idle timeout vs absolute timeout:** v1 is absolute only. Add idle timeout if customers ask.
+- **Session "remember me":** v1 is one fixed duration. Add longer-lived sessions if needed.
+- **WorkOS Organizations:** v1 is single-tenant. Multi-org mapping is feature 4.4 territory if at all.
+- **Refresh tokens:** v1 issues a 24h session and re-prompts. Acceptable for the buyer profile.
+- **Webhook signature verification consolidation:** out of scope for SSO; webhook auth is unchanged.

--- a/packages/cli/src/__tests__/sso-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/sso-bootstrap.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
+
+// Stub the core module so we don't actually hit WorkOS during tests.
+vi.mock("@urateam/core", async () => {
+  const actual = await vi.importActual<typeof import("@urateam/core")>(
+    "@urateam/core",
+  );
+  return {
+    ...actual,
+    getDefaultWorkosClient: vi.fn(async (_apiKey: string) => ({
+      getAuthorizationUrl: async () => "https://stub/auth",
+      authenticateWithCode: async () => ({
+        user: {
+          id: "u",
+          email: "u@example.com",
+          firstName: null,
+          lastName: null,
+        },
+      }),
+    })),
+  };
+});
+
+const FULL_ENV: NodeJS.ProcessEnv = {
+  URATEAM_SSO_ENABLED: "true",
+  URATEAM_WORKOS_API_KEY: "sk_test",
+  URATEAM_WORKOS_CLIENT_ID: "client_test",
+  URATEAM_WORKOS_REDIRECT_URI: "https://dash.example.com/auth/callback",
+  URATEAM_SSO_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+};
+
+// The first dynamic import("@urateam/core") in a worker is slow (~3s) because
+// it pulls in the whole core barrel. Give each test 15s of headroom.
+describe("bootstrapSsoFromEnv", { timeout: 15_000 }, () => {
+  let exitSpy: any;
+  let errorSpy: any;
+
+  beforeEach(() => {
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((_code?: number) => {
+        throw new Error("__EXIT__");
+      }) as never);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("returns undefined when SSO is not enabled", async () => {
+    const result = await bootstrapSsoFromEnv({});
+    expect(result).toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns sso config + workos client when all env vars are present", async () => {
+    const result = await bootstrapSsoFromEnv({ ...FULL_ENV });
+    expect(result).toBeDefined();
+    expect(result!.sso.enabled).toBe(true);
+    expect(result!.sso.workosClientId).toBe("client_test");
+    expect(result!.sso.redirectUri).toBe(
+      "https://dash.example.com/auth/callback",
+    );
+    expect(result!.workos).toBeDefined();
+    expect(typeof result!.workos.getAuthorizationUrl).toBe("function");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits when URATEAM_WORKOS_API_KEY is missing", async () => {
+    const env = { ...FULL_ENV };
+    delete env.URATEAM_WORKOS_API_KEY;
+    await expect(bootstrapSsoFromEnv(env)).rejects.toThrow("__EXIT__");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalled();
+    const msg = errorSpy.mock.calls[0]!.join(" ");
+    expect(msg).toContain("URATEAM_WORKOS_API_KEY");
+  });
+
+  it("exits when URATEAM_SSO_STATE_SECRET is missing", async () => {
+    const env = { ...FULL_ENV };
+    delete env.URATEAM_SSO_STATE_SECRET;
+    await expect(bootstrapSsoFromEnv(env)).rejects.toThrow("__EXIT__");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("accepts optional allowedDomain", async () => {
+    const result = await bootstrapSsoFromEnv({
+      ...FULL_ENV,
+      URATEAM_SSO_ALLOWED_DOMAIN: "acme.com",
+    });
+    expect(result!.sso.allowedDomain).toBe("acme.com");
+  });
+});

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
 
 export const devCommand = new Command("dev")
   .description("Start local development server (webhook + dashboard)")
@@ -54,11 +55,14 @@ export const devCommand = new Command("dev")
     };
 
     const { app, db } = await createApp(config);
+    const ssoBootstrap = await bootstrapSsoFromEnv();
     const dashboardApp = createDashboard({
       db,
       pipelineConfigs: config.pipelineConfigs,
       repoConfigs: config.repoConfigs,
       auth: dashboardAuth,
+      sso: ssoBootstrap?.sso,
+      workos: ssoBootstrap?.workos,
     });
 
     const { serve } = await import("@hono/node-server");

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -54,8 +54,10 @@ export const devCommand = new Command("dev")
       githubWebhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
     };
 
-    const { app, db } = await createApp(config);
+    // Validate SSO env vars before opening DB so misconfig fails fast.
     const ssoBootstrap = await bootstrapSsoFromEnv();
+
+    const { app, db } = await createApp(config);
     const dashboardApp = createDashboard({
       db,
       pipelineConfigs: config.pipelineConfigs,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -150,6 +150,11 @@ export const startCommand = new Command("start")
       githubWebhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
     };
 
+    // --- SSO (Enterprise, opt-in via URATEAM_SSO_ENABLED=true) ---
+    // Validate SSO env vars BEFORE opening the DB / starting the runner so a
+    // misconfigured deployment fails fast without leaking resources.
+    const ssoBootstrap = await bootstrapSsoFromEnv();
+
     // --- Start servers ---
     const { app, runner, db } = await createApp(config);
 
@@ -158,8 +163,6 @@ export const startCommand = new Command("start")
     const port = parseInt(process.env.PORT ?? options.port, 10);
     const dashboardPort = parseInt(process.env.DASHBOARD_PORT ?? options.dashboardPort, 10);
 
-    // --- SSO (Enterprise, opt-in via URATEAM_SSO_ENABLED=true) ---
-    const ssoBootstrap = await bootstrapSsoFromEnv();
     const dashboardApp = createDashboard({
       db,
       pipelineConfigs: config.pipelineConfigs,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
+import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
 
 export const startCommand = new Command("start")
   .description("Start production server (webhook + dashboard)")
@@ -157,12 +158,19 @@ export const startCommand = new Command("start")
     const port = parseInt(process.env.PORT ?? options.port, 10);
     const dashboardPort = parseInt(process.env.DASHBOARD_PORT ?? options.dashboardPort, 10);
 
+    // --- SSO (Enterprise, opt-in via URATEAM_SSO_ENABLED=true) ---
+    const ssoBootstrap = await bootstrapSsoFromEnv();
     const dashboardApp = createDashboard({
       db,
       pipelineConfigs: config.pipelineConfigs,
       repoConfigs: config.repoConfigs,
       auth: dashboardAuth,
+      sso: ssoBootstrap?.sso,
+      workos: ssoBootstrap?.workos,
     });
+    if (ssoBootstrap) {
+      console.log(`SSO: enabled (WorkOS client ${ssoBootstrap.sso.workosClientId})`);
+    }
 
     console.log(`Linear Agent Framework starting`);
     console.log(`Webhook:   http://localhost:${port}`);

--- a/packages/cli/src/sso-bootstrap.ts
+++ b/packages/cli/src/sso-bootstrap.ts
@@ -1,0 +1,73 @@
+import type { SsoConfig, WorkosClient } from "@urateam/core";
+
+export interface SsoBootstrapResult {
+  sso: SsoConfig;
+  workos: WorkosClient;
+}
+
+/**
+ * Read SSO-related env vars and, if `URATEAM_SSO_ENABLED === "true"`, build a
+ * validated `SsoConfig` and resolve a default WorkOS client. If SSO is
+ * disabled, returns `undefined`. If SSO is enabled but a required env var is
+ * missing, logs an error and exits the process (per spec § 6).
+ *
+ * Required env vars when enabled:
+ *   - URATEAM_WORKOS_API_KEY
+ *   - URATEAM_WORKOS_CLIENT_ID
+ *   - URATEAM_WORKOS_REDIRECT_URI
+ *   - URATEAM_SSO_STATE_SECRET
+ * Optional:
+ *   - URATEAM_SSO_ALLOWED_DOMAIN
+ *   - URATEAM_SSO_SESSION_HOURS (default 24)
+ *   - URATEAM_SSO_COOKIE_NAME (default "urateam_session")
+ *   - URATEAM_SSO_COOKIE_SECURE (default "true")
+ */
+export async function bootstrapSsoFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<SsoBootstrapResult | undefined> {
+  if (env.URATEAM_SSO_ENABLED !== "true") return undefined;
+
+  const required = {
+    URATEAM_WORKOS_API_KEY: env.URATEAM_WORKOS_API_KEY,
+    URATEAM_WORKOS_CLIENT_ID: env.URATEAM_WORKOS_CLIENT_ID,
+    URATEAM_WORKOS_REDIRECT_URI: env.URATEAM_WORKOS_REDIRECT_URI,
+    URATEAM_SSO_STATE_SECRET: env.URATEAM_SSO_STATE_SECRET,
+  };
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length > 0) {
+    console.error(
+      `URATEAM_SSO_ENABLED=true but the following env vars are missing: ${missing.join(", ")}. ` +
+        `Set them and restart, or unset URATEAM_SSO_ENABLED to run without SSO.`,
+    );
+    process.exit(1);
+  }
+
+  const { SsoConfigSchema, getDefaultWorkosClient } = await import(
+    "@urateam/core"
+  );
+
+  let sso: SsoConfig;
+  try {
+    sso = SsoConfigSchema.parse({
+      enabled: true,
+      workosApiKey: required.URATEAM_WORKOS_API_KEY,
+      workosClientId: required.URATEAM_WORKOS_CLIENT_ID,
+      redirectUri: required.URATEAM_WORKOS_REDIRECT_URI,
+      allowedDomain: env.URATEAM_SSO_ALLOWED_DOMAIN || undefined,
+      sessionDurationHours: env.URATEAM_SSO_SESSION_HOURS
+        ? parseInt(env.URATEAM_SSO_SESSION_HOURS, 10)
+        : 24,
+      cookieName: env.URATEAM_SSO_COOKIE_NAME || "urateam_session",
+      cookieSecure: env.URATEAM_SSO_COOKIE_SECURE !== "false",
+      stateSigningSecret: required.URATEAM_SSO_STATE_SECRET,
+    });
+  } catch (err) {
+    console.error("SSO config validation failed:", (err as Error).message);
+    process.exit(1);
+  }
+
+  const workos = await getDefaultWorkosClient(sso.workosApiKey);
+  return { sso, workos };
+}

--- a/packages/cli/src/sso-bootstrap.ts
+++ b/packages/cli/src/sso-bootstrap.ts
@@ -22,16 +22,34 @@ export interface SsoBootstrapResult {
  *   - URATEAM_SSO_COOKIE_NAME (default "urateam_session")
  *   - URATEAM_SSO_COOKIE_SECURE (default "true")
  */
+function trimEnv(v: string | undefined): string | undefined {
+  return v?.trim() || undefined;
+}
+
 export async function bootstrapSsoFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<SsoBootstrapResult | undefined> {
-  if (env.URATEAM_SSO_ENABLED !== "true") return undefined;
+  const enabledRaw = trimEnv(env.URATEAM_SSO_ENABLED);
+  if (!enabledRaw) return undefined;
+  const enabledLower = enabledRaw.toLowerCase();
+  if (enabledLower !== "true") {
+    // Refuse silently-falsy values like "false"/"no"/"0" without warning,
+    // but anything else is almost certainly a misconfigured truthy value
+    // (e.g. "True", "yes", "1") — warn loudly so it shows up in startup logs.
+    if (!["false", "no", "0", "off"].includes(enabledLower)) {
+      console.warn(
+        `URATEAM_SSO_ENABLED=${enabledRaw} is not a recognized boolean. ` +
+          `SSO will NOT be enabled. Use "true" to enable.`,
+      );
+    }
+    return undefined;
+  }
 
   const required = {
-    URATEAM_WORKOS_API_KEY: env.URATEAM_WORKOS_API_KEY,
-    URATEAM_WORKOS_CLIENT_ID: env.URATEAM_WORKOS_CLIENT_ID,
-    URATEAM_WORKOS_REDIRECT_URI: env.URATEAM_WORKOS_REDIRECT_URI,
-    URATEAM_SSO_STATE_SECRET: env.URATEAM_SSO_STATE_SECRET,
+    URATEAM_WORKOS_API_KEY: trimEnv(env.URATEAM_WORKOS_API_KEY),
+    URATEAM_WORKOS_CLIENT_ID: trimEnv(env.URATEAM_WORKOS_CLIENT_ID),
+    URATEAM_WORKOS_REDIRECT_URI: trimEnv(env.URATEAM_WORKOS_REDIRECT_URI),
+    URATEAM_SSO_STATE_SECRET: trimEnv(env.URATEAM_SSO_STATE_SECRET),
   };
   const missing = Object.entries(required)
     .filter(([, v]) => !v)
@@ -55,7 +73,7 @@ export async function bootstrapSsoFromEnv(
       workosApiKey: required.URATEAM_WORKOS_API_KEY,
       workosClientId: required.URATEAM_WORKOS_CLIENT_ID,
       redirectUri: required.URATEAM_WORKOS_REDIRECT_URI,
-      allowedDomain: env.URATEAM_SSO_ALLOWED_DOMAIN || undefined,
+      allowedDomain: trimEnv(env.URATEAM_SSO_ALLOWED_DOMAIN),
       sessionDurationHours: env.URATEAM_SSO_SESSION_HOURS
         ? parseInt(env.URATEAM_SSO_SESSION_HOURS, 10)
         : 24,

--- a/packages/core/src/__tests__/audit/sso-events.test.ts
+++ b/packages/core/src/__tests__/audit/sso-events.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  dashboardLoginEvent,
+  dashboardLogoutEvent,
+  dashboardLoginDeniedEvent,
+} from "../../audit/events.js";
+
+describe("SSO audit event builders", () => {
+  describe("dashboardLoginEvent", () => {
+    it("builds a dashboard.login event with user details in payload", () => {
+      const evt = dashboardLoginEvent({
+        userId: "user_123",
+        email: "alice@example.com",
+        workosUserId: "workos_abc",
+      });
+
+      expect(evt.eventType).toBe("dashboard.login");
+      expect(evt.actorType).toBe("dashboard-user");
+      expect(evt.actor).toBe("dashboard:alice@example.com");
+      expect(evt.payload).toEqual({
+        userId: "user_123",
+        email: "alice@example.com",
+        workosUserId: "workos_abc",
+      });
+      expect(evt.id).toMatch(/^evt_/);
+      expect(evt.timestamp).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("dashboardLogoutEvent", () => {
+    it("builds a dashboard.logout event with userId in payload", () => {
+      const evt = dashboardLogoutEvent({
+        userId: "user_123",
+        email: "alice@example.com",
+      });
+
+      expect(evt.eventType).toBe("dashboard.logout");
+      expect(evt.actorType).toBe("dashboard-user");
+      expect(evt.actor).toBe("dashboard:alice@example.com");
+      expect(evt.payload).toEqual({ userId: "user_123" });
+    });
+  });
+
+  describe("dashboardLoginDeniedEvent", () => {
+    it("builds a dashboard.login_denied event without userId", () => {
+      const evt = dashboardLoginDeniedEvent({
+        email: "intruder@evil.example",
+        reason: "domain-mismatch",
+      });
+
+      expect(evt.eventType).toBe("dashboard.login_denied");
+      expect(evt.actorType).toBe("dashboard-user");
+      expect(evt.actor).toBe("dashboard:intruder@evil.example");
+      expect(evt.payload).toEqual({ reason: "domain-mismatch" });
+      expect(evt.payload).not.toHaveProperty("userId");
+    });
+  });
+});

--- a/packages/core/src/__tests__/auth/session-store.test.ts
+++ b/packages/core/src/__tests__/auth/session-store.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { upsertUser } from "../../auth/user-store.js";
+import {
+  createSession,
+  getSession,
+  deleteSession,
+  pruneExpiredSessions,
+  touchSessionLastSeen,
+} from "../../auth/session-store.js";
+
+let db: any;
+let userId: string;
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  userId = await upsertUser(db, {
+    email: "a@b.com",
+    name: "A",
+    workosUserId: null,
+  });
+});
+
+describe("session-store", () => {
+  it("creates a session and reads it back", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    expect(sid).toBeTruthy();
+    expect(sid.length).toBeGreaterThan(20);
+    const s = await getSession(db, sid);
+    expect(s?.userId).toBe(userId);
+    expect(s?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("returns null for unknown session id", async () => {
+    expect(await getSession(db, "nope")).toBeNull();
+  });
+
+  it("returns null for expired sessions", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    await deleteSession(db, sid);
+    const { dashboardSessions } = await import("../../db/schema.js");
+    await (db as any).insert(dashboardSessions).values({
+      id: sid,
+      userId,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await getSession(db, sid)).toBeNull();
+  });
+
+  it("deleteSession removes the row", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    await deleteSession(db, sid);
+    expect(await getSession(db, sid)).toBeNull();
+  });
+
+  it("pruneExpiredSessions removes only expired rows", async () => {
+    const live = await createSession(db, { userId, durationHours: 24 });
+    const dead = "sess_dead";
+    const { dashboardSessions } = await import("../../db/schema.js");
+    await (db as any).insert(dashboardSessions).values({
+      id: dead,
+      userId,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const deleted = await pruneExpiredSessions(db);
+    expect(deleted).toBe(1);
+    expect(await getSession(db, live)).not.toBeNull();
+  });
+
+  it("touchSessionLastSeen updates lastSeenAt", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    const before = (await getSession(db, sid))!.lastSeenAt;
+    await new Promise((r) => setTimeout(r, 50));
+    await touchSessionLastSeen(db, sid);
+    const after = (await getSession(db, sid))!.lastSeenAt;
+    expect(after.getTime()).toBeGreaterThanOrEqual(before.getTime());
+  });
+});

--- a/packages/core/src/__tests__/auth/sso-config.test.ts
+++ b/packages/core/src/__tests__/auth/sso-config.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { SsoConfigSchema } from "../../types.js";
+import { signState, verifyState, validateNextPath } from "../../auth/sso-config.js";
+
+const validConfig = {
+  enabled: true,
+  workosApiKey: "sk_test_xxx",
+  workosClientId: "client_xxx",
+  redirectUri: "https://example.com/auth/callback",
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+describe("SsoConfigSchema", () => {
+  it("parses a valid config", () => {
+    const parsed = SsoConfigSchema.parse(validConfig);
+    expect(parsed.sessionDurationHours).toBe(24);
+    expect(parsed.cookieName).toBe("urateam_session");
+    expect(parsed.cookieSecure).toBe(true);
+  });
+
+  it("rejects missing apiKey", () => {
+    const bad = { ...validConfig } as any;
+    delete bad.workosApiKey;
+    expect(() => SsoConfigSchema.parse(bad)).toThrow();
+  });
+
+  it("rejects non-url redirectUri", () => {
+    expect(() => SsoConfigSchema.parse({ ...validConfig, redirectUri: "not-a-url" })).toThrow();
+  });
+});
+
+describe("signState / verifyState", () => {
+  const secret = "0123456789abcdef0123456789abcdef";
+
+  it("round-trips a payload", () => {
+    const signed = signState({ next: "/runs", nonce: "abc" }, secret);
+    const verified = verifyState(signed, secret);
+    expect(verified).toEqual({ next: "/runs", nonce: "abc" });
+  });
+
+  it("rejects a tampered payload", () => {
+    const signed = signState({ next: "/runs", nonce: "abc" }, secret);
+    // Flip the first char of the payload portion to simulate tampering.
+    // (Plan's original `.replace("/runs", "/evil")` is a no-op because the
+    // payload is base64url-encoded and contains no "/runs" substring.)
+    const tampered = (signed[0] === "a" ? "b" : "a") + signed.slice(1);
+    expect(verifyState(tampered, secret)).toBeNull();
+  });
+
+  it("rejects a wrong-secret signature", () => {
+    const signed = signState({ next: "/runs", nonce: "abc" }, secret);
+    expect(verifyState(signed, "different-secret-1234567890abcdef")).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(verifyState("garbage", secret)).toBeNull();
+    expect(verifyState("no.dot", secret)).toBeNull();
+    expect(verifyState("", secret)).toBeNull();
+  });
+});
+
+describe("validateNextPath", () => {
+  it("accepts same-origin absolute paths", () => {
+    expect(validateNextPath("/")).toBe("/");
+    expect(validateNextPath("/runs")).toBe("/runs");
+    expect(validateNextPath("/runs/123")).toBe("/runs/123");
+  });
+
+  it("rejects scheme-relative URLs", () => {
+    expect(validateNextPath("//evil.com")).toBe("/");
+    expect(validateNextPath("//evil.com/path")).toBe("/");
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(validateNextPath("https://evil.com")).toBe("/");
+    expect(validateNextPath("http://evil.com")).toBe("/");
+  });
+
+  it("rejects backslash variants", () => {
+    expect(validateNextPath("/\\evil.com")).toBe("/");
+    expect(validateNextPath("\\\\evil.com")).toBe("/");
+  });
+
+  it("falls back to / for empty / nullish", () => {
+    expect(validateNextPath("")).toBe("/");
+    expect(validateNextPath(undefined as any)).toBe("/");
+  });
+});

--- a/packages/core/src/__tests__/auth/sso-feature-flag.test.ts
+++ b/packages/core/src/__tests__/auth/sso-feature-flag.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isFeatureLicensed, checkLicense } from "../../license.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+describe("sso feature flag", () => {
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("is licensed under enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    expect(checkLicense().tier).toBe("enterprise");
+    expect(isFeatureLicensed("sso")).toBe(true);
+  });
+
+  it("is NOT licensed under pro tier", async () => {
+    await installTestProLicense("pro");
+    expect(checkLicense().tier).toBe("pro");
+    expect(isFeatureLicensed("sso")).toBe(false);
+  });
+
+  it("is NOT licensed under oss (no license)", async () => {
+    // restore first to ensure no license env
+    await restoreLicense();
+    delete process.env.URATEAM_LICENSE_KEY;
+    const { _resetLicenseCache } = await import("../../license.js");
+    _resetLicenseCache();
+    expect(checkLicense().tier).toBe("oss");
+    expect(isFeatureLicensed("sso")).toBe(false);
+  });
+
+  it("is re-exported from the @urateam/core barrel", async () => {
+    const core = await import("../../index.js");
+    expect(typeof (core as Record<string, unknown>).upsertUser).toBe("function");
+    expect(typeof (core as Record<string, unknown>).createSession).toBe("function");
+  });
+});

--- a/packages/core/src/__tests__/auth/user-store.test.ts
+++ b/packages/core/src/__tests__/auth/user-store.test.ts
@@ -88,6 +88,30 @@ describe("user-store", () => {
     expect(fetched).toBeNull();
   });
 
+  it("is race-safe when two concurrent upserts arrive for the same email", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const [idA, idB] = await Promise.all([
+      upsertUser(db, {
+        email: "race@example.com",
+        name: "Race A",
+        workosUserId: "workos_race_a",
+      }),
+      upsertUser(db, {
+        email: "race@example.com",
+        name: "Race B",
+        workosUserId: "workos_race_b",
+      }),
+    ]);
+    expect(idA).toBe(idB);
+    const user = await getUserById(db, idA);
+    expect(user).not.toBeNull();
+    expect(user!.email).toBe("race@example.com");
+    // Exactly one row in the table — no UNIQUE violation, no duplicate.
+    const { dashboardUsers } = await import("../../db/schema.js");
+    const rows = await (db as any).select().from(dashboardUsers);
+    expect(rows).toHaveLength(1);
+  });
+
   it("upsertUser accepts null name and workosUserId", async () => {
     const db = await createDb({ connectionString: ":memory:" });
     const id = await upsertUser(db, {

--- a/packages/core/src/__tests__/auth/user-store.test.ts
+++ b/packages/core/src/__tests__/auth/user-store.test.ts
@@ -3,76 +3,82 @@ import { createDb } from "../../db/client.js";
 import { upsertUser, getUserById } from "../../auth/user-store.js";
 
 describe("user-store", () => {
-  it("inserts a new user and returns it with a usr_ id", async () => {
+  it("inserts a new user and returns a usr_ id", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    const user = await upsertUser(db, {
+    const id = await upsertUser(db, {
       email: "alice@example.com",
       name: "Alice",
       workosUserId: "workos_1",
     });
-    expect(user.id).toMatch(/^usr_/);
-    expect(user.email).toBe("alice@example.com");
-    expect(user.name).toBe("Alice");
-    expect(user.workosUserId).toBe("workos_1");
-    expect(user.createdAt).toBeInstanceOf(Date);
+    expect(id).toMatch(/^usr_/);
+    const user = await getUserById(db, id);
+    expect(user).not.toBeNull();
+    expect(user!.email).toBe("alice@example.com");
+    expect(user!.name).toBe("Alice");
+    expect(user!.workosUserId).toBe("workos_1");
+    expect(user!.createdAt).toBeInstanceOf(Date);
   });
 
   it("normalizes email to lowercase on insert", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    const user = await upsertUser(db, {
+    const id = await upsertUser(db, {
       email: "Bob@Example.COM",
       name: "Bob",
       workosUserId: "workos_2",
     });
-    expect(user.email).toBe("bob@example.com");
+    const user = await getUserById(db, id);
+    expect(user!.email).toBe("bob@example.com");
   });
 
   it("updates existing user when email already exists (case-insensitive)", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    const first = await upsertUser(db, {
+    const firstId = await upsertUser(db, {
       email: "carol@example.com",
       name: "Carol",
       workosUserId: "workos_3",
     });
-    const second = await upsertUser(db, {
+    const secondId = await upsertUser(db, {
       email: "CAROL@example.com",
       name: "Carol Updated",
       workosUserId: "workos_3b",
     });
-    expect(second.id).toBe(first.id);
-    expect(second.name).toBe("Carol Updated");
-    expect(second.workosUserId).toBe("workos_3b");
-    expect(second.email).toBe("carol@example.com");
+    expect(secondId).toBe(firstId);
+    const user = await getUserById(db, secondId);
+    expect(user!.name).toBe("Carol Updated");
+    expect(user!.workosUserId).toBe("workos_3b");
+    expect(user!.email).toBe("carol@example.com");
   });
 
   it("updates lastLoginAt on upsert of existing user", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    const first = await upsertUser(db, {
+    const firstId = await upsertUser(db, {
       email: "dave@example.com",
       name: "Dave",
       workosUserId: "workos_4",
     });
-    expect(first.lastLoginAt).toBeInstanceOf(Date);
-    const firstLogin = first.lastLoginAt!.getTime();
+    const first = await getUserById(db, firstId);
+    expect(first!.lastLoginAt).toBeInstanceOf(Date);
+    const firstLogin = first!.lastLoginAt!.getTime();
     await new Promise((r) => setTimeout(r, 5));
-    const second = await upsertUser(db, {
+    const secondId = await upsertUser(db, {
       email: "dave@example.com",
       name: "Dave",
       workosUserId: "workos_4",
     });
-    expect(second.lastLoginAt!.getTime()).toBeGreaterThanOrEqual(firstLogin);
+    const second = await getUserById(db, secondId);
+    expect(second!.lastLoginAt!.getTime()).toBeGreaterThanOrEqual(firstLogin);
   });
 
   it("getUserById returns the user when found", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    const created = await upsertUser(db, {
+    const id = await upsertUser(db, {
       email: "eve@example.com",
       name: "Eve",
       workosUserId: "workos_5",
     });
-    const fetched = await getUserById(db, created.id);
+    const fetched = await getUserById(db, id);
     expect(fetched).not.toBeNull();
-    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.id).toBe(id);
     expect(fetched!.email).toBe("eve@example.com");
   });
 
@@ -84,12 +90,13 @@ describe("user-store", () => {
 
   it("upsertUser accepts null name and workosUserId", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    const user = await upsertUser(db, {
+    const id = await upsertUser(db, {
       email: "frank@example.com",
       name: null,
       workosUserId: null,
     });
-    expect(user.name).toBeNull();
-    expect(user.workosUserId).toBeNull();
+    const user = await getUserById(db, id);
+    expect(user!.name).toBeNull();
+    expect(user!.workosUserId).toBeNull();
   });
 });

--- a/packages/core/src/__tests__/auth/user-store.test.ts
+++ b/packages/core/src/__tests__/auth/user-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { upsertUser, getUserById } from "../../auth/user-store.js";
+
+describe("user-store", () => {
+  it("inserts a new user and returns it with a usr_ id", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const user = await upsertUser(db, {
+      email: "alice@example.com",
+      name: "Alice",
+      workosUserId: "workos_1",
+    });
+    expect(user.id).toMatch(/^usr_/);
+    expect(user.email).toBe("alice@example.com");
+    expect(user.name).toBe("Alice");
+    expect(user.workosUserId).toBe("workos_1");
+    expect(user.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("normalizes email to lowercase on insert", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const user = await upsertUser(db, {
+      email: "Bob@Example.COM",
+      name: "Bob",
+      workosUserId: "workos_2",
+    });
+    expect(user.email).toBe("bob@example.com");
+  });
+
+  it("updates existing user when email already exists (case-insensitive)", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const first = await upsertUser(db, {
+      email: "carol@example.com",
+      name: "Carol",
+      workosUserId: "workos_3",
+    });
+    const second = await upsertUser(db, {
+      email: "CAROL@example.com",
+      name: "Carol Updated",
+      workosUserId: "workos_3b",
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.name).toBe("Carol Updated");
+    expect(second.workosUserId).toBe("workos_3b");
+    expect(second.email).toBe("carol@example.com");
+  });
+
+  it("updates lastLoginAt on upsert of existing user", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const first = await upsertUser(db, {
+      email: "dave@example.com",
+      name: "Dave",
+      workosUserId: "workos_4",
+    });
+    expect(first.lastLoginAt).toBeInstanceOf(Date);
+    const firstLogin = first.lastLoginAt!.getTime();
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await upsertUser(db, {
+      email: "dave@example.com",
+      name: "Dave",
+      workosUserId: "workos_4",
+    });
+    expect(second.lastLoginAt!.getTime()).toBeGreaterThanOrEqual(firstLogin);
+  });
+
+  it("getUserById returns the user when found", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const created = await upsertUser(db, {
+      email: "eve@example.com",
+      name: "Eve",
+      workosUserId: "workos_5",
+    });
+    const fetched = await getUserById(db, created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.email).toBe("eve@example.com");
+  });
+
+  it("getUserById returns null when not found", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const fetched = await getUserById(db, "usr_nonexistent");
+    expect(fetched).toBeNull();
+  });
+
+  it("upsertUser accepts null name and workosUserId", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const user = await upsertUser(db, {
+      email: "frank@example.com",
+      name: null,
+      workosUserId: null,
+    });
+    expect(user.name).toBeNull();
+    expect(user.workosUserId).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/auth/workos-client.test.ts
+++ b/packages/core/src/__tests__/auth/workos-client.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { type WorkosClient } from "../../auth/workos-client.js";
+
+describe("WorkosClient interface", () => {
+  it("the type allows a stub implementation", () => {
+    const stub: WorkosClient = {
+      async getAuthorizationUrl(args) {
+        return `https://workos.example/authz?state=${args.state}&client=${args.clientId}`;
+      },
+      async authenticateWithCode(_args) {
+        return {
+          user: { id: "wu_test", email: "a@b.com", firstName: "A", lastName: "B" },
+        };
+      },
+    };
+    expect(stub).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/db-sso-schema.test.ts
+++ b/packages/core/src/__tests__/db-sso-schema.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { dashboardUsers, dashboardSessions } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("sso schema", () => {
+  it("creates dashboard_users and dashboard_sessions tables on fresh SQLite db", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const userCols = (db as any).all(
+      sql`PRAGMA table_info(dashboard_users)`,
+    ) as Array<{ name: string }>;
+    expect(userCols.map((c) => c.name).sort()).toEqual([
+      "created_at",
+      "email",
+      "id",
+      "last_login_at",
+      "name",
+      "workos_user_id",
+    ]);
+    const sessionCols = (db as any).all(
+      sql`PRAGMA table_info(dashboard_sessions)`,
+    ) as Array<{ name: string }>;
+    expect(sessionCols.map((c) => c.name).sort()).toEqual([
+      "created_at",
+      "expires_at",
+      "id",
+      "last_seen_at",
+      "user_id",
+    ]);
+  });
+
+  it("inserts and reads back a user + session", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_1",
+      email: "a@b.com",
+      name: "A B",
+      workosUserId: "wu_1",
+    });
+    await (db as any).insert(dashboardSessions).values({
+      id: "s_1",
+      userId: "u_1",
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+    const users = await (db as any).select().from(dashboardUsers);
+    expect(users).toHaveLength(1);
+    expect(users[0].email).toBe("a@b.com");
+    const sessions = await (db as any).select().from(dashboardSessions);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].userId).toBe("u_1");
+  });
+});

--- a/packages/core/src/__tests__/pm-sso-prune-step.test.ts
+++ b/packages/core/src/__tests__/pm-sso-prune-step.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPmScheduler } from "../pm/scheduler.js";
+import { createDb } from "../db/client.js";
+import { dashboardSessions } from "../db/schema.js";
+import { upsertUser } from "../auth/index.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+function stubActions() {
+  return {
+    evaluateBudget: vi.fn().mockResolvedValue({
+      scopes: [
+        {
+          scope: { kind: "global" as const },
+          scopeLabel: "global",
+          limit: 100,
+          used: 0,
+          percent: 0,
+          tier: "ok" as const,
+        },
+      ],
+      worstTier: "ok" as const,
+      promoteBlocked: false,
+      activeCount: 0,
+    }),
+    recoverRetriableRuns: vi.fn().mockResolvedValue({ recovered: [], exhausted: [] }),
+    recoverStuckInProgressIssues: vi.fn().mockResolvedValue([]),
+    triageNewIssues: vi.fn().mockResolvedValue([]),
+    resolveApprovals: vi.fn().mockResolvedValue({ resolved: 0, stillPending: 0 }),
+    promoteReadyIssues: vi.fn().mockResolvedValue([]),
+    deprioritizeStaleIssues: vi.fn().mockResolvedValue([]),
+    cancelAbandonedIssues: vi.fn().mockResolvedValue([]),
+    postDigest: vi.fn().mockResolvedValue(undefined),
+    getActiveFileMaps: vi.fn().mockResolvedValue(new Map()),
+    predictConflict: vi.fn().mockResolvedValue({ overlapRisk: "none", likelyFiles: [], reasoning: "" }),
+  };
+}
+
+function baseConfig(extra: Record<string, unknown> = {}): any {
+  return {
+    enabled: true,
+    cronIntervalMs: 1800000,
+    triageBatchSize: 3,
+    maxInFlight: 3,
+    dailyTokenBudget: 100,
+    slackChannelId: "C123",
+    teamIds: ["team-1"],
+    ...extra,
+  };
+}
+
+describe("pm tick session prune sweep", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("deletes expired dashboard sessions and keeps live ones", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const userId = await upsertUser(db as any, {
+      email: "u@example.com",
+      name: "U",
+      workosUserId: null,
+    });
+
+    await (db as any).insert(dashboardSessions).values([
+      {
+        id: "expired-session",
+        userId,
+        expiresAt: new Date(Date.now() - 60_000),
+        lastSeenAt: new Date(Date.now() - 120_000),
+      },
+      {
+        id: "live-session",
+        userId,
+        expiresAt: new Date(Date.now() + 3600_000),
+        lastSeenAt: new Date(),
+      },
+    ]);
+
+    const scheduler = createPmScheduler({
+      config: baseConfig(),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await scheduler.tick();
+
+    const rows = await (db as any).select().from(dashboardSessions);
+    const ids = rows.map((r: any) => r.id);
+    expect(ids).not.toContain("expired-session");
+    expect(ids).toContain("live-session");
+  });
+
+  it("tick does not throw when session prune fails", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    // Break the dashboard_sessions table so pruneExpiredSessions throws.
+    await (db as any).run?.("DROP TABLE dashboard_sessions");
+
+    const scheduler = createPmScheduler({
+      config: baseConfig(),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -123,6 +123,47 @@ export function licenseValidationFailedEvent(args: {
   });
 }
 
+export function dashboardLoginEvent(args: {
+  userId: string;
+  email: string;
+  workosUserId: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.login",
+    actor: `dashboard:${args.email}`,
+    actorType: "dashboard-user",
+    payload: {
+      userId: args.userId,
+      email: args.email,
+      workosUserId: args.workosUserId,
+    },
+  });
+}
+
+export function dashboardLogoutEvent(args: {
+  userId: string;
+  email: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.logout",
+    actor: `dashboard:${args.email}`,
+    actorType: "dashboard-user",
+    payload: { userId: args.userId },
+  });
+}
+
+export function dashboardLoginDeniedEvent(args: {
+  email: string;
+  reason: "domain-mismatch";
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.login_denied",
+    actor: `dashboard:${args.email}`,
+    actorType: "dashboard-user",
+    payload: { reason: args.reason },
+  });
+}
+
 export function configLoadedEvent(args: {
   path: string;
   sha256: string;

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,3 +1,4 @@
 export * from "./sso-config.js";
 export * from "./user-store.js";
 export * from "./session-store.js";
+export * from "./workos-client.js";

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,2 +1,3 @@
 export * from "./sso-config.js";
 export * from "./user-store.js";
+export * from "./session-store.js";

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,0 +1,1 @@
+export * from "./sso-config.js";

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,1 +1,2 @@
 export * from "./sso-config.js";
+export * from "./user-store.js";

--- a/packages/core/src/auth/session-store.ts
+++ b/packages/core/src/auth/session-store.ts
@@ -79,6 +79,11 @@ export async function touchSessionLastSeen(
       .set({ lastSeenAt: new Date() })
       .where(eq(dashboardSessions.id, id));
   } catch (err) {
-    log.warn({ err, id }, "touchSessionLastSeen failed");
+    // Session IDs are bearer credentials — never log them in full. Log a
+    // short prefix for correlation only.
+    log.warn(
+      { err, idPrefix: id.slice(0, 8) + "…" },
+      "touchSessionLastSeen failed",
+    );
   }
 }

--- a/packages/core/src/auth/session-store.ts
+++ b/packages/core/src/auth/session-store.ts
@@ -1,0 +1,84 @@
+import { randomBytes } from "node:crypto";
+import { and, eq, gt, lt } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { dashboardSessions } from "../db/schema.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "auth.session" });
+
+export interface DashboardSession {
+  id: string;
+  userId: string;
+  createdAt: Date;
+  expiresAt: Date;
+  lastSeenAt: Date;
+}
+
+export async function createSession(
+  db: AnyDb,
+  args: { userId: string; durationHours: number },
+): Promise<string> {
+  const id = randomBytes(32).toString("base64url");
+  const expiresAt = new Date(Date.now() + args.durationHours * 3600_000);
+  await db.insert(dashboardSessions).values({
+    id,
+    userId: args.userId,
+    expiresAt,
+    lastSeenAt: new Date(),
+  });
+  return id;
+}
+
+export async function getSession(
+  db: AnyDb,
+  id: string,
+): Promise<DashboardSession | null> {
+  const rows = await db
+    .select()
+    .from(dashboardSessions)
+    .where(
+      and(
+        eq(dashboardSessions.id, id),
+        gt(dashboardSessions.expiresAt, new Date()),
+      ),
+    );
+  if (rows.length === 0) return null;
+  const r = rows[0]!;
+  return {
+    id: r.id,
+    userId: r.userId,
+    createdAt: r.createdAt,
+    expiresAt: r.expiresAt,
+    lastSeenAt: r.lastSeenAt,
+  };
+}
+
+export async function deleteSession(db: AnyDb, id: string): Promise<void> {
+  await db.delete(dashboardSessions).where(eq(dashboardSessions.id, id));
+}
+
+export async function pruneExpiredSessions(db: AnyDb): Promise<number> {
+  const result = await db
+    .delete(dashboardSessions)
+    .where(lt(dashboardSessions.expiresAt, new Date()));
+  const n =
+    (result as { changes?: number; rowCount?: number })?.changes ??
+    (result as { changes?: number; rowCount?: number })?.rowCount ??
+    0;
+  log.info({ deleted: n }, "expired sessions pruned");
+  return n;
+}
+
+export async function touchSessionLastSeen(
+  db: AnyDb,
+  id: string,
+): Promise<void> {
+  try {
+    await db
+      .update(dashboardSessions)
+      .set({ lastSeenAt: new Date() })
+      .where(eq(dashboardSessions.id, id));
+  } catch (err) {
+    log.warn({ err, id }, "touchSessionLastSeen failed");
+  }
+}

--- a/packages/core/src/auth/sso-config.ts
+++ b/packages/core/src/auth/sso-config.ts
@@ -1,0 +1,47 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+interface StatePayload {
+  next: string;
+  nonce: string;
+}
+
+export function signState(payload: StatePayload, secret: string): string {
+  const json = JSON.stringify(payload);
+  const b64 = Buffer.from(json, "utf8").toString("base64url");
+  const hmac = createHmac("sha256", secret).update(b64).digest("base64url");
+  return `${b64}.${hmac}`;
+}
+
+export function verifyState(signed: string, secret: string): StatePayload | null {
+  if (!signed || typeof signed !== "string") return null;
+  const idx = signed.lastIndexOf(".");
+  if (idx <= 0 || idx === signed.length - 1) return null;
+  const b64 = signed.slice(0, idx);
+  const sig = signed.slice(idx + 1);
+  const expected = createHmac("sha256", secret).update(b64).digest("base64url");
+  const sigBuf = Buffer.from(sig, "base64url");
+  const expBuf = Buffer.from(expected, "base64url");
+  if (sigBuf.length !== expBuf.length) return null;
+  if (!timingSafeEqual(sigBuf, expBuf)) return null;
+  try {
+    const json = Buffer.from(b64, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (typeof parsed?.next !== "string" || typeof parsed?.nonce !== "string") return null;
+    return parsed as StatePayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate that `next` is a same-origin absolute path. Reject scheme-relative
+ * (`//evil.com`), absolute (`https://evil.com`), and backslash variants.
+ * Falls back to "/" on any rejection.
+ */
+export function validateNextPath(next: string | undefined | null): string {
+  if (!next || typeof next !== "string") return "/";
+  if (!next.startsWith("/")) return "/";
+  if (next.startsWith("//")) return "/";
+  if (next.startsWith("/\\") || next.includes("\\")) return "/";
+  return next;
+}

--- a/packages/core/src/auth/user-store.ts
+++ b/packages/core/src/auth/user-store.ts
@@ -24,8 +24,14 @@ function normalizeEmail(email: string): string {
 
 /**
  * Insert or update a dashboard user by normalized email. Returns the
- * user id. On update, `name`, `workosUserId`, and `lastLoginAt` are
- * refreshed; `id` and `createdAt` are preserved.
+ * canonical user id. On update, `name`, `workosUserId`, and `lastLoginAt`
+ * are refreshed; `id` and `createdAt` are preserved.
+ *
+ * Implemented as an atomic upsert (`onConflictDoUpdate` on the unique
+ * `email` column) so that two concurrent `/auth/callback` requests for the
+ * same email cannot both see `existing.length === 0` and race on INSERT.
+ * The generated `id` is only used if no row exists; on conflict we read
+ * back the canonical id from the surviving row.
  */
 export async function upsertUser(
   db: AnyDb,
@@ -33,37 +39,35 @@ export async function upsertUser(
 ): Promise<string> {
   const email = normalizeEmail(input.email);
   const now = new Date();
+  const id = `usr_${randomUUID()}`;
 
-  const existing = await db
+  await db
+    .insert(dashboardUsers)
+    .values({
+      id,
+      email,
+      name: input.name,
+      workosUserId: input.workosUserId,
+      createdAt: now,
+      lastLoginAt: now,
+    })
+    .onConflictDoUpdate({
+      target: dashboardUsers.email,
+      set: {
+        name: input.name,
+        workosUserId: input.workosUserId,
+        lastLoginAt: now,
+      },
+    });
+
+  // Read back the canonical id — it may be a pre-existing row's id, not
+  // the one we just generated above.
+  const rows = await db
     .select()
     .from(dashboardUsers)
     .where(eq(dashboardUsers.email, email))
     .limit(1);
-
-  if (existing.length > 0) {
-    const row = existing[0]!;
-    await db
-      .update(dashboardUsers)
-      .set({
-        name: input.name,
-        workosUserId: input.workosUserId,
-        lastLoginAt: now,
-      })
-      .where(eq(dashboardUsers.id, row.id));
-    return row.id;
-  }
-
-  const id = `usr_${randomUUID()}`;
-  await db.insert(dashboardUsers).values({
-    id,
-    email,
-    name: input.name,
-    workosUserId: input.workosUserId,
-    createdAt: now,
-    lastLoginAt: now,
-  });
-
-  return id;
+  return rows[0]!.id;
 }
 
 /**

--- a/packages/core/src/auth/user-store.ts
+++ b/packages/core/src/auth/user-store.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { dashboardUsers } from "../db/schema.js";
+
+export interface DashboardUser {
+  id: string;
+  email: string;
+  name: string | null;
+  workosUserId: string | null;
+  createdAt: Date;
+  lastLoginAt: Date | null;
+}
+
+export interface UpsertUserInput {
+  email: string;
+  name: string | null;
+  workosUserId: string | null;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Insert or update a dashboard user by normalized email. Returns the
+ * resulting row. On update, `name`, `workosUserId`, and `lastLoginAt` are
+ * refreshed; `id` and `createdAt` are preserved.
+ */
+export async function upsertUser(
+  db: AnyDb,
+  input: UpsertUserInput,
+): Promise<DashboardUser> {
+  const email = normalizeEmail(input.email);
+  const now = new Date();
+
+  const existing = await db
+    .select()
+    .from(dashboardUsers)
+    .where(eq(dashboardUsers.email, email))
+    .limit(1);
+
+  if (existing.length > 0) {
+    const row = existing[0]!;
+    await db
+      .update(dashboardUsers)
+      .set({
+        name: input.name,
+        workosUserId: input.workosUserId,
+        lastLoginAt: now,
+      })
+      .where(eq(dashboardUsers.id, row.id));
+    return {
+      id: row.id,
+      email,
+      name: input.name,
+      workosUserId: input.workosUserId,
+      createdAt: row.createdAt,
+      lastLoginAt: now,
+    };
+  }
+
+  const id = `usr_${randomUUID()}`;
+  await db.insert(dashboardUsers).values({
+    id,
+    email,
+    name: input.name,
+    workosUserId: input.workosUserId,
+    createdAt: now,
+    lastLoginAt: now,
+  });
+
+  return {
+    id,
+    email,
+    name: input.name,
+    workosUserId: input.workosUserId,
+    createdAt: now,
+    lastLoginAt: now,
+  };
+}
+
+/**
+ * Look up a dashboard user by id. Returns `null` when not found.
+ */
+export async function getUserById(
+  db: AnyDb,
+  id: string,
+): Promise<DashboardUser | null> {
+  const rows = await db
+    .select()
+    .from(dashboardUsers)
+    .where(eq(dashboardUsers.id, id))
+    .limit(1);
+  if (rows.length === 0) return null;
+  const row = rows[0]!;
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name ?? null,
+    workosUserId: row.workosUserId ?? null,
+    createdAt: row.createdAt,
+    lastLoginAt: row.lastLoginAt ?? null,
+  };
+}

--- a/packages/core/src/auth/user-store.ts
+++ b/packages/core/src/auth/user-store.ts
@@ -24,13 +24,13 @@ function normalizeEmail(email: string): string {
 
 /**
  * Insert or update a dashboard user by normalized email. Returns the
- * resulting row. On update, `name`, `workosUserId`, and `lastLoginAt` are
+ * user id. On update, `name`, `workosUserId`, and `lastLoginAt` are
  * refreshed; `id` and `createdAt` are preserved.
  */
 export async function upsertUser(
   db: AnyDb,
   input: UpsertUserInput,
-): Promise<DashboardUser> {
+): Promise<string> {
   const email = normalizeEmail(input.email);
   const now = new Date();
 
@@ -50,14 +50,7 @@ export async function upsertUser(
         lastLoginAt: now,
       })
       .where(eq(dashboardUsers.id, row.id));
-    return {
-      id: row.id,
-      email,
-      name: input.name,
-      workosUserId: input.workosUserId,
-      createdAt: row.createdAt,
-      lastLoginAt: now,
-    };
+    return row.id;
   }
 
   const id = `usr_${randomUUID()}`;
@@ -70,14 +63,7 @@ export async function upsertUser(
     lastLoginAt: now,
   });
 
-  return {
-    id,
-    email,
-    name: input.name,
-    workosUserId: input.workosUserId,
-    createdAt: now,
-    lastLoginAt: now,
-  };
+  return id;
 }
 
 /**

--- a/packages/core/src/auth/workos-client.ts
+++ b/packages/core/src/auth/workos-client.ts
@@ -1,0 +1,77 @@
+/**
+ * Thin interface over @workos-inc/node so tests can inject a stub
+ * without importing the SDK or hitting the network.
+ */
+export interface WorkosAuthorizeArgs {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+}
+
+export interface WorkosAuthenticateArgs {
+  clientId: string;
+  code: string;
+}
+
+export interface WorkosUserProfile {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+export interface WorkosAuthenticateResult {
+  user: WorkosUserProfile;
+}
+
+export interface WorkosClient {
+  getAuthorizationUrl(args: WorkosAuthorizeArgs): Promise<string>;
+  authenticateWithCode(args: WorkosAuthenticateArgs): Promise<WorkosAuthenticateResult>;
+}
+
+let cached: WorkosClient | null = null;
+
+/**
+ * Default WorkOS client. Lazily instantiates the SDK on first use so test
+ * environments that never call this never need the SDK installed.
+ */
+export async function getDefaultWorkosClient(apiKey: string): Promise<WorkosClient> {
+  if (cached) return cached;
+  // Dynamic import so the dep is loaded only when actually used.
+  // The SDK lives in @urateam/dashboard (the only package that activates SSO),
+  // so core does not declare it as a dependency. Suppress the missing-types
+  // error here — the dashboard provides the resolved module at runtime.
+  // @ts-expect-error — @workos-inc/node is an optional runtime dep provided by dashboard
+  const { WorkOS } = await import("@workos-inc/node");
+  const workos: any = new WorkOS(apiKey);
+  cached = {
+    async getAuthorizationUrl(args) {
+      return workos.userManagement.getAuthorizationUrl({
+        clientId: args.clientId,
+        redirectUri: args.redirectUri,
+        state: args.state,
+        provider: "authkit",
+      });
+    },
+    async authenticateWithCode(args) {
+      const result = await workos.userManagement.authenticateWithCode({
+        clientId: args.clientId,
+        code: args.code,
+      });
+      return {
+        user: {
+          id: result.user.id,
+          email: result.user.email,
+          firstName: result.user.firstName ?? null,
+          lastName: result.user.lastName ?? null,
+        },
+      };
+    },
+  };
+  return cached;
+}
+
+/** Test-only: reset the cached client. */
+export function _resetWorkosClient(): void {
+  cached = null;
+}

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -182,6 +182,26 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
   CREATE INDEX IF NOT EXISTS idx_audit_events_type_ts ON audit_events(event_type, timestamp DESC);
   CREATE INDEX IF NOT EXISTS idx_audit_events_scope_ts ON audit_events(scope, timestamp DESC);
   CREATE INDEX IF NOT EXISTS idx_audit_events_run_id ON audit_events(run_id);
+
+  CREATE TABLE IF NOT EXISTS dashboard_users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT,
+    workos_user_id TEXT,
+    created_at ${ts} NOT NULL,
+    last_login_at ${ts}
+  );
+
+  CREATE TABLE IF NOT EXISTS dashboard_sessions (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES dashboard_users(id),
+    created_at ${ts} NOT NULL,
+    expires_at ${ts} NOT NULL,
+    last_seen_at ${ts} NOT NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
+  CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);
 `;
 }
 

--- a/packages/core/src/db/migrations/postgres/008_sso.sql
+++ b/packages/core/src/db/migrations/postgres/008_sso.sql
@@ -1,0 +1,20 @@
+-- Enterprise feature 4.1: SSO via WorkOS
+CREATE TABLE IF NOT EXISTS dashboard_users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  workos_user_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL,
+  last_login_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS dashboard_sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES dashboard_users(id),
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);

--- a/packages/core/src/db/migrations/sqlite/007_sso.sql
+++ b/packages/core/src/db/migrations/sqlite/007_sso.sql
@@ -1,0 +1,20 @@
+-- Enterprise feature 4.1: SSO via WorkOS
+CREATE TABLE IF NOT EXISTS dashboard_users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  workos_user_id TEXT,
+  created_at INTEGER NOT NULL,
+  last_login_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS dashboard_sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES dashboard_users(id),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -178,3 +178,28 @@ export const auditEvents = sqliteTable("audit_events", {
   outputTokens: integer("output_tokens").notNull().default(0),
   payload: text("payload").notNull().default("{}"),
 });
+
+export const dashboardUsers = sqliteTable("dashboard_users", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  workosUserId: text("workos_user_id"),
+  createdAt: crossTimestamp("created_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  lastLoginAt: crossTimestamp("last_login_at"),
+});
+
+export const dashboardSessions = sqliteTable("dashboard_sessions", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => dashboardUsers.id),
+  createdAt: crossTimestamp("created_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+  expiresAt: crossTimestamp("expires_at").notNull(),
+  lastSeenAt: crossTimestamp("last_seen_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types.js";
 export { checkLicense, isFeatureLicensed, type LicenseStatus } from "./license.js";
 export * from "./audit/index.js";
+export * from "./auth/index.js";
 export { computeConfigFingerprint } from "./audit/config-fingerprint.js";
 export { rootLogger, createLogger, addLogStream } from "./logger.js";
 export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db } from "./db/index.js";

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -23,6 +23,7 @@ import { resolveWorkflowStates } from "./linear-helpers.js";
 import { sql } from "drizzle-orm";
 import { createLogger } from "../logger.js";
 import { logAuditEvent, budgetRefusedEvent, pruneAuditLog } from "../audit/index.js";
+import { pruneExpiredSessions } from "../auth/index.js";
 
 const log = createLogger({ component: "PmAgent:scheduler" });
 
@@ -474,6 +475,16 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           }
         } catch (err) {
           log.warn({ err }, "audit retention sweep failed");
+        }
+
+        // Dashboard session prune sweep (no-op if SSO unlicensed).
+        // Wrapped in try/catch — prune failure must not crash the tick.
+        try {
+          if (isFeatureLicensed("sso")) {
+            await pruneExpiredSessions(db);
+          }
+        } catch (err) {
+          log.warn({ err }, "session prune failed");
         }
 
       log.info({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -379,6 +379,7 @@ export const AuditEventTypeSchema = z.enum([
   "budget.alert_fired", "budget.run_refused",
   "license.validation_failed", "config.loaded",
   "dashboard.manual_action",
+  "dashboard.login", "dashboard.logout", "dashboard.login_denied",
 ]);
 export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
 
@@ -407,10 +408,24 @@ export type AuditEvent = z.infer<typeof AuditEventSchema>;
  * section introduced with the audit-log feature; additional sections can be
  * added here as the rest of the config is migrated to zod.
  */
+export const SsoConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  workosApiKey: z.string().min(1),
+  workosClientId: z.string().min(1),
+  redirectUri: z.string().url(),
+  allowedDomain: z.string().optional(),
+  sessionDurationHours: z.number().int().positive().default(24),
+  cookieName: z.string().default("urateam_session"),
+  cookieSecure: z.boolean().default(true),
+  stateSigningSecret: z.string().min(16),
+});
+export type SsoConfig = z.infer<typeof SsoConfigSchema>;
+
 export const AppConfigSchema = z.object({
   auditLog: z.object({
     enabled: z.boolean().optional(),
     retentionDays: z.number().int().positive().optional().default(365),
   }).optional(),
+  sso: SsoConfigSchema.optional(),
 });
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -20,11 +20,12 @@
   "dependencies": {
     "@hono/node-server": "^1.14.0",
     "@urateam/core": "workspace:*",
+    "@workos-inc/node": "^8.13.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.7.0"
   },
   "devDependencies": {
-    "vitest": "^3.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/dashboard/src/__tests__/auth-routes.test.ts
+++ b/packages/dashboard/src/__tests__/auth-routes.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createDb, signState } from "@urateam/core";
+import type { WorkosClient } from "@urateam/core";
+import {
+  auditEvents,
+  dashboardSessions,
+} from "@urateam/core/dist/db/schema.js";
+import { createAuthRouter } from "../routes/auth.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test",
+  workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  allowedDomain: undefined as string | undefined,
+  sessionDurationHours: 24,
+  cookieName: "urateam_session",
+  cookieSecure: false,
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+const stubWorkos: WorkosClient = {
+  async getAuthorizationUrl(args) {
+    return `https://workos.example/auth?state=${args.state}&client=${args.clientId}`;
+  },
+  async authenticateWithCode(_args) {
+    return {
+      user: {
+        id: "wu_test",
+        email: "alice@acme.com",
+        firstName: "Alice",
+        lastName: "X",
+      },
+    };
+  },
+};
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+function buildApp() {
+  const app = new Hono();
+  app.route(
+    "/",
+    createAuthRouter({ db, sso: ssoConfig as any, workos: stubWorkos }),
+  );
+  return app;
+}
+
+// flush fire-and-forget audit writes
+async function tick(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe("/auth/login", () => {
+  it("returns 302 to a workos url with a signed state", async () => {
+    const res = await buildApp().request("/auth/login?next=/runs");
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("location")!;
+    expect(loc).toContain("workos.example");
+    expect(loc).toContain("state=");
+  });
+});
+
+describe("/auth/callback", () => {
+  it("creates a session, sets cookie, writes audit event, redirects to next", async () => {
+    const state = signState(
+      { next: "/runs", nonce: "n" },
+      ssoConfig.stateSigningSecret,
+    );
+    const res = await buildApp().request(
+      `/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/runs");
+    const setCookie = res.headers.get("set-cookie")!;
+    expect(setCookie).toContain("urateam_session=");
+    expect(setCookie).toContain("HttpOnly");
+    const sessions = await db.select().from(dashboardSessions);
+    expect(sessions).toHaveLength(1);
+    await tick();
+    const events = await db.select().from(auditEvents);
+    expect(
+      events.find((e: any) => e.eventType === "dashboard.login"),
+    ).toBeDefined();
+  });
+
+  it("returns 400 on state mismatch", async () => {
+    const res = await buildApp().request(
+      `/auth/callback?code=abc&state=garbage`,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 + audit event when allowedDomain rejects", async () => {
+    ssoConfig.allowedDomain = "evil.com";
+    const state = signState(
+      { next: "/", nonce: "n" },
+      ssoConfig.stateSigningSecret,
+    );
+    const res = await buildApp().request(
+      `/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    expect(res.status).toBe(403);
+    await tick();
+    const events = await db.select().from(auditEvents);
+    expect(
+      events.find((e: any) => e.eventType === "dashboard.login_denied"),
+    ).toBeDefined();
+    ssoConfig.allowedDomain = undefined;
+  });
+});
+
+describe("/auth/logout", () => {
+  it("deletes session, clears cookie, writes logout event", async () => {
+    const state = signState(
+      { next: "/", nonce: "n" },
+      ssoConfig.stateSigningSecret,
+    );
+    const cb = await buildApp().request(
+      `/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    const cookieHeader = cb.headers.get("set-cookie")!;
+    const sid = cookieHeader.match(/urateam_session=([^;]+)/)![1];
+
+    const res = await buildApp().request("/auth/logout", {
+      method: "POST",
+      headers: { cookie: `urateam_session=${sid}` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/auth/login");
+    const sessions = await db.select().from(dashboardSessions);
+    expect(sessions).toHaveLength(0);
+    await tick();
+    const events = await db.select().from(auditEvents);
+    expect(
+      events.find((e: any) => e.eventType === "dashboard.logout"),
+    ).toBeDefined();
+  });
+});

--- a/packages/dashboard/src/__tests__/auth-routes.test.ts
+++ b/packages/dashboard/src/__tests__/auth-routes.test.ts
@@ -133,9 +133,16 @@ describe("/auth/logout", () => {
     const cookieHeader = cb.headers.get("set-cookie")!;
     const sid = cookieHeader.match(/urateam_session=([^;]+)/)![1];
 
+    // Logout is now CSRF-protected at the server level: the dashboard
+    // middleware requires an HX-Request header on all state-changing
+    // routes. This test drives createAuthRouter directly (no middleware
+    // stack) but we send the header anyway to mirror the real client.
     const res = await buildApp().request("/auth/logout", {
       method: "POST",
-      headers: { cookie: `urateam_session=${sid}` },
+      headers: {
+        cookie: `urateam_session=${sid}`,
+        "HX-Request": "true",
+      },
     });
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe("/auth/login");

--- a/packages/dashboard/src/__tests__/helpers/license.ts
+++ b/packages/dashboard/src/__tests__/helpers/license.ts
@@ -1,0 +1,80 @@
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { _resetLicenseCache } from "@urateam/core/dist/license.js";
+
+function b64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(privateKey: KeyObject, payload: object): string {
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const headerB64 = b64url(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = sign(null, Buffer.from(signingInput), privateKey);
+  return `${signingInput}.${b64url(sig)}`;
+}
+
+let savedPublicKey: string | undefined;
+let savedEnv: string | undefined;
+
+/**
+ * Install a test license at the requested tier, replacing the embedded
+ * public key with a generated one so the JWT verifies. Used by dashboard
+ * tests for enterprise-tier features (audit-log, sso).
+ */
+export async function installTestProLicense(
+  tier: "pro" | "enterprise" = "enterprise",
+): Promise<void> {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyB64 = Buffer.from(
+    publicKey.export({ format: "der", type: "spki" }),
+  ).toString("base64");
+
+  const mod = await import("@urateam/core/dist/license-public-key.js");
+  if (savedPublicKey === undefined) {
+    savedPublicKey = (mod as { LICENSE_PUBLIC_KEY_DER_B64: string })
+      .LICENSE_PUBLIC_KEY_DER_B64;
+  }
+  Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+    value: publicKeyB64,
+    writable: true,
+    configurable: true,
+  });
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = makeJwt(privateKey, {
+    iss: "urateam.dev",
+    sub: "cust_test",
+    tier,
+    seats: 25,
+    iat: now,
+    exp: now + 86_400,
+  });
+
+  if (savedEnv === undefined) savedEnv = process.env.URATEAM_LICENSE_KEY;
+  process.env.URATEAM_LICENSE_KEY = jwt;
+  _resetLicenseCache();
+}
+
+export async function restoreLicense(): Promise<void> {
+  if (savedPublicKey !== undefined) {
+    const mod = await import("@urateam/core/dist/license-public-key.js");
+    Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+      value: savedPublicKey,
+      writable: true,
+      configurable: true,
+    });
+    savedPublicKey = undefined;
+  }
+  if (savedEnv === undefined) {
+    delete process.env.URATEAM_LICENSE_KEY;
+  } else {
+    process.env.URATEAM_LICENSE_KEY = savedEnv;
+    savedEnv = undefined;
+  }
+  _resetLicenseCache();
+}

--- a/packages/dashboard/src/__tests__/sso-integration.test.ts
+++ b/packages/dashboard/src/__tests__/sso-integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "@urateam/core";
+import type { WorkosClient } from "@urateam/core";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+import { createDashboard } from "../server.js";
+
+let db: any;
+
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test",
+  workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  sessionDurationHours: 24,
+  cookieName: "urateam_session",
+  cookieSecure: false,
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+const stubWorkos: WorkosClient = {
+  async getAuthorizationUrl(args) {
+    return `https://workos.example/auth?state=${args.state}&client=${args.clientId}`;
+  },
+  async authenticateWithCode(_args) {
+    return {
+      user: {
+        id: "wu_test",
+        email: "alice@acme.com",
+        firstName: "Alice",
+        lastName: "X",
+      },
+    };
+  },
+};
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+describe("server with SSO", () => {
+  it("redirects /runs to /auth/login when SSO is licensed and enabled with no cookie", async () => {
+    await installTestProLicense("enterprise");
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      sso: ssoConfig as any,
+      workos: stubWorkos,
+    });
+    const res = await app.request("/runs");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/auth/login");
+  });
+
+  it("falls back to basic auth when SSO is not licensed even if enabled", async () => {
+    await restoreLicense();
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      sso: ssoConfig as any,
+      workos: stubWorkos,
+      auth: { username: "u", password: "p" },
+    });
+    const res = await app.request("/runs");
+    expect(res.status).toBe(401); // basic auth challenge
+  });
+
+  it("uses basic auth when SSO is licensed but disabled", async () => {
+    await installTestProLicense("enterprise");
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      sso: { ...ssoConfig, enabled: false } as any,
+      workos: stubWorkos,
+      auth: { username: "u", password: "p" },
+    });
+    const res = await app.request("/runs");
+    expect(res.status).toBe(401);
+  });
+
+  it("serves /auth/login (302 to WorkOS) without basic auth when SSO active", async () => {
+    await installTestProLicense("enterprise");
+    const app = createDashboard({
+      db,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      sso: ssoConfig as any,
+      workos: stubWorkos,
+    });
+    const res = await app.request("/auth/login?next=/runs");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("workos.example");
+  });
+});

--- a/packages/dashboard/src/__tests__/sso-middleware.test.ts
+++ b/packages/dashboard/src/__tests__/sso-middleware.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { createDb, upsertUser, createSession } from "@urateam/core";
+import { createSsoMiddleware } from "../middleware/sso.js";
+
+let db: any;
+let userId: string;
+
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test",
+  workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  sessionDurationHours: 24,
+  cookieName: "urateam_session",
+  cookieSecure: false,
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+} as const;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  userId = await upsertUser(db, {
+    email: "a@b.com",
+    name: "A",
+    workosUserId: null,
+  });
+});
+
+function appWithSso() {
+  const app = new Hono();
+  app.use("*", createSsoMiddleware({ db, sso: ssoConfig as any }));
+  app.get("/runs", (c) => c.text(`hello ${(c.get("user") as any).email}`));
+  app.post("/webhooks/linear", (c) => c.text("ok"));
+  app.get("/auth/login", (c) => c.text("login page"));
+  return app;
+}
+
+describe("ssoMiddleware", () => {
+  it("redirects to /auth/login when no cookie present", async () => {
+    const res = await appWithSso().request("/runs");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/auth/login");
+    expect(res.headers.get("location")).toContain("next=%2Fruns");
+  });
+
+  it("allows /auth/* paths through without a cookie", async () => {
+    const res = await appWithSso().request("/auth/login");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /webhooks/* paths through without a cookie", async () => {
+    const res = await appWithSso().request("/webhooks/linear", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 with c.get('user') populated when valid session cookie present", async () => {
+    const sid = await createSession(db, { userId, durationHours: 24 });
+    const res = await appWithSso().request("/runs", {
+      headers: { cookie: `urateam_session=${sid}` },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello a@b.com");
+  });
+
+  it("clears cookie and redirects when session id is unknown", async () => {
+    const res = await appWithSso().request("/runs", {
+      headers: { cookie: `urateam_session=unknown` },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("set-cookie")).toContain("urateam_session=;");
+  });
+});

--- a/packages/dashboard/src/__tests__/sso-middleware.test.ts
+++ b/packages/dashboard/src/__tests__/sso-middleware.test.ts
@@ -29,7 +29,7 @@ beforeEach(async () => {
 function appWithSso() {
   const app = new Hono();
   app.use("*", createSsoMiddleware({ db, sso: ssoConfig as any }));
-  app.get("/runs", (c) => c.text(`hello ${(c.get("user") as any).email}`));
+  app.get("/runs", (c) => c.text(`hello ${(c.get("user" as never) as any).email}`));
   app.post("/webhooks/linear", (c) => c.text("ok"));
   app.get("/auth/login", (c) => c.text("login page"));
   return app;

--- a/packages/dashboard/src/middleware/sso.ts
+++ b/packages/dashboard/src/middleware/sso.ts
@@ -31,7 +31,13 @@ export function createSsoMiddleware(
 
     const session = await getSession(deps.db, cookie);
     if (!session) {
-      setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+      setCookie(c, deps.sso.cookieName, "", {
+        maxAge: 0,
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+        secure: deps.sso.cookieSecure,
+      });
       return c.redirect(
         `/auth/login?next=${encodeURIComponent(path)}`,
         302,
@@ -41,7 +47,13 @@ export function createSsoMiddleware(
     const user = await getUserById(deps.db, session.userId);
     if (!user) {
       await deleteSession(deps.db, cookie);
-      setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+      setCookie(c, deps.sso.cookieName, "", {
+        maxAge: 0,
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+        secure: deps.sso.cookieSecure,
+      });
       return c.redirect(`/auth/login`, 302);
     }
 

--- a/packages/dashboard/src/middleware/sso.ts
+++ b/packages/dashboard/src/middleware/sso.ts
@@ -1,0 +1,53 @@
+import { getCookie, setCookie } from "hono/cookie";
+import type { MiddlewareHandler } from "hono";
+import {
+  getSession,
+  getUserById,
+  deleteSession,
+  touchSessionLastSeen,
+} from "@urateam/core";
+import type { SsoConfig } from "@urateam/core";
+
+interface SsoMiddlewareDeps {
+  db: any;
+  sso: SsoConfig;
+}
+
+export function createSsoMiddleware(
+  deps: SsoMiddlewareDeps,
+): MiddlewareHandler {
+  return async (c, next) => {
+    const path = c.req.path;
+    if (path.startsWith("/auth/")) return next();
+    if (path.startsWith("/webhooks/")) return next();
+
+    const cookie = getCookie(c, deps.sso.cookieName);
+    if (!cookie) {
+      return c.redirect(
+        `/auth/login?next=${encodeURIComponent(path)}`,
+        302,
+      );
+    }
+
+    const session = await getSession(deps.db, cookie);
+    if (!session) {
+      setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+      return c.redirect(
+        `/auth/login?next=${encodeURIComponent(path)}`,
+        302,
+      );
+    }
+
+    const user = await getUserById(deps.db, session.userId);
+    if (!user) {
+      await deleteSession(deps.db, cookie);
+      setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+      return c.redirect(`/auth/login`, 302);
+    }
+
+    c.set("user", user);
+    c.set("session", session);
+    void touchSessionLastSeen(deps.db, cookie);
+    return next();
+  };
+}

--- a/packages/dashboard/src/routes/audit.ts
+++ b/packages/dashboard/src/routes/audit.ts
@@ -78,7 +78,10 @@ export function createAuditRouter(db: Db, basePath = ""): Hono {
     const { events, nextCursor } = await listAuditEvents(db as any, readerFilters);
     const content = renderAuditPage({ events, nextCursor, filters });
     if (c.req.header("HX-Request")) return c.html(content);
-    return c.html(layout("Audit Log", content, basePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(
+      layout("Audit Log", content, basePath, { userEmail: user?.email }),
+    );
   });
 
   // HTMX partial used by the "Load more" link to append rows.

--- a/packages/dashboard/src/routes/auth.ts
+++ b/packages/dashboard/src/routes/auth.ts
@@ -129,7 +129,13 @@ export function createAuthRouter(deps: AuthRouterDeps): Hono {
         }
       }
     }
-    setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+    setCookie(c, deps.sso.cookieName, "", {
+      maxAge: 0,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: deps.sso.cookieSecure,
+    });
     return c.redirect("/auth/login", 302);
   });
 

--- a/packages/dashboard/src/routes/auth.ts
+++ b/packages/dashboard/src/routes/auth.ts
@@ -1,0 +1,137 @@
+import { Hono } from "hono";
+import { setCookie, getCookie } from "hono/cookie";
+import { randomUUID } from "node:crypto";
+import {
+  signState,
+  verifyState,
+  validateNextPath,
+  upsertUser,
+  createSession,
+  deleteSession,
+  getSession,
+  getUserById,
+  logAuditEvent,
+  dashboardLoginEvent,
+  dashboardLogoutEvent,
+  dashboardLoginDeniedEvent,
+} from "@urateam/core";
+import type { SsoConfig, WorkosClient } from "@urateam/core";
+import { createLogger } from "@urateam/core";
+
+const log = createLogger({ component: "dashboard.auth" });
+
+interface AuthRouterDeps {
+  db: any;
+  sso: SsoConfig;
+  workos: WorkosClient;
+}
+
+export function createAuthRouter(deps: AuthRouterDeps): Hono {
+  const app = new Hono();
+
+  app.get("/auth/login", async (c) => {
+    const next = validateNextPath(c.req.query("next"));
+    const state = signState(
+      { next, nonce: randomUUID() },
+      deps.sso.stateSigningSecret,
+    );
+    const url = await deps.workos.getAuthorizationUrl({
+      clientId: deps.sso.workosClientId,
+      redirectUri: deps.sso.redirectUri,
+      state,
+    });
+    return c.redirect(url, 302);
+  });
+
+  app.get("/auth/callback", async (c) => {
+    const code = c.req.query("code");
+    const stateRaw = c.req.query("state");
+    if (!code || !stateRaw) return c.text("Missing code or state", 400);
+    const state = verifyState(stateRaw, deps.sso.stateSigningSecret);
+    if (!state) return c.text("Invalid login state. Please try again.", 400);
+
+    let result;
+    try {
+      result = await deps.workos.authenticateWithCode({
+        clientId: deps.sso.workosClientId,
+        code,
+      });
+    } catch (err) {
+      log.warn({ err }, "WorkOS authenticateWithCode failed");
+      return c.text(
+        "SSO provider error. Try again or contact your administrator.",
+        503,
+      );
+    }
+
+    const email = result.user.email.toLowerCase();
+    if (deps.sso.allowedDomain) {
+      const expected = "@" + deps.sso.allowedDomain.toLowerCase();
+      if (!email.endsWith(expected)) {
+        void logAuditEvent(
+          deps.db,
+          dashboardLoginDeniedEvent({ email, reason: "domain-mismatch" }),
+        );
+        return c.text(
+          `Access denied. ${email} is not in the allowed domain. Contact your administrator.`,
+          403,
+        );
+      }
+    }
+
+    const fullName =
+      [result.user.firstName, result.user.lastName]
+        .filter(Boolean)
+        .join(" ")
+        .trim() || null;
+    const userId = await upsertUser(deps.db, {
+      email,
+      name: fullName,
+      workosUserId: result.user.id,
+    });
+    const sessionId = await createSession(deps.db, {
+      userId,
+      durationHours: deps.sso.sessionDurationHours,
+    });
+
+    setCookie(c, deps.sso.cookieName, sessionId, {
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: deps.sso.cookieSecure,
+      path: "/",
+      maxAge: deps.sso.sessionDurationHours * 3600,
+    });
+
+    void logAuditEvent(
+      deps.db,
+      dashboardLoginEvent({
+        userId,
+        email,
+        workosUserId: result.user.id,
+      }),
+    );
+
+    return c.redirect(validateNextPath(state.next), 302);
+  });
+
+  app.post("/auth/logout", async (c) => {
+    const sid = getCookie(c, deps.sso.cookieName);
+    if (sid) {
+      const session = await getSession(deps.db, sid);
+      if (session) {
+        const user = await getUserById(deps.db, session.userId);
+        await deleteSession(deps.db, sid);
+        if (user) {
+          void logAuditEvent(
+            deps.db,
+            dashboardLogoutEvent({ userId: user.id, email: user.email }),
+          );
+        }
+      }
+    }
+    setCookie(c, deps.sso.cookieName, "", { maxAge: 0, path: "/" });
+    return c.redirect("/auth/login", 302);
+  });
+
+  return app;
+}

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -113,11 +113,17 @@ export function createDashboard(config: DashboardConfig): Hono {
   // CSRF / Origin validation for state-changing requests
   app.use("*", async (c, next) => {
     const method = c.req.method;
-    // /auth/* endpoints are SSO callbacks / form-submitted logout — they are
-    // not HTMX driven, so the HX-Request requirement does not apply.
+    // /auth/login and /auth/callback are GET-based OAuth handoffs with no
+    // body — they cannot be targets of CSRF. /auth/logout is POST and MUST
+    // go through CSRF (either HX-Request or a token) so an attacker can't
+    // embed a <form action="/auth/logout"> on a third-party site and force
+    // a logout.
+    const path = c.req.path;
+    const csrfExempt =
+      path === "/auth/login" || path === "/auth/callback";
     if (
       ["POST", "PUT", "DELETE", "PATCH"].includes(method) &&
-      !c.req.path.startsWith("/auth/")
+      !csrfExempt
     ) {
       // Require HX-Request header on HTMX-driven state-changing endpoints
       if (!c.req.header("HX-Request")) {

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -1,14 +1,22 @@
 import { Hono } from "hono";
 import { basicAuth } from "hono/basic-auth";
 import { serveStatic } from "@hono/node-server/serve-static";
-import { createLogger } from "@urateam/core";
-import type { Db, PipelineConfig, RepoConfig } from "@urateam/core";
+import { createLogger, isFeatureLicensed } from "@urateam/core";
+import type {
+  Db,
+  PipelineConfig,
+  RepoConfig,
+  SsoConfig,
+  WorkosClient,
+} from "@urateam/core";
 import { createRunsRouter } from "./routes/runs.js";
 import { createTokensRouter } from "./routes/tokens.js";
 import { createErrorsRouter } from "./routes/errors.js";
 import { createConfigRouter } from "./routes/config.js";
 import { createCoordinationRouter } from "./routes/coordination.js";
 import { createAuditRouter } from "./routes/audit.js";
+import { createAuthRouter } from "./routes/auth.js";
+import { createSsoMiddleware } from "./middleware/sso.js";
 
 const logger = createLogger({ component: "dashboard" });
 
@@ -17,6 +25,16 @@ export interface DashboardConfig {
   pipelineConfigs: Record<string, PipelineConfig>;
   repoConfigs: Record<string, RepoConfig>;
   auth?: { username: string; password: string };
+  /**
+   * Optional SSO configuration. When the `sso` feature is licensed AND
+   * `sso.enabled === true`, the dashboard mounts the WorkOS auth router
+   * and the session-validating SSO middleware in place of basic auth.
+   * Callers must also pass `workos` (a `WorkosClient` instance) — typically
+   * obtained from `getDefaultWorkosClient(sso.workosApiKey)`. This keeps
+   * `createDashboard` synchronous and lets tests inject a stub client.
+   */
+  sso?: SsoConfig;
+  workos?: WorkosClient;
   /**
    * Root path prefix for all dashboard navigation links (e.g. `"/ateam"`).
    * No trailing slash. Falls back to the `DASHBOARD_BASE_PATH` environment
@@ -95,7 +113,12 @@ export function createDashboard(config: DashboardConfig): Hono {
   // CSRF / Origin validation for state-changing requests
   app.use("*", async (c, next) => {
     const method = c.req.method;
-    if (["POST", "PUT", "DELETE", "PATCH"].includes(method)) {
+    // /auth/* endpoints are SSO callbacks / form-submitted logout — they are
+    // not HTMX driven, so the HX-Request requirement does not apply.
+    if (
+      ["POST", "PUT", "DELETE", "PATCH"].includes(method) &&
+      !c.req.path.startsWith("/auth/")
+    ) {
       // Require HX-Request header on HTMX-driven state-changing endpoints
       if (!c.req.header("HX-Request")) {
         return c.text("Forbidden: HTMX header required", 403);
@@ -112,9 +135,31 @@ export function createDashboard(config: DashboardConfig): Hono {
     await next();
   });
 
-  // Always require basic auth — dashboard exposes sensitive operational data.
-  // If credentials are not configured, block all access with a clear error.
-  if (config.auth?.username && config.auth?.password) {
+  // Authentication: SSO (Enterprise) takes priority over basic auth when
+  // licensed AND enabled. Otherwise fall back to basic auth, or 503 if no
+  // credentials are configured.
+  const ssoActive =
+    isFeatureLicensed("sso") && config.sso?.enabled === true;
+
+  if (ssoActive) {
+    if (!config.workos) {
+      throw new Error(
+        "SSO is licensed and enabled, but no WorkosClient was provided to createDashboard(). " +
+          "Pass `workos: await getDefaultWorkosClient(sso.workosApiKey)`.",
+      );
+    }
+    logger.info("Mounting SSO auth router and session middleware");
+    const authRouter = createAuthRouter({
+      db: config.db,
+      sso: config.sso!,
+      workos: config.workos,
+    });
+    app.route("/", authRouter);
+    app.use(
+      "*",
+      createSsoMiddleware({ db: config.db, sso: config.sso! }),
+    );
+  } else if (config.auth?.username && config.auth?.password) {
     app.use(
       "*",
       basicAuth({

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -147,6 +147,15 @@ export function createDashboard(config: DashboardConfig): Hono {
   const ssoActive =
     isFeatureLicensed("sso") && config.sso?.enabled === true;
 
+  // Warn when sso config is present but the feature is not licensed —
+  // operators with `sso.enabled: true` in their config but no enterprise
+  // license would otherwise silently get basicAuth with no clue why.
+  if (config.sso?.enabled === true && !isFeatureLicensed("sso")) {
+    logger.warn(
+      "SSO is configured (sso.enabled=true) but the 'sso' feature is not licensed — falling back to basic auth",
+    );
+  }
+
   if (ssoActive) {
     if (!config.workos) {
       throw new Error(

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -55,8 +55,12 @@ export function layout(
 ): string {
   // Explicit parameter takes priority; fall back to env var for backward compat.
   const bp = normalizeBasePath(basePath ?? getBasePath());
+  // Logout goes through the dashboard CSRF middleware (which requires an
+  // HX-Request header on all state-changing routes). Using hx-post with an
+  // explicit HX-Request header on the button ensures the request is not
+  // forgeable from a third-party origin via a plain <form> submission.
   const signOut = ctx?.userEmail
-    ? `<form method="post" action="${bp}/auth/logout" class="signout-form"><button type="submit" class="link">Sign out (${escapeHtml(ctx.userEmail)})</button></form>`
+    ? `<button type="button" class="link signout-btn" hx-post="${bp}/auth/logout" hx-headers='{"HX-Request":"true"}' hx-push-url="true" hx-swap="none">Sign out (${escapeHtml(ctx.userEmail)})</button>`
     : "";
   const cspContent =
     "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self'";

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -37,9 +37,27 @@ function normalizeBasePath(basePath: string): string {
  *                   (sourced from `DashboardConfig.basePath`) to decouple
  *                   link rendering from the process environment.
  */
-export function layout(title: string, content: string, basePath?: string): string {
+/**
+ * Optional context propagated from the request handler. When `userEmail`
+ * is set the nav renders a Sign Out form (POST /auth/logout). Routes that
+ * have access to `c.get("user")` should pass it; others omit and get the
+ * existing layout unchanged.
+ */
+export interface LayoutContext {
+  userEmail?: string;
+}
+
+export function layout(
+  title: string,
+  content: string,
+  basePath?: string,
+  ctx?: LayoutContext,
+): string {
   // Explicit parameter takes priority; fall back to env var for backward compat.
   const bp = normalizeBasePath(basePath ?? getBasePath());
+  const signOut = ctx?.userEmail
+    ? `<form method="post" action="${bp}/auth/logout" class="signout-form"><button type="submit" class="link">Sign out (${escapeHtml(ctx.userEmail)})</button></form>`
+    : "";
   const cspContent =
     "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self'";
   return `<!DOCTYPE html>
@@ -67,6 +85,7 @@ export function layout(title: string, content: string, basePath?: string): strin
     <a href="${bp}/audit">Audit</a>
     <a href="${bp}/config">Config</a>
     <a href="${bp}/coordination">Coordination</a>
+    ${signOut}
   </nav>
   <main>
     <h1>${escapeHtml(title)}</h1>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@urateam/core':
         specifier: workspace:*
         version: link:../core
+      '@workos-inc/node':
+        specifier: ^8.13.0
+        version: 8.13.0
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(postgres@3.4.9)
@@ -1019,6 +1022,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@workos-inc/node@8.13.0':
+    resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
+    engines: {node: '>=20.15.0'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1309,6 +1316,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2603,6 +2613,10 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@workos-inc/node@8.13.0':
+    dependencies:
+      eventemitter3: 5.0.4
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2862,6 +2876,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.6: {}
 


### PR DESCRIPTION
## Summary
- Replaces dashboard HTTP Basic Auth with WorkOS AuthKit SSO when `isFeatureLicensed("sso") && config.sso?.enabled === true`
- New tables: `dashboard_users`, `dashboard_sessions` (both via `crossTimestamp`)
- New core module `packages/core/src/auth/` (sso-config, user-store, session-store, workos-client) with full DI seam for tests
- New dashboard middleware + `/auth/login` `/auth/callback` `/auth/logout` routes
- CLI bootstrap reads SSO env vars and validates at startup; missing vars when SSO is enabled → process exit
- Three new audit event types (`dashboard.login`, `dashboard.logout`, `dashboard.login_denied`) flow through the existing license-gated audit writer
- PM tick prunes expired sessions after the audit retention sweep
- Domain allowlist (`sso.allowedDomain`) restricts which emails can complete login
- Server-side sessions = revocable in seconds via `/auth/logout` or admin DB delete
- Webhooks bypass SSO middleware (HMAC verification unchanged)
- OSS / Pro deployments unchanged — Basic Auth path untouched
- Operator setup guide at `deploy/SSO_SETUP.md`

Spec: `docs/superpowers/specs/2026-04-14-sso-design.md`
Plan: `docs/superpowers/plans/2026-04-14-sso-via-workos.md`

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 984 core + 8 dashboard + 7 cli files passing
- [x] Holistic external review — 1 critical, 2 high, 2 medium findings; all fixed inline (CLI wiring, CSRF on logout, upsertUser race via onConflictDoUpdate, clear-cookie security attrs, session-id log redaction)
- [ ] Manual: stub WorkOS callback flow against a dev instance with `URATEAM_SSO_ENABLED=true`
- [ ] Manual: confirm Basic Auth still works on a deployment with `sso.enabled=false`

## Deferred (not blockers)
- Sign Out link only renders on the `/audit` page in v1 — threading user context through `runs`/`tokens`/`errors`/`config` views is a follow-up
- Per-route RBAC is feature 4.4; this PR is a binary gate
- WorkOS Organizations / multi-tenant mapping deferred to feature 4.4 territory
- SCIM, refresh tokens, idle vs absolute timeout — out of scope per spec § 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)