### PR TITLE
feat: cost & roi dashboard (enterprise 4.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,17 @@ It is a pnpm monorepo with 3 packages:
 - License gate: `isFeatureLicensed("org-policy")` required at every call site
 - **Known perf follow-up**: `verifyApprovalsReceived` calls `listMembersInOrg` per team per check with no cache — high-frequency CI webhooks on a PR with 5+ required teams can exhaust GitHub's secondary rate limit. Documented TODO in the auto-merge gate block
 
+### Cost & ROI dashboard (Enterprise feature 4.5)
+- Module: `packages/core/src/cost/` — `rates.ts` (model-rate + time-saved resolution), `per-run.ts` (`computeRunCost`), `aggregate.ts` (`aggregateAll` over runs+stages with 10k row cap + `truncated` flag), `rollup.ts` (`recomputeCostRollups`, `readRollupWindow`), `csv.ts` (`streamCostCsv` with formula-injection guard)
+- Config: `AppConfig.costs = { modelPricing, hourlyEngRate, timeSavedPerPrDefault }`. Per-pipeline `PipelineConfig.timeSavedPerPr` override. Defaults: $50/h eng rate, 4h per PR, Anthropic list pricing
+- Per-run cost = Σ(stage_runs.input/output tokens × model rate). Model per stage = `pipelineConfig.stageModels[stage] ?? pipelineConfig.profile.model ?? "claude-sonnet-4-6"`
+- Time saved = `count(completed runs) × resolveTimeSavedPerPr(pipelineKey)`. ROI = `(timeSavedHours × hourlyEngRate) / dollars`
+- New table: `cost_rollups_daily` — rebuilt nightly in PM tick via `recomputeCostRollups`. **Uses `""` empty-string sentinel instead of NULL for `linear_team_id`** so composite UNIQUE `(date, pipeline_key, linear_team_id, repo_url)` fires correctly with `onConflictDoUpdate` on both SQLite and Postgres
+- Day boundary: half-open `[start, end)` with `lt` (not `lte`) to avoid sub-millisecond precision drops on Postgres `TIMESTAMPTZ`
+- Dashboard route `/cost` — summary card + 3 breakdown tables (team/repo/pipeline) + collapsible formula footer + CSV export at `/cost/export.csv`. All 3 routes 404 unless `isFeatureLicensed("cost-roi")`
+- **10k run cap on `aggregateAll`**: when exceeded, results are truncated to the 10k most recent and `summary.truncated = true`; dashboard shows a warning banner
+- Preset windows (7d/30d/90d/365d) currently go through `aggregateAll` live; `readRollupWindow` exists but is deferred to v2 for rollup-backed reads
+
 ### Coordination (`packages/core/src/pm/coordination.ts`)
 - DB-backed `active_work` table tracks files modified by in-flight pipeline runs
 - `upsertActiveWork` uses atomic `onConflictDoUpdate` (requires UNIQUE on `run_id`)

--- a/docs/superpowers/plans/2026-04-15-cost-roi-dashboard.md
+++ b/docs/superpowers/plans/2026-04-15-cost-roi-dashboard.md
@@ -1,0 +1,2041 @@
+# Cost & ROI Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship enterprise feature 4.5 — a `/cost` dashboard page with summary card, three breakdown tables (team / repo / pipeline), date-range picker, and CSV export — per `docs/superpowers/specs/2026-04-15-cost-roi-dashboard-design.md`.
+
+**Architecture:** New `packages/core/src/cost/` module owns aggregation + pricing as mostly-pure functions. Per-run cost is computed at read time from `stage_runs` tokens plus a configured model-pricing table — no schema change on run tables. A new `cost_rollups_daily` table is rebuilt nightly by a new PM tick step, enabling <500ms preset-window queries. Custom date ranges compute live via `aggregateAll`. Dashboard route renders the page; CSV export shares the same aggregation path. License-gated by `isFeatureLicensed("cost-roi")`.
+
+**Tech Stack:** TypeScript, Drizzle ORM, Hono + HTMX, Vitest, Zod, pino.
+
+---
+
+## File Structure
+
+### New files
+- `packages/core/src/cost/index.ts` — barrel
+- `packages/core/src/cost/types.ts` — `CostSummary`, `BreakdownRow`, `BreakdownDimension`, `RunCost`, `ModelRate`
+- `packages/core/src/cost/rates.ts` — `resolveModelRate`, `resolveTimeSavedPerPr`
+- `packages/core/src/cost/per-run.ts` — `computeRunCost`
+- `packages/core/src/cost/aggregate.ts` — `aggregateAll` (two SQL queries + in-process grouping into summary + 3 dimensions)
+- `packages/core/src/cost/rollup.ts` — `recomputeCostRollups`, `readRollupWindow`
+- `packages/core/src/cost/csv.ts` — `streamCostCsv`
+- `packages/core/src/db/migrations/sqlite/007_cost_rollups.sql`
+- `packages/core/src/db/migrations/postgres/008_cost_rollups.sql`
+- `packages/core/src/__tests__/cost/rates.test.ts`
+- `packages/core/src/__tests__/cost/per-run.test.ts`
+- `packages/core/src/__tests__/cost/aggregate.test.ts`
+- `packages/core/src/__tests__/cost/rollup.test.ts`
+- `packages/core/src/__tests__/cost/csv.test.ts`
+- `packages/core/src/__tests__/cost-integration.test.ts`
+- `packages/dashboard/src/routes/cost.ts`
+- `packages/dashboard/src/views/cost.ts`
+- `packages/dashboard/src/__tests__/cost.test.ts`
+
+### Modified files
+- `packages/core/src/db/schema.ts` — add `costRollupsDaily`
+- `packages/core/src/db/client.ts` — extend `getCreateTablesDDL()` with the new table, add `${num}` interpolation (`REAL` vs `DOUBLE PRECISION`)
+- `packages/core/src/types.ts` — add `CostsConfigSchema`, `ModelPricingSchema`; extend `AppConfigSchema.costs`; add `PipelineConfig.timeSavedPerPr`
+- `packages/core/src/license.ts` — add `"cost-roi"` to Enterprise feature set
+- `packages/core/src/index.ts` — re-export `./cost/index.js`
+- `packages/core/src/pm/scheduler.ts` — add `recomputeCostRollups` tick step
+- `packages/dashboard/src/server.ts` — register `createCostRouter`
+- `packages/dashboard/src/views/layout.ts` — add "Cost" nav entry after "Audit"
+- `CLAUDE.md` — new "Cost & ROI dashboard" section under Key Patterns
+
+---
+
+## Task 1: Zod config schemas
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+- Test: `packages/core/src/__tests__/cost-types.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  CostsConfigSchema, ModelPricingSchema, PipelineConfigSchema, AppConfigSchema,
+} from "../types.js";
+
+describe("CostsConfigSchema", () => {
+  it("parses an empty object and applies defaults", () => {
+    const parsed = CostsConfigSchema.parse({});
+    expect(parsed.hourlyEngRate).toBe(50);
+    expect(parsed.timeSavedPerPrDefault).toBe(4);
+    expect(parsed.modelPricing["claude-opus-4-6"]).toEqual({ inputPerMillion: 15, outputPerMillion: 75 });
+    expect(parsed.modelPricing["claude-sonnet-4-6"]).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+    expect(parsed.modelPricing["claude-haiku-4-5"]).toEqual({ inputPerMillion: 1, outputPerMillion: 5 });
+  });
+
+  it("accepts an override", () => {
+    const parsed = CostsConfigSchema.parse({
+      hourlyEngRate: 75,
+      timeSavedPerPrDefault: 6,
+      modelPricing: {
+        "claude-opus-4-6": { inputPerMillion: 10, outputPerMillion: 50 },
+      },
+    });
+    expect(parsed.hourlyEngRate).toBe(75);
+    expect(parsed.timeSavedPerPrDefault).toBe(6);
+    expect(parsed.modelPricing["claude-opus-4-6"].inputPerMillion).toBe(10);
+  });
+
+  it("rejects non-positive rates", () => {
+    expect(() => CostsConfigSchema.parse({ hourlyEngRate: 0 })).toThrow();
+    expect(() => CostsConfigSchema.parse({ hourlyEngRate: -1 })).toThrow();
+    expect(() => CostsConfigSchema.parse({
+      modelPricing: { foo: { inputPerMillion: -1, outputPerMillion: 1 } },
+    })).toThrow();
+  });
+});
+
+describe("PipelineConfigSchema.timeSavedPerPr", () => {
+  it("accepts optional timeSavedPerPr", () => {
+    const cfg = PipelineConfigSchema.parse({
+      name: "auto-implement",
+      stages: [{ stage: "implement" }],
+      retry: { maxAttempts: 1, strategy: "fail-fast" },
+      review: { requiredApprovals: 1 },
+      prStrategy: "draft",
+      timeSavedPerPr: 6,
+    } as any);
+    expect(cfg.timeSavedPerPr).toBe(6);
+  });
+
+  it("accepts config without timeSavedPerPr", () => {
+    const cfg = PipelineConfigSchema.parse({
+      name: "quick-fix",
+      stages: [{ stage: "implement" }],
+      retry: { maxAttempts: 1, strategy: "fail-fast" },
+      review: { requiredApprovals: 1 },
+      prStrategy: "draft",
+    } as any);
+    expect(cfg.timeSavedPerPr).toBeUndefined();
+  });
+});
+
+describe("AppConfigSchema.costs", () => {
+  it("accepts optional costs field", () => {
+    const parsed = AppConfigSchema.parse({ costs: { hourlyEngRate: 100 } });
+    expect(parsed.costs?.hourlyEngRate).toBe(100);
+  });
+
+  it("accepts omitted costs", () => {
+    const parsed = AppConfigSchema.parse({});
+    expect(parsed.costs).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/cost-types.test.ts
+```
+
+- [ ] **Step 3: Add schemas to `types.ts`**
+
+Append to `packages/core/src/types.ts`:
+```ts
+// --- Cost / ROI ---
+export const ModelPricingSchema = z.object({
+  inputPerMillion: z.number().positive(),
+  outputPerMillion: z.number().positive(),
+});
+export type ModelPricing = z.infer<typeof ModelPricingSchema>;
+
+export const CostsConfigSchema = z.object({
+  modelPricing: z.record(z.string(), ModelPricingSchema).default({
+    "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+    "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    "claude-haiku-4-5":  { inputPerMillion:  1, outputPerMillion:  5 },
+  }),
+  hourlyEngRate: z.number().positive().default(50),
+  timeSavedPerPrDefault: z.number().positive().default(4),
+});
+export type CostsConfig = z.infer<typeof CostsConfigSchema>;
+```
+
+Find `PipelineConfigSchema` and add `timeSavedPerPr: z.number().positive().optional(),` to its shape.
+
+Find `AppConfigSchema` and extend it with `costs: CostsConfigSchema.optional(),`.
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/types.ts packages/core/src/__tests__/cost-types.test.ts
+git commit -m "feat(cost): zod schemas for costs config and pipeline timeSavedPerPr"
+```
+
+---
+
+## Task 2: Rate resolution helpers
+
+**Files:**
+- Create: `packages/core/src/cost/types.ts`
+- Create: `packages/core/src/cost/rates.ts`
+- Create: `packages/core/src/cost/index.ts`
+- Test: `packages/core/src/__tests__/cost/rates.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { resolveModelRate, resolveTimeSavedPerPr } from "../../cost/rates.js";
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+      "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": { timeSavedPerPr: 6 } as any,
+    "quick-fix": {} as any,
+  },
+} as any;
+
+describe("resolveModelRate", () => {
+  it("returns configured rate", () => {
+    const r = resolveModelRate("claude-opus-4-6", config);
+    expect(r).toEqual({ inputPerMillion: 15, outputPerMillion: 75 });
+  });
+
+  it("falls back to sonnet when model is unknown", () => {
+    const r = resolveModelRate("nonexistent-model", config);
+    expect(r).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+  });
+
+  it("uses built-in sonnet default when config has no sonnet", () => {
+    const r = resolveModelRate("unknown", { costs: { modelPricing: {}, hourlyEngRate: 50, timeSavedPerPrDefault: 4 } } as any);
+    expect(r).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+  });
+
+  it("uses built-in default when config has no costs", () => {
+    const r = resolveModelRate("claude-opus-4-6", {} as any);
+    // Falls through to built-in sonnet default since no modelPricing provided at all
+    expect(r).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+  });
+});
+
+describe("resolveTimeSavedPerPr", () => {
+  it("uses pipeline override when set", () => {
+    expect(resolveTimeSavedPerPr("auto-implement", config)).toBe(6);
+  });
+
+  it("uses costs default when pipeline has no override", () => {
+    expect(resolveTimeSavedPerPr("quick-fix", config)).toBe(4);
+  });
+
+  it("uses built-in default (4h) when neither pipeline nor costs config set", () => {
+    expect(resolveTimeSavedPerPr("unknown", {} as any)).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `cost/types.ts`**
+
+```ts
+export interface ModelRate {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+export interface RunCost {
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+}
+
+export interface CostSummary {
+  window: { from: Date; to: Date };
+  runs: number;
+  prsMerged: number;
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+  roiMultiplier: number;
+}
+
+export type BreakdownDimension = "team" | "repo" | "pipeline";
+
+export interface BreakdownRow {
+  key: string;
+  label: string;
+  runs: number;
+  prsMerged: number;
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+  roiMultiplier: number;
+}
+
+export interface AggregateResult {
+  summary: CostSummary;
+  byTeam: BreakdownRow[];
+  byRepo: BreakdownRow[];
+  byPipeline: BreakdownRow[];
+}
+```
+
+- [ ] **Step 4: Create `cost/rates.ts`**
+
+```ts
+import type { ModelRate } from "./types.js";
+
+const BUILTIN_SONNET: ModelRate = { inputPerMillion: 3, outputPerMillion: 15 };
+
+/**
+ * Resolve the $/M-token rate for a given model. Lookup order:
+ * 1. config.costs.modelPricing[modelName] — configured explicit rate
+ * 2. config.costs.modelPricing["claude-sonnet-4-6"] — fallback to sonnet
+ * 3. Built-in sonnet default ($3/$15 per M) — for deployments with no costs config
+ */
+export function resolveModelRate(
+  modelName: string,
+  config: { costs?: { modelPricing?: Record<string, ModelRate> } },
+): ModelRate {
+  const table = config.costs?.modelPricing;
+  if (!table) return BUILTIN_SONNET;
+  return table[modelName] ?? table["claude-sonnet-4-6"] ?? BUILTIN_SONNET;
+}
+
+/**
+ * Resolve the `timeSavedPerPr` hours for a given pipeline. Lookup order:
+ * 1. pipelineConfigs[pipelineKey].timeSavedPerPr
+ * 2. config.costs.timeSavedPerPrDefault
+ * 3. Built-in default (4h)
+ */
+export function resolveTimeSavedPerPr(
+  pipelineKey: string,
+  config: {
+    costs?: { timeSavedPerPrDefault?: number };
+    pipelineConfigs?: Record<string, { timeSavedPerPr?: number }>;
+  },
+): number {
+  const override = config.pipelineConfigs?.[pipelineKey]?.timeSavedPerPr;
+  if (override !== undefined) return override;
+  return config.costs?.timeSavedPerPrDefault ?? 4;
+}
+```
+
+- [ ] **Step 5: Create `cost/index.ts`**
+
+```ts
+export * from "./types.js";
+export * from "./rates.js";
+```
+
+- [ ] **Step 6: Run, verify pass**
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/core/src/cost packages/core/src/__tests__/cost/rates.test.ts
+git commit -m "feat(cost): rate resolution helpers"
+```
+
+---
+
+## Task 3: Per-run cost computation
+
+**Files:**
+- Create: `packages/core/src/cost/per-run.ts`
+- Modify: `packages/core/src/cost/index.ts`
+- Test: `packages/core/src/__tests__/cost/per-run.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { computeRunCost } from "../../cost/per-run.js";
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+      "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": {
+      stageModels: { implement: "claude-opus-4-6" },
+      profile: { model: "claude-sonnet-4-6" },
+      timeSavedPerPr: 6,
+    } as any,
+    "quick-fix": {
+      profile: { model: "claude-sonnet-4-6" },
+    } as any,
+  },
+} as any;
+
+describe("computeRunCost", () => {
+  it("prices stages at their configured model rates", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [
+      { stage: "implement", inputTokens: 1_000_000, outputTokens: 500_000 },
+      { stage: "review", inputTokens: 100_000, outputTokens: 20_000 },
+    ] as any;
+    const cost = computeRunCost(run, stages, config);
+    // implement: 1M × $15 + 0.5M × $75 = $15 + $37.5 = $52.5
+    // review (sonnet default): 0.1M × $3 + 0.02M × $15 = $0.30 + $0.30 = $0.60
+    expect(cost.dollars).toBeCloseTo(53.1, 2);
+    expect(cost.inputTokens).toBe(1_100_000);
+    expect(cost.outputTokens).toBe(520_000);
+  });
+
+  it("assigns timeSavedHours only when run.status === 'completed'", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [{ stage: "implement", inputTokens: 0, outputTokens: 0 }] as any;
+    expect(computeRunCost(run, stages, config).timeSavedHours).toBe(6);
+  });
+
+  it("zero timeSavedHours on failed runs", () => {
+    const run = { pipelineKey: "auto-implement", status: "failed" } as any;
+    const stages = [{ stage: "implement", inputTokens: 1_000_000, outputTokens: 500_000 }] as any;
+    expect(computeRunCost(run, stages, config).timeSavedHours).toBe(0);
+  });
+
+  it("uses pipeline profile model when stageModels is empty", () => {
+    const run = { pipelineKey: "quick-fix", status: "completed" } as any;
+    const stages = [{ stage: "implement", inputTokens: 1_000_000, outputTokens: 1_000_000 }] as any;
+    const cost = computeRunCost(run, stages, config);
+    // sonnet: 1M × $3 + 1M × $15 = $18
+    expect(cost.dollars).toBeCloseTo(18, 2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `cost/per-run.ts`**
+
+```ts
+import { resolveModelRate, resolveTimeSavedPerPr } from "./rates.js";
+import type { RunCost } from "./types.js";
+
+interface PipelineRunRow {
+  pipelineKey: string;
+  status: string;
+}
+
+interface StageRunRow {
+  stage: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+interface CostConfig {
+  costs?: {
+    modelPricing?: Record<string, { inputPerMillion: number; outputPerMillion: number }>;
+    hourlyEngRate?: number;
+    timeSavedPerPrDefault?: number;
+  };
+  pipelineConfigs?: Record<string, {
+    stageModels?: Record<string, string>;
+    profile?: { model?: string };
+    timeSavedPerPr?: number;
+  }>;
+}
+
+export function computeRunCost(
+  run: PipelineRunRow,
+  stages: StageRunRow[],
+  config: CostConfig,
+): RunCost {
+  const pc = config.pipelineConfigs?.[run.pipelineKey];
+  let dollars = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  for (const s of stages) {
+    const modelName =
+      pc?.stageModels?.[s.stage] ??
+      pc?.profile?.model ??
+      "claude-sonnet-4-6";
+    const rate = resolveModelRate(modelName, config);
+    dollars += (s.inputTokens * rate.inputPerMillion) / 1_000_000;
+    dollars += (s.outputTokens * rate.outputPerMillion) / 1_000_000;
+    inputTokens += s.inputTokens;
+    outputTokens += s.outputTokens;
+  }
+  const timeSavedHours =
+    run.status === "completed" ? resolveTimeSavedPerPr(run.pipelineKey, config) : 0;
+  return { inputTokens, outputTokens, dollars, timeSavedHours };
+}
+```
+
+Add `export * from "./per-run.js";` to `cost/index.ts`.
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/cost/per-run.ts packages/core/src/cost/index.ts packages/core/src/__tests__/cost/per-run.test.ts
+git commit -m "feat(cost): per-run cost computation"
+```
+
+---
+
+## Task 4: Cost rollups table + migration
+
+**Files:**
+- Create: `packages/core/src/db/migrations/sqlite/007_cost_rollups.sql`
+- Create: `packages/core/src/db/migrations/postgres/008_cost_rollups.sql`
+- Modify: `packages/core/src/db/schema.ts`
+- Modify: `packages/core/src/db/client.ts` (`getCreateTablesDDL`)
+- Test: `packages/core/src/__tests__/db-cost-rollups-schema.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { costRollupsDaily } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("cost_rollups_daily schema", () => {
+  it("creates table with the expected columns", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const cols = (db as any).all(sql`PRAGMA table_info(cost_rollups_daily)`) as Array<{name: string}>;
+    expect(cols.map(c => c.name).sort()).toEqual([
+      "computed_at", "date", "dollars", "id", "input_tokens", "linear_team_id",
+      "output_tokens", "pipeline_key", "prs_merged", "repo_url", "runs", "time_saved_hours",
+    ]);
+  });
+
+  it("inserts and reads back a row", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(costRollupsDaily).values({
+      id: "r_1", date: "2026-04-01", pipelineKey: "auto-implement",
+      linearTeamId: "T1", repoUrl: "https://github.com/x/y",
+      runs: 5, prsMerged: 4, inputTokens: 1000, outputTokens: 500,
+      dollars: 12.34, timeSavedHours: 16,
+    });
+    const rows = await (db as any).select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dollars).toBeCloseTo(12.34, 2);
+    expect(rows[0].timeSavedHours).toBe(16);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-cost-rollups-schema.test.ts
+```
+
+- [ ] **Step 3: Add table to `db/schema.ts`**
+
+Append:
+```ts
+export const costRollupsDaily = sqliteTable("cost_rollups_daily", {
+  id: text("id").primaryKey(),
+  date: text("date").notNull(),
+  pipelineKey: text("pipeline_key").notNull(),
+  linearTeamId: text("linear_team_id"),
+  repoUrl: text("repo_url").notNull(),
+  runs: integer("runs").notNull().default(0),
+  prsMerged: integer("prs_merged").notNull().default(0),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  dollars: real("dollars").notNull().default(0),
+  timeSavedHours: real("time_saved_hours").notNull().default(0),
+  computedAt: crossTimestamp("computed_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (t) => [
+  unique().on(t.date, t.pipelineKey, t.linearTeamId, t.repoUrl),
+]);
+```
+
+If `real` isn't already imported from `drizzle-orm/sqlite-core`, add it to the existing import line in schema.ts.
+
+- [ ] **Step 4: Create SQLite migration**
+
+Create `packages/core/src/db/migrations/sqlite/007_cost_rollups.sql`:
+```sql
+-- Enterprise feature 4.5: cost rollups
+CREATE TABLE IF NOT EXISTS cost_rollups_daily (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  pipeline_key TEXT NOT NULL,
+  linear_team_id TEXT,
+  repo_url TEXT NOT NULL,
+  runs INTEGER NOT NULL DEFAULT 0,
+  prs_merged INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  dollars REAL NOT NULL DEFAULT 0,
+  time_saved_hours REAL NOT NULL DEFAULT 0,
+  computed_at INTEGER NOT NULL,
+  UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);
+```
+
+- [ ] **Step 5: Create Postgres migration**
+
+Create `packages/core/src/db/migrations/postgres/008_cost_rollups.sql`:
+```sql
+-- Enterprise feature 4.5: cost rollups
+CREATE TABLE IF NOT EXISTS cost_rollups_daily (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  pipeline_key TEXT NOT NULL,
+  linear_team_id TEXT,
+  repo_url TEXT NOT NULL,
+  runs INTEGER NOT NULL DEFAULT 0,
+  prs_merged INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  dollars DOUBLE PRECISION NOT NULL DEFAULT 0,
+  time_saved_hours DOUBLE PRECISION NOT NULL DEFAULT 0,
+  computed_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);
+```
+
+- [ ] **Step 6: Extend `getCreateTablesDDL()`**
+
+In `packages/core/src/db/client.ts`, inside `getCreateTablesDDL(driver)`, add a new interpolation variable alongside the existing `${ts}`:
+```ts
+const num = driver === "postgres" ? "DOUBLE PRECISION" : "REAL";
+```
+
+Append to the returned template string (before the closing backtick):
+```sql
+  CREATE TABLE IF NOT EXISTS cost_rollups_daily (
+    id TEXT PRIMARY KEY,
+    date TEXT NOT NULL,
+    pipeline_key TEXT NOT NULL,
+    linear_team_id TEXT,
+    repo_url TEXT NOT NULL,
+    runs INTEGER NOT NULL DEFAULT 0,
+    prs_merged INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    dollars ${num} NOT NULL DEFAULT 0,
+    time_saved_hours ${num} NOT NULL DEFAULT 0,
+    computed_at ${ts} NOT NULL,
+    UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+  );
+  CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
+  CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);
+```
+
+- [ ] **Step 7: Run, verify pass**
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/core/src/db packages/core/src/__tests__/db-cost-rollups-schema.test.ts
+git commit -m "feat(cost): add cost_rollups_daily table"
+```
+
+---
+
+## Task 5: Aggregation (`aggregateAll`)
+
+**Files:**
+- Create: `packages/core/src/cost/aggregate.ts`
+- Modify: `packages/core/src/cost/index.ts`
+- Test: `packages/core/src/__tests__/cost/aggregate.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns, stageRuns } from "../../db/schema.js";
+import { aggregateAll } from "../../cost/aggregate.js";
+
+let db: any;
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+      "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": {
+      stageModels: { implement: "claude-opus-4-6" },
+      profile: { model: "claude-sonnet-4-6" },
+      timeSavedPerPr: 6,
+    } as any,
+    "quick-fix": {
+      profile: { model: "claude-sonnet-4-6" },
+    } as any,
+  },
+} as any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+async function seedRun(id: string, opts: {
+  pipelineKey: string; teamId?: string; repoUrl: string;
+  status?: string; implementInputTokens?: number; implementOutputTokens?: number;
+  completedAt: Date;
+}) {
+  await db.insert(pipelineRuns).values({
+    id, issueId: `BEC-${id}`, issueTitle: "t",
+    pipelineKey: opts.pipelineKey,
+    repoUrl: opts.repoUrl,
+    status: opts.status ?? "completed",
+    startedAt: new Date(opts.completedAt.getTime() - 60000),
+    completedAt: opts.completedAt,
+    linearTeamId: opts.teamId,
+  });
+  if (opts.implementInputTokens || opts.implementOutputTokens) {
+    await db.insert(stageRuns).values({
+      id: `s_${id}_imp`, pipelineRunId: id, stage: "implement",
+      status: "completed",
+      startedAt: new Date(opts.completedAt.getTime() - 60000),
+      completedAt: opts.completedAt,
+      inputTokens: opts.implementInputTokens ?? 0,
+      outputTokens: opts.implementOutputTokens ?? 0,
+    });
+  }
+}
+
+describe("aggregateAll", () => {
+  it("returns zero totals for an empty db", async () => {
+    const r = await aggregateAll(db, { from: new Date("2026-01-01"), to: new Date("2026-12-31") }, config);
+    expect(r.summary.runs).toBe(0);
+    expect(r.summary.dollars).toBe(0);
+    expect(r.summary.timeSavedHours).toBe(0);
+    expect(r.byTeam).toEqual([]);
+    expect(r.byRepo).toEqual([]);
+    expect(r.byPipeline).toEqual([]);
+  });
+
+  it("aggregates across pipelines with correct dollar math", async () => {
+    await seedRun("1", {
+      pipelineKey: "auto-implement", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 1_000_000, implementOutputTokens: 500_000,
+      completedAt: new Date("2026-04-01T10:00:00Z"),
+    });
+    await seedRun("2", {
+      pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-02T10:00:00Z"),
+    });
+
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-04-30T23:59:59Z"),
+    }, config);
+
+    // run 1 (opus implement): 1M × $15 + 0.5M × $75 = $52.50
+    // run 2 (sonnet implement): 0.1M × $3 + 0.05M × $15 = $1.05
+    expect(r.summary.runs).toBe(2);
+    expect(r.summary.prsMerged).toBe(2);
+    expect(r.summary.dollars).toBeCloseTo(53.55, 2);
+    // time saved: run 1 (auto-implement override = 6h) + run 2 (quick-fix default = 4h) = 10h
+    expect(r.summary.timeSavedHours).toBe(10);
+
+    // byTeam: one row (T1) with summed totals
+    expect(r.byTeam).toHaveLength(1);
+    expect(r.byTeam[0].key).toBe("team:T1");
+    expect(r.byTeam[0].dollars).toBeCloseTo(53.55, 2);
+
+    // byPipeline: two rows (auto-implement, quick-fix)
+    expect(r.byPipeline).toHaveLength(2);
+    const auto = r.byPipeline.find((b: any) => b.key === "pipeline:auto-implement")!;
+    expect(auto.dollars).toBeCloseTo(52.50, 2);
+    expect(auto.timeSavedHours).toBe(6);
+
+    // ROI = (timeSavedHours × hourlyEngRate) / dollars = (10 × 50) / 53.55 ≈ 9.34
+    expect(r.summary.roiMultiplier).toBeCloseTo(500 / 53.55, 2);
+  });
+
+  it("excludes runs outside the window", async () => {
+    await seedRun("1", {
+      pipelineKey: "quick-fix",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-01-01T10:00:00Z"),
+    });
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-04-30T23:59:59Z"),
+    }, config);
+    expect(r.summary.runs).toBe(0);
+  });
+
+  it("counts failed runs in cost but not in prsMerged / timeSaved", async () => {
+    await seedRun("1", {
+      pipelineKey: "quick-fix", status: "failed",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-01T10:00:00Z"),
+    });
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-04-30T23:59:59Z"),
+    }, config);
+    expect(r.summary.runs).toBe(1);
+    expect(r.summary.prsMerged).toBe(0);
+    expect(r.summary.timeSavedHours).toBe(0);
+    expect(r.summary.dollars).toBeCloseTo(1.05, 2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `cost/aggregate.ts`**
+
+```ts
+import { and, gte, lte, inArray } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { computeRunCost } from "./per-run.js";
+import type { AggregateResult, BreakdownRow, CostSummary } from "./types.js";
+
+export interface AggregateFilters {
+  from: Date;
+  to: Date;
+}
+
+interface CostConfig {
+  costs?: {
+    hourlyEngRate?: number;
+    modelPricing?: Record<string, { inputPerMillion: number; outputPerMillion: number }>;
+    timeSavedPerPrDefault?: number;
+  };
+  pipelineConfigs?: Record<string, any>;
+}
+
+function emptyBucket(key: string, label: string): BreakdownRow {
+  return {
+    key, label, runs: 0, prsMerged: 0,
+    inputTokens: 0, outputTokens: 0,
+    dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+  };
+}
+
+function finalizeRoi(row: { dollars: number; timeSavedHours: number }, hourlyRate: number): number {
+  if (row.dollars === 0) return row.timeSavedHours > 0 ? Infinity : 0;
+  return (row.timeSavedHours * hourlyRate) / row.dollars;
+}
+
+export async function aggregateAll(
+  db: AnyDb,
+  filters: AggregateFilters,
+  config: CostConfig,
+): Promise<AggregateResult> {
+  const hourlyRate = config.costs?.hourlyEngRate ?? 50;
+
+  const runs = await db.select().from(pipelineRuns).where(
+    and(
+      gte(pipelineRuns.completedAt, filters.from),
+      lte(pipelineRuns.completedAt, filters.to),
+    ),
+  );
+
+  if (runs.length === 0) {
+    return {
+      summary: {
+        window: { from: filters.from, to: filters.to },
+        runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
+        dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+      },
+      byTeam: [], byRepo: [], byPipeline: [],
+    };
+  }
+
+  const runIds = runs.map((r: any) => r.id);
+  const stages = await db.select().from(stageRuns).where(inArray(stageRuns.pipelineRunId, runIds));
+
+  const stagesByRun = new Map<string, any[]>();
+  for (const s of stages) {
+    const arr = stagesByRun.get(s.pipelineRunId) ?? [];
+    arr.push(s);
+    stagesByRun.set(s.pipelineRunId, arr);
+  }
+
+  const summary: CostSummary = {
+    window: { from: filters.from, to: filters.to },
+    runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
+    dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+  };
+  const byTeam = new Map<string, BreakdownRow>();
+  const byRepo = new Map<string, BreakdownRow>();
+  const byPipeline = new Map<string, BreakdownRow>();
+
+  for (const run of runs) {
+    const runStages = stagesByRun.get(run.id) ?? [];
+    const cost = computeRunCost(run as any, runStages as any, config);
+
+    summary.runs += 1;
+    summary.inputTokens += cost.inputTokens;
+    summary.outputTokens += cost.outputTokens;
+    summary.dollars += cost.dollars;
+    summary.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") summary.prsMerged += 1;
+
+    const teamKey = `team:${run.linearTeamId ?? "unassigned"}`;
+    const teamLabel = run.linearTeamId ?? "(unassigned)";
+    if (!byTeam.has(teamKey)) byTeam.set(teamKey, emptyBucket(teamKey, teamLabel));
+    const tb = byTeam.get(teamKey)!;
+    tb.runs += 1; tb.inputTokens += cost.inputTokens; tb.outputTokens += cost.outputTokens;
+    tb.dollars += cost.dollars; tb.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") tb.prsMerged += 1;
+
+    const repoKey = `repo:${run.repoUrl}`;
+    if (!byRepo.has(repoKey)) byRepo.set(repoKey, emptyBucket(repoKey, run.repoUrl));
+    const rb = byRepo.get(repoKey)!;
+    rb.runs += 1; rb.inputTokens += cost.inputTokens; rb.outputTokens += cost.outputTokens;
+    rb.dollars += cost.dollars; rb.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") rb.prsMerged += 1;
+
+    const pipelineKey = `pipeline:${run.pipelineKey}`;
+    if (!byPipeline.has(pipelineKey)) byPipeline.set(pipelineKey, emptyBucket(pipelineKey, run.pipelineKey));
+    const pb = byPipeline.get(pipelineKey)!;
+    pb.runs += 1; pb.inputTokens += cost.inputTokens; pb.outputTokens += cost.outputTokens;
+    pb.dollars += cost.dollars; pb.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") pb.prsMerged += 1;
+  }
+
+  summary.roiMultiplier = finalizeRoi(summary, hourlyRate);
+  const sort = (a: BreakdownRow, b: BreakdownRow) => b.dollars - a.dollars;
+  const finalize = (rows: BreakdownRow[]) => {
+    for (const r of rows) r.roiMultiplier = finalizeRoi(r, hourlyRate);
+    return rows.sort(sort);
+  };
+
+  return {
+    summary,
+    byTeam: finalize(Array.from(byTeam.values())),
+    byRepo: finalize(Array.from(byRepo.values())),
+    byPipeline: finalize(Array.from(byPipeline.values())),
+  };
+}
+```
+
+Add `export * from "./aggregate.js";` to `cost/index.ts`.
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/cost/aggregate.ts packages/core/src/cost/index.ts packages/core/src/__tests__/cost/aggregate.test.ts
+git commit -m "feat(cost): aggregateAll over pipeline_runs + stage_runs"
+```
+
+---
+
+## Task 6: Rollup job
+
+**Files:**
+- Create: `packages/core/src/cost/rollup.ts`
+- Modify: `packages/core/src/cost/index.ts`
+- Test: `packages/core/src/__tests__/cost/rollup.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../../db/schema.js";
+import { recomputeCostRollups, readRollupWindow } from "../../cost/rollup.js";
+
+let db: any;
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "quick-fix": { profile: { model: "claude-sonnet-4-6" } } as any,
+  },
+} as any;
+
+async function seedCompletedRun(id: string, completedAt: Date) {
+  await db.insert(pipelineRuns).values({
+    id, issueId: `BEC-${id}`, issueTitle: "t",
+    pipelineKey: "quick-fix", repoUrl: "https://github.com/acme/api",
+    status: "completed",
+    startedAt: new Date(completedAt.getTime() - 60000),
+    completedAt,
+    linearTeamId: "T1",
+  });
+  await db.insert(stageRuns).values({
+    id: `s_${id}`, pipelineRunId: id, stage: "implement",
+    status: "completed",
+    startedAt: new Date(completedAt.getTime() - 60000),
+    completedAt,
+    inputTokens: 100_000,
+    outputTokens: 50_000,
+  });
+}
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+describe("recomputeCostRollups", () => {
+  it("writes one row per (date, pipeline, team, repo) for yesterday", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    await seedCompletedRun("r1", yesterday);
+    await seedCompletedRun("r2", yesterday);
+    const result = await recomputeCostRollups(db, config);
+    expect(result.rowsWritten).toBeGreaterThan(0);
+    const rows = await db.select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].runs).toBe(2);
+    expect(rows[0].prsMerged).toBe(2);
+    expect(rows[0].inputTokens).toBe(200_000);
+    expect(rows[0].outputTokens).toBe(100_000);
+    // sonnet: 0.2M × $3 + 0.1M × $15 = $0.60 + $1.50 = $2.10
+    expect(rows[0].dollars).toBeCloseTo(2.10, 2);
+    expect(rows[0].timeSavedHours).toBe(8);
+  });
+
+  it("is idempotent — re-running on the same day doesn't double-count", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    await seedCompletedRun("r1", yesterday);
+    await recomputeCostRollups(db, config);
+    await recomputeCostRollups(db, config);
+    const rows = await db.select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].runs).toBe(1);
+  });
+
+  it("readRollupWindow returns rows inside the window", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    await seedCompletedRun("r1", yesterday);
+    await recomputeCostRollups(db, config);
+    const from = new Date(Date.now() - 7 * 86400_000);
+    const to = new Date();
+    const rows = await readRollupWindow(db, from, to);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `cost/rollup.ts`**
+
+```ts
+import { randomUUID } from "node:crypto";
+import { and, gte, lte, eq, desc } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { computeRunCost } from "./per-run.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "cost.rollup" });
+
+interface CostConfig {
+  costs?: {
+    modelPricing?: Record<string, { inputPerMillion: number; outputPerMillion: number }>;
+    timeSavedPerPrDefault?: number;
+    hourlyEngRate?: number;
+  };
+  pipelineConfigs?: Record<string, any>;
+}
+
+function dayBounds(dateStr: string): { start: Date; end: Date } {
+  const start = new Date(dateStr + "T00:00:00.000Z");
+  const end = new Date(dateStr + "T23:59:59.999Z");
+  return { start, end };
+}
+
+function utcDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function recomputeCostRollups(
+  db: AnyDb,
+  config: CostConfig,
+): Promise<{ rowsWritten: number }> {
+  // Determine yesterday (UTC). Rollups only cover completed UTC days.
+  const now = new Date();
+  const yesterdayUtc = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1,
+  ));
+  const dateStr = utcDateStr(yesterdayUtc);
+  const { start, end } = dayBounds(dateStr);
+
+  const runs = await db.select().from(pipelineRuns).where(
+    and(
+      gte(pipelineRuns.completedAt, start),
+      lte(pipelineRuns.completedAt, end),
+    ),
+  );
+
+  if (runs.length === 0) {
+    log.info({ date: dateStr, rowsWritten: 0 }, "no runs to roll up");
+    return { rowsWritten: 0 };
+  }
+
+  const runIds = runs.map((r: any) => r.id);
+  const stages = await db.select().from(stageRuns).where(
+    // TS-friendly inArray via raw SQL if inArray is unavailable here
+    // (imported separately in the real file)
+    inArrayHelper(stageRuns.pipelineRunId, runIds),
+  );
+
+  const stagesByRun = new Map<string, any[]>();
+  for (const s of stages) {
+    const arr = stagesByRun.get(s.pipelineRunId) ?? [];
+    arr.push(s);
+    stagesByRun.set(s.pipelineRunId, arr);
+  }
+
+  const buckets = new Map<string, {
+    pipelineKey: string; linearTeamId: string | null; repoUrl: string;
+    runs: number; prsMerged: number; inputTokens: number; outputTokens: number;
+    dollars: number; timeSavedHours: number;
+  }>();
+
+  for (const run of runs) {
+    const runStages = stagesByRun.get(run.id) ?? [];
+    const cost = computeRunCost(run as any, runStages as any, config);
+    const key = `${run.pipelineKey}|${run.linearTeamId ?? ""}|${run.repoUrl}`;
+    let b = buckets.get(key);
+    if (!b) {
+      b = {
+        pipelineKey: run.pipelineKey,
+        linearTeamId: run.linearTeamId ?? null,
+        repoUrl: run.repoUrl,
+        runs: 0, prsMerged: 0,
+        inputTokens: 0, outputTokens: 0,
+        dollars: 0, timeSavedHours: 0,
+      };
+      buckets.set(key, b);
+    }
+    b.runs += 1;
+    b.inputTokens += cost.inputTokens;
+    b.outputTokens += cost.outputTokens;
+    b.dollars += cost.dollars;
+    b.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") b.prsMerged += 1;
+  }
+
+  let rowsWritten = 0;
+  for (const b of buckets.values()) {
+    await db.insert(costRollupsDaily).values({
+      id: `cr_${randomUUID()}`,
+      date: dateStr,
+      pipelineKey: b.pipelineKey,
+      linearTeamId: b.linearTeamId,
+      repoUrl: b.repoUrl,
+      runs: b.runs,
+      prsMerged: b.prsMerged,
+      inputTokens: b.inputTokens,
+      outputTokens: b.outputTokens,
+      dollars: b.dollars,
+      timeSavedHours: b.timeSavedHours,
+      computedAt: new Date(),
+    }).onConflictDoUpdate({
+      target: [
+        costRollupsDaily.date,
+        costRollupsDaily.pipelineKey,
+        costRollupsDaily.linearTeamId,
+        costRollupsDaily.repoUrl,
+      ],
+      set: {
+        runs: b.runs,
+        prsMerged: b.prsMerged,
+        inputTokens: b.inputTokens,
+        outputTokens: b.outputTokens,
+        dollars: b.dollars,
+        timeSavedHours: b.timeSavedHours,
+        computedAt: new Date(),
+      },
+    });
+    rowsWritten += 1;
+  }
+
+  log.info({ date: dateStr, rowsWritten }, "cost rollup complete");
+  return { rowsWritten };
+}
+
+export async function readRollupWindow(
+  db: AnyDb,
+  from: Date,
+  to: Date,
+): Promise<any[]> {
+  const fromDate = utcDateStr(from);
+  const toDate = utcDateStr(to);
+  return await db.select().from(costRollupsDaily).where(
+    and(
+      gte(costRollupsDaily.date, fromDate),
+      lte(costRollupsDaily.date, toDate),
+    ),
+  );
+}
+
+// NOTE: replace this helper with a real `inArray(...)` import from drizzle-orm
+// in the real implementation:
+function inArrayHelper(col: any, values: any[]): any {
+  // Implemented via drizzle `inArray(col, values)`; this stub exists so the
+  // plan snippet compiles as shown. Real code should `import { inArray } from "drizzle-orm"`.
+  throw new Error("replace with drizzle-orm inArray");
+}
+```
+
+**Note to implementer:** replace `inArrayHelper` with a real `inArray` import from `drizzle-orm`. The stub is just so the plan code block reads cleanly.
+
+Add `export * from "./rollup.js";` to `cost/index.ts`.
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/cost/rollup.ts packages/core/src/cost/index.ts packages/core/src/__tests__/cost/rollup.test.ts
+git commit -m "feat(cost): daily rollup job with idempotent upsert"
+```
+
+---
+
+## Task 7: CSV export
+
+**Files:**
+- Create: `packages/core/src/cost/csv.ts`
+- Modify: `packages/core/src/cost/index.ts`
+- Test: `packages/core/src/__tests__/cost/csv.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns, stageRuns } from "../../db/schema.js";
+import { streamCostCsv } from "../../cost/csv.js";
+
+async function collect(iter: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const chunk of iter) out += chunk;
+  return out;
+}
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "quick-fix": { profile: { model: "claude-sonnet-4-6" } } as any,
+  },
+} as any;
+
+describe("streamCostCsv", () => {
+  it("emits header then one row per run", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await db.insert(pipelineRuns).values({
+      id: "r1", issueId: "BEC-1", issueTitle: "t",
+      pipelineKey: "quick-fix", repoUrl: "https://github.com/acme/api",
+      status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+      linearTeamId: "T1",
+    });
+    await db.insert(stageRuns).values({
+      id: "s1", pipelineRunId: "r1", stage: "implement", status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+      inputTokens: 100_000, outputTokens: 50_000,
+    });
+
+    const csv = await collect(streamCostCsv(db, {
+      from: new Date("2026-04-01"),
+      to: new Date("2026-04-30"),
+    }, config));
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe("completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours");
+    expect(lines[1]).toContain("r1");
+    expect(lines[1]).toContain("BEC-1");
+    expect(lines[1]).toContain("quick-fix");
+  });
+
+  it("escapes formula-injection prefixes", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await db.insert(pipelineRuns).values({
+      id: "r1", issueId: "=HYPERLINK(evil)", issueTitle: "t",
+      pipelineKey: "quick-fix", repoUrl: "https://github.com/acme/api",
+      status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+    });
+    const csv = await collect(streamCostCsv(db, {
+      from: new Date("2026-04-01"),
+      to: new Date("2026-04-30"),
+    }, config));
+    expect(csv).toContain("'=HYPERLINK(evil)");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `cost/csv.ts`**
+
+```ts
+import type { AnyDb } from "../db/client.js";
+import { and, gte, lte, inArray } from "drizzle-orm";
+import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { computeRunCost } from "./per-run.js";
+
+const HEADER =
+  "completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours";
+
+const FORMULA_PREFIX = /^[=+\-@\t]/;
+
+function escapeCsvField(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  let s = String(value);
+  if (FORMULA_PREFIX.test(s)) s = "'" + s;
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export interface CsvFilters {
+  from: Date;
+  to: Date;
+}
+
+interface CostConfig {
+  costs?: any;
+  pipelineConfigs?: Record<string, any>;
+}
+
+export async function* streamCostCsv(
+  db: AnyDb,
+  filters: CsvFilters,
+  config: CostConfig,
+): AsyncIterable<string> {
+  yield HEADER + "\n";
+
+  const runs = await db.select().from(pipelineRuns).where(
+    and(
+      gte(pipelineRuns.completedAt, filters.from),
+      lte(pipelineRuns.completedAt, filters.to),
+    ),
+  );
+  if (runs.length === 0) return;
+
+  const runIds = runs.map((r: any) => r.id);
+  const stages = await db.select().from(stageRuns).where(inArray(stageRuns.pipelineRunId, runIds));
+  const stagesByRun = new Map<string, any[]>();
+  for (const s of stages) {
+    const arr = stagesByRun.get(s.pipelineRunId) ?? [];
+    arr.push(s);
+    stagesByRun.set(s.pipelineRunId, arr);
+  }
+
+  for (const run of runs) {
+    const runStages = stagesByRun.get(run.id) ?? [];
+    const cost = computeRunCost(run as any, runStages as any, config);
+    const fields = [
+      run.completedAt?.toISOString() ?? "",
+      run.id,
+      run.issueId,
+      run.pipelineKey,
+      run.linearTeamId ?? "",
+      run.repoUrl,
+      cost.inputTokens,
+      cost.outputTokens,
+      cost.dollars.toFixed(4),
+      cost.timeSavedHours,
+    ].map(escapeCsvField);
+    yield fields.join(",") + "\n";
+  }
+}
+```
+
+Add `export * from "./csv.js";` to `cost/index.ts`.
+
+- [ ] **Step 4: Run, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/cost/csv.ts packages/core/src/cost/index.ts packages/core/src/__tests__/cost/csv.test.ts
+git commit -m "feat(cost): streaming CSV export"
+```
+
+---
+
+## Task 8: License flag + core barrel re-export
+
+**Files:**
+- Modify: `packages/core/src/license.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/src/__tests__/cost-license.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { _resetLicenseCache, isFeatureLicensed } from "../license.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+beforeEach(() => { _resetLicenseCache(); });
+afterEach(async () => { await restoreLicense(); });
+
+describe("cost-roi feature flag", () => {
+  it("licensed at enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    expect(isFeatureLicensed("cost-roi")).toBe(true);
+  });
+
+  it("not licensed at pro tier", async () => {
+    await installTestProLicense("pro");
+    expect(isFeatureLicensed("cost-roi")).toBe(false);
+  });
+
+  it("not licensed without a license", async () => {
+    await restoreLicense();
+    expect(isFeatureLicensed("cost-roi")).toBe(false);
+  });
+
+  it("cost module re-exported from @urateam/core barrel", async () => {
+    const mod = await import("../index.js");
+    expect(typeof (mod as any).computeRunCost).toBe("function");
+    expect(typeof (mod as any).aggregateAll).toBe("function");
+    expect(typeof (mod as any).resolveModelRate).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Add `"cost-roi"` to Enterprise feature set**
+
+Find `ENTERPRISE_FEATURES` in `packages/core/src/license.ts` and add `"cost-roi"`. Verify the array also contains `"audit-log"` (as baseline — it should, from feature 4.2).
+
+- [ ] **Step 4: Re-export from core barrel**
+
+In `packages/core/src/index.ts` add:
+```ts
+export * from "./cost/index.js";
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/license.ts packages/core/src/index.ts packages/core/src/__tests__/cost-license.test.ts
+git commit -m "feat(cost): add cost-roi to enterprise feature set"
+```
+
+---
+
+## Task 9: PM scheduler rollup step
+
+**Files:**
+- Modify: `packages/core/src/pm/scheduler.ts`
+- Test: `packages/core/src/__tests__/pm-cost-rollup-step.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../db/client.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+// Mirror the pattern from pm-audit-retention-step.test.ts for tick invocation
+
+describe("pm cost rollup step", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+  afterEach(async () => { await restoreLicense(); });
+
+  it("writes cost_rollups_daily rows from yesterday's runs when licensed", async () => {
+    const db = await createDb({ connectionString: ":memory:" }) as any;
+    const yesterday = new Date(Date.now() - 86400_000);
+    await db.insert(pipelineRuns).values({
+      id: "r1", issueId: "BEC-1", issueTitle: "t",
+      pipelineKey: "quick-fix", repoUrl: "https://github.com/x/y",
+      status: "completed",
+      startedAt: new Date(yesterday.getTime() - 60000),
+      completedAt: yesterday,
+    });
+    await db.insert(stageRuns).values({
+      id: "s1", pipelineRunId: "r1", stage: "implement", status: "completed",
+      startedAt: new Date(yesterday.getTime() - 60000),
+      completedAt: yesterday,
+      inputTokens: 1000, outputTokens: 500,
+    });
+
+    // Call the tick (match the existing pm-audit-retention-step.test.ts pattern).
+    // The tick runs pruneAuditLog, pruneExpiredSessions, then recomputeCostRollups.
+    // ... (inline the tick harness pattern from pm-audit-retention-step.test.ts)
+
+    const rollups = await db.select().from(costRollupsDaily);
+    expect(rollups.length).toBeGreaterThan(0);
+  });
+});
+```
+
+Note to implementer: read `packages/core/src/__tests__/pm-audit-retention-step.test.ts` first — that file sets up the tick harness. Copy its pattern to invoke the tick without re-inventing it.
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Add the rollup step to `pm/scheduler.ts`**
+
+Find the block that calls `pruneAuditLog` (feature 4.2) and `pruneExpiredSessions` (feature 4.1). Add after them, inside the same try/catch pattern:
+
+```ts
+try {
+  if (isFeatureLicensed("cost-roi")) {
+    const { recomputeCostRollups } = await import("../cost/index.js");
+    await recomputeCostRollups(db, config as any);
+  }
+} catch (err) {
+  log.warn({ err }, "cost rollup failed");
+}
+```
+
+If a static import doesn't create a cycle, prefer that — add `import { recomputeCostRollups } from "../cost/index.js";` at the top.
+
+- [ ] **Step 4: Run new test + full pm suite**
+
+```
+cd packages/core && npx vitest run src/__tests__/pm
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/pm/scheduler.ts packages/core/src/__tests__/pm-cost-rollup-step.test.ts
+git commit -m "feat(cost): run daily cost rollups in pm tick"
+```
+
+---
+
+## Task 10: Dashboard route + view
+
+**Files:**
+- Create: `packages/dashboard/src/routes/cost.ts`
+- Create: `packages/dashboard/src/views/cost.ts`
+- Modify: `packages/dashboard/src/views/layout.ts`
+- Modify: `packages/dashboard/src/server.ts`
+- Test: `packages/dashboard/src/__tests__/cost.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Model after `packages/dashboard/src/__tests__/audit.test.ts`. Include tests for:
+- Unlicensed → 404 on `/cost`, `/cost/page`, `/cost/export.csv`
+- Licensed → 200, page contains "PRs merged", contains a seeded pipeline name, contains a dollar amount
+- Licensed → CSV export 200 with `text/csv` content-type and the header row
+
+Use `installTestProLicense("enterprise")` via an inlined helper (see `audit.test.ts` for the pattern). Seed a completed pipeline run + stage run directly via `@urateam/core/dist/db/schema.js` subpath import (same pattern as `audit.test.ts`).
+
+Full test code:
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "@urateam/core";
+import { buildServer } from "../server.js";
+// inline the installTestProLicense helper pattern from audit.test.ts
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "quick-fix": { profile: { model: "claude-sonnet-4-6" } },
+  },
+};
+
+describe("/cost routes", () => {
+  let db: any;
+  let app: any;
+
+  beforeEach(async () => {
+    db = await createDb({ connectionString: ":memory:" });
+    app = buildServer({ db, costs: config.costs, pipelineConfigs: config.pipelineConfigs });
+  });
+
+  it("returns 404 when cost-roi feature is not licensed", async () => {
+    const res = await app.request("/cost");
+    expect(res.status).toBe(404);
+  });
+
+  it("renders cost page when licensed", async () => {
+    await installTestProLicense("enterprise");
+    app = buildServer({ db, costs: config.costs, pipelineConfigs: config.pipelineConfigs });
+    // seed a run ...
+    const res = await app.request("/cost");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("PRs merged");
+    await restoreLicense();
+  });
+
+  it("streams CSV export when licensed", async () => {
+    await installTestProLicense("enterprise");
+    app = buildServer({ db, costs: config.costs, pipelineConfigs: config.pipelineConfigs });
+    const res = await app.request("/cost/export.csv");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/csv");
+    const body = await res.text();
+    expect(body).toContain("completed_at,run_id,issue_id,pipeline_key");
+    await restoreLicense();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `packages/dashboard/src/routes/cost.ts`**
+
+```ts
+import { Hono } from "hono";
+import { isFeatureLicensed, aggregateAll, streamCostCsv } from "@urateam/core";
+import { renderCostPage } from "../views/cost.js";
+
+interface CostRouterDeps {
+  db: any;
+  costs: any;
+  pipelineConfigs: Record<string, any>;
+}
+
+function parseWindow(url: URL): { from: Date; to: Date; preset: string } {
+  const preset = url.searchParams.get("window") ?? "30d";
+  const now = new Date();
+  let from: Date;
+  let to: Date = now;
+  if (preset === "custom") {
+    from = url.searchParams.get("from") ? new Date(url.searchParams.get("from")!) : new Date(now.getTime() - 30 * 86400_000);
+    to = url.searchParams.get("to") ? new Date(url.searchParams.get("to")!) : now;
+  } else {
+    const days = preset === "7d" ? 7 : preset === "90d" ? 90 : preset === "365d" ? 365 : 30;
+    from = new Date(now.getTime() - days * 86400_000);
+  }
+  return { from, to, preset };
+}
+
+export function createCostRouter(deps: CostRouterDeps): Hono {
+  const app = new Hono();
+
+  app.use("*", async (c, next) => {
+    if (!isFeatureLicensed("cost-roi")) return c.notFound();
+    await next();
+  });
+
+  app.get("/", async (c) => {
+    const url = new URL(c.req.url);
+    const { from, to, preset } = parseWindow(url);
+    const result = await aggregateAll(deps.db, { from, to }, {
+      costs: deps.costs,
+      pipelineConfigs: deps.pipelineConfigs,
+    });
+    return c.html(renderCostPage({ result, filters: { from, to, preset }, costs: deps.costs }));
+  });
+
+  app.get("/page", async (c) => {
+    const url = new URL(c.req.url);
+    const { from, to, preset } = parseWindow(url);
+    const result = await aggregateAll(deps.db, { from, to }, {
+      costs: deps.costs,
+      pipelineConfigs: deps.pipelineConfigs,
+    });
+    return c.html(renderCostPage({ result, filters: { from, to, preset }, costs: deps.costs, partial: true }));
+  });
+
+  app.get("/export.csv", async (c) => {
+    const url = new URL(c.req.url);
+    const { from, to } = parseWindow(url);
+    const stream = streamCostCsv(deps.db, { from, to }, {
+      costs: deps.costs,
+      pipelineConfigs: deps.pipelineConfigs,
+    });
+    const readable = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of stream) controller.enqueue(new TextEncoder().encode(chunk));
+        controller.close();
+      },
+    });
+    const fromStr = from.toISOString().slice(0, 10);
+    const toStr = to.toISOString().slice(0, 10);
+    return new Response(readable, {
+      headers: {
+        "content-type": "text/csv; charset=utf-8",
+        "content-disposition": `attachment; filename="cost-${fromStr}-${toStr}.csv"`,
+      },
+    });
+  });
+
+  return app;
+}
+```
+
+- [ ] **Step 4: Create `packages/dashboard/src/views/cost.ts`**
+
+Read `packages/dashboard/src/views/audit.ts` first for the existing escape/render pattern. Then implement:
+
+```ts
+import { layout } from "./layout.js";
+import type { AggregateResult } from "@urateam/core";
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+function fmtNumber(n: number): string {
+  return n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+}
+
+function fmtDollars(n: number): string {
+  return "$" + n.toFixed(2);
+}
+
+function fmtRoi(n: number): string {
+  if (!isFinite(n)) return "∞";
+  return n.toFixed(1) + "×";
+}
+
+interface CostPageInput {
+  result: AggregateResult;
+  filters: { from: Date; to: Date; preset: string };
+  costs: any;
+  partial?: boolean;
+}
+
+export function renderCostPage(input: CostPageInput): string {
+  const { summary, byTeam, byRepo, byPipeline } = input.result;
+  const hourlyRate = input.costs?.hourlyEngRate ?? 50;
+  const value = summary.timeSavedHours * hourlyRate;
+
+  const renderTable = (title: string, rows: typeof byTeam) => `
+    <h3>${escapeHtml(title)}</h3>
+    <table class="cost-breakdown">
+      <thead><tr>
+        <th>Name</th><th>Runs</th><th>PRs merged</th><th>Hours saved</th>
+        <th>Tokens</th><th>$</th><th>ROI</th>
+      </tr></thead>
+      <tbody>
+        ${rows.map(r => `
+          <tr>
+            <td>${escapeHtml(r.label)}</td>
+            <td>${fmtNumber(r.runs)}</td>
+            <td>${fmtNumber(r.prsMerged)}</td>
+            <td>${fmtNumber(r.timeSavedHours)}</td>
+            <td>${fmtNumber(r.inputTokens + r.outputTokens)}</td>
+            <td>${fmtDollars(r.dollars)}</td>
+            <td>${fmtRoi(r.roiMultiplier)}</td>
+          </tr>
+        `).join("")}
+      </tbody>
+    </table>`;
+
+  const body = `
+    <h1>Cost &amp; ROI</h1>
+    <form hx-get="/cost/page" hx-trigger="change" hx-target="#cost-body">
+      <select name="window">
+        <option value="7d"${input.filters.preset === "7d" ? " selected" : ""}>Last 7 days</option>
+        <option value="30d"${input.filters.preset === "30d" ? " selected" : ""}>Last 30 days</option>
+        <option value="90d"${input.filters.preset === "90d" ? " selected" : ""}>Last 90 days</option>
+        <option value="365d"${input.filters.preset === "365d" ? " selected" : ""}>Last 365 days</option>
+        <option value="custom"${input.filters.preset === "custom" ? " selected" : ""}>Custom</option>
+      </select>
+      ${input.filters.preset === "custom" ? `
+        <input type="date" name="from" value="${input.filters.from.toISOString().slice(0,10)}" />
+        <input type="date" name="to" value="${input.filters.to.toISOString().slice(0,10)}" />
+      ` : ""}
+      <a href="/cost/export.csv?window=${escapeHtml(input.filters.preset)}&from=${input.filters.from.toISOString().slice(0,10)}&to=${input.filters.to.toISOString().slice(0,10)}" class="button">Export CSV</a>
+    </form>
+
+    <div id="cost-body">
+      <div class="summary-card">
+        <p><strong>${fmtNumber(summary.prsMerged)} PRs merged</strong> · <strong>${fmtNumber(summary.timeSavedHours)}h saved</strong></p>
+        <p>${fmtNumber(summary.inputTokens + summary.outputTokens)} tokens · ${fmtDollars(summary.dollars)} cost</p>
+        <p><strong>ROI:</strong> ${fmtNumber(summary.timeSavedHours)}h × ${fmtDollars(hourlyRate)}/h = ${fmtDollars(value)} value ÷ ${fmtDollars(summary.dollars)} cost = ${fmtRoi(summary.roiMultiplier)}</p>
+      </div>
+      ${renderTable("By team", byTeam)}
+      ${renderTable("By repo", byRepo)}
+      ${renderTable("By pipeline", byPipeline)}
+
+      <details>
+        <summary>Formula</summary>
+        <p>Time saved per PR is ${fmtNumber(input.costs?.timeSavedPerPrDefault ?? 4)}h by default, overridable per pipeline.</p>
+        <p>Dollar cost is computed per-stage from each stage's model:</p>
+        <ul>
+          ${Object.entries(input.costs?.modelPricing ?? {}).map(([model, rate]: [string, any]) =>
+            `<li>${escapeHtml(model)}: $${rate.inputPerMillion}/M input, $${rate.outputPerMillion}/M output</li>`
+          ).join("")}
+        </ul>
+        <p>Hourly engineer rate (for ROI): ${fmtDollars(hourlyRate)}</p>
+        <p>ROI = (hours saved × hourly rate) / dollar cost</p>
+      </details>
+    </div>
+  `;
+
+  if (input.partial) return body;
+  return layout({ title: "Cost & ROI", body });
+}
+```
+
+- [ ] **Step 5: Wire into `server.ts`**
+
+In `buildServer`, accept `costs` and `pipelineConfigs` in the deps (they likely already exist). Register:
+```ts
+import { createCostRouter } from "./routes/cost.js";
+// ...
+app.route("/cost", createCostRouter({
+  db: config.db,
+  costs: config.costs,
+  pipelineConfigs: config.pipelineConfigs,
+}));
+```
+
+The cost router's internal middleware gates on `isFeatureLicensed("cost-roi")`, so no outer check needed.
+
+- [ ] **Step 6: Add "Cost" nav entry to `layout.ts`**
+
+Find the nav list. Add `<a href="/cost">Cost</a>` after `<a href="/audit">Audit</a>`, before `<a href="/errors">Errors</a>`.
+
+- [ ] **Step 7: Run tests**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/cost.test.ts
+```
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/dashboard/src/routes/cost.ts packages/dashboard/src/views/cost.ts packages/dashboard/src/server.ts packages/dashboard/src/views/layout.ts packages/dashboard/src/__tests__/cost.test.ts
+git commit -m "feat(cost): dashboard /cost page with summary, breakdowns, csv export"
+```
+
+---
+
+## Task 11: End-to-end integration test
+
+**Files:**
+- Create: `packages/core/src/__tests__/cost-integration.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Seed 20 runs across 3 pipelines, 2 teams, 2 repos. Call `aggregateAll`. Assert totals match hand-computed values. Call `recomputeCostRollups` and verify the rollup table matches the live aggregation.
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb, aggregateAll, recomputeCostRollups } from "@urateam/core";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "@urateam/core/dist/db/schema.js";
+
+describe("cost e2e", () => {
+  it("aggregate matches expected totals and rollup matches live aggregation", async () => {
+    const db = await createDb({ connectionString: ":memory:" }) as any;
+
+    const config = {
+      costs: {
+        modelPricing: {
+          "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+        },
+        hourlyEngRate: 50,
+        timeSavedPerPrDefault: 4,
+      },
+      pipelineConfigs: {
+        "auto-implement": { timeSavedPerPr: 6, profile: { model: "claude-sonnet-4-6" } },
+        "quick-fix":      { profile: { model: "claude-sonnet-4-6" } },
+        "bug":            { profile: { model: "claude-sonnet-4-6" } },
+      },
+    } as any;
+
+    const yesterday = new Date(Date.now() - 86400_000);
+    for (let i = 0; i < 20; i++) {
+      const pipelineKey = ["auto-implement", "quick-fix", "bug"][i % 3];
+      await db.insert(pipelineRuns).values({
+        id: `r${i}`, issueId: `BEC-${i}`, issueTitle: "t",
+        pipelineKey,
+        repoUrl: i % 2 === 0 ? "https://github.com/acme/api" : "https://github.com/acme/web",
+        status: "completed",
+        startedAt: new Date(yesterday.getTime() - 60000),
+        completedAt: yesterday,
+        linearTeamId: i % 2 === 0 ? "T1" : "T2",
+      });
+      await db.insert(stageRuns).values({
+        id: `s${i}`, pipelineRunId: `r${i}`, stage: "implement", status: "completed",
+        startedAt: new Date(yesterday.getTime() - 60000),
+        completedAt: yesterday,
+        inputTokens: 100_000, outputTokens: 50_000,
+      });
+    }
+
+    const live = await aggregateAll(db, {
+      from: new Date(yesterday.getTime() - 86400_000),
+      to: new Date(),
+    }, config);
+    expect(live.summary.runs).toBe(20);
+    expect(live.summary.prsMerged).toBe(20);
+    expect(live.byTeam).toHaveLength(2);
+    expect(live.byRepo).toHaveLength(2);
+    expect(live.byPipeline).toHaveLength(3);
+
+    // Rollup should produce the same dollar total across all rows
+    await recomputeCostRollups(db, config);
+    const rollups = await db.select().from(costRollupsDaily);
+    const rollupTotal = rollups.reduce((acc: number, r: any) => acc + r.dollars, 0);
+    expect(rollupTotal).toBeCloseTo(live.summary.dollars, 2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/cost-integration.test.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/core/src/__tests__/cost-integration.test.ts
+git commit -m "test(cost): end-to-end aggregate and rollup"
+```
+
+---
+
+## Task 12: Build, test sweep, holistic review, CLAUDE.md, PR
+
+- [ ] **Step 1: Build**
+
+```
+cd /private/tmp/urateam/.worktrees/cost-roi && pnpm build
+```
+Expected: clean. If the dashboard or CLI TS errors appear around the new `costs`/`pipelineConfigs` params on `buildServer`, thread them through the call sites in `packages/cli/src/commands/{dev,start}.ts`.
+
+- [ ] **Step 2: Full test suite**
+
+```
+pnpm test
+```
+Expected: all pass. Known-flaky `@urateam/cli` `run.test.ts` under turbo parallel load — verify standalone.
+
+- [ ] **Step 3: Integration tests**
+
+```
+pnpm test:integration
+```
+
+- [ ] **Step 4: Holistic external review**
+
+Dispatch `feature-dev:code-reviewer` with:
+- Spec: `docs/superpowers/specs/2026-04-15-cost-roi-dashboard-design.md`
+- Plan: `docs/superpowers/plans/2026-04-15-cost-roi-dashboard.md`
+- Diff: `git diff main...HEAD`
+
+Ask specifically about:
+- Postgres parity for `REAL`/`DOUBLE PRECISION` `dollars` column
+- `onConflictDoUpdate` with composite unique constraint on `(date, pipelineKey, linearTeamId, repoUrl)` when `linearTeamId` is nullable (Postgres + SQLite handle NULL differently in unique constraints)
+- Timezone handling in `recomputeCostRollups` day boundary
+- XSS on the `/cost` page (especially the breakdown label and model name rendering)
+- CSV formula injection coverage
+- Rollup vs live aggregation drift (does `readRollupWindow` get used yet, or is the dashboard still live-aggregating everything? — likely the latter in v1)
+- Performance: is the in-process grouping a problem for 10k-run windows?
+
+Address all high-confidence findings.
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+Append under "Key Patterns":
+```
+### Cost & ROI dashboard (Enterprise feature 4.5)
+- Module: `packages/core/src/cost/` — `rates.ts` (model-rate + time-saved resolution), `per-run.ts` (`computeRunCost`), `aggregate.ts` (`aggregateAll` over runs+stages), `rollup.ts` (`recomputeCostRollups`, `readRollupWindow`), `csv.ts` (`streamCostCsv` with formula-injection guard)
+- Config: `AppConfig.costs = { modelPricing, hourlyEngRate, timeSavedPerPrDefault }`. Per-pipeline `PipelineConfig.timeSavedPerPr` override
+- Per-run cost = Σ(stage_runs.input/output tokens × model rate). Model per stage = `pipelineConfig.stageModels[stage] ?? pipelineConfig.profile.model ?? "claude-sonnet-4-6"`
+- Time saved = `count(completed runs) × resolveTimeSavedPerPr(pipelineKey)`
+- ROI = (timeSavedHours × hourlyEngRate) / dollars
+- New table: `cost_rollups_daily` — rebuilt nightly in PM tick via `recomputeCostRollups`, idempotent via `onConflictDoUpdate` on `(date, pipeline_key, linear_team_id, repo_url)`
+- Dashboard route `/cost` — summary card + 3 breakdown tables (team, repo, pipeline) + collapsible formula footer + CSV export at `/cost/export.csv`. All 3 routes 404 unless `isFeatureLicensed("cost-roi")`
+- Preset windows (7d/30d/90d/365d) SHOULD read from `readRollupWindow` in v2; v1 uses live `aggregateAll` for all requests. Rollups are populated but not yet consumed by the read path
+```
+
+- [ ] **Step 6: Commit CLAUDE.md and open PR**
+
+```
+git add CLAUDE.md
+git commit -m "docs(claude.md): cost & roi dashboard feature notes"
+git push -u origin feat/cost-roi
+gh pr create --title "feat: cost & roi dashboard (enterprise 4.5)" --body "$(cat <<'EOF'
+## Summary
+- `/cost` dashboard page with summary card + three breakdown tables (by team, repo, pipeline) + date-range picker + CSV export
+- Per-run cost computed at read time from `stage_runs` tokens × configurable model-pricing table — no schema change on run tables
+- Time saved = count(completed PRs) × `timeSavedPerPr` (default 4h, per-pipeline override)
+- ROI = (timeSaved × hourlyEngRate) / dollars, with $50/hr default
+- New `cost_rollups_daily` table rebuilt nightly in PM tick; v1 dashboard still live-aggregates (rollups consumed in v2)
+- Formula footer shows every rate used — operator can screenshot for CFO audit
+- License-gated by `isFeatureLicensed("cost-roi")`
+
+Spec: docs/superpowers/specs/2026-04-15-cost-roi-dashboard-design.md
+Plan: docs/superpowers/plans/2026-04-15-cost-roi-dashboard.md
+
+## Test plan
+- [ ] pnpm test (unit)
+- [ ] pnpm test:integration
+- [ ] Manual: open /cost on a seeded deployment, verify summary matches hand-computed totals
+- [ ] Manual: CSV export downloads, opens correctly in spreadsheet, formula injection neutralized
+
+## Deferred
+- Charts / sparklines / trendlines
+- Per-issue breakdown (re-sort of run list, no aggregation value)
+- Rollup-backed read path (v1 live-aggregates; v2 reads from rollups for preset windows)
+- Multi-currency support
+- Historical rollup backfill older than first PM tick
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Every spec section (§2 config, §3 module layout, §4 data flow, §5 schema, §6 rollup job, §7 dashboard, §8 license, §9 testing, §10 migration) is implemented by a numbered task.
+- **Placeholders:** None. Task 6 includes a `inArrayHelper` stub labeled as such — the implementer is instructed to replace it with a real `drizzle-orm` `inArray` import.
+- **Type consistency:** `CostSummary`, `BreakdownRow`, `AggregateResult`, `RunCost`, `ModelRate`, `AggregateFilters` defined once in `cost/types.ts` and referenced consistently. `computeRunCost(run, stages, config)` signature stable across tasks 3, 5, 6, 7, 11.
+- **Known deferred:** v1 dashboard live-aggregates all queries; the rollup consumer path (`readRollupWindow` driving the preset windows) is tracked as a v2 follow-up in CLAUDE.md and the PR body. The rollup table is still populated in v1 so v2 doesn't need a backfill.
+- **Runner.ts untouched:** Unlike feature 4.6, this feature doesn't require any changes to `pipeline/runner.ts` — all aggregation is read-side. Much lower regression risk.

--- a/docs/superpowers/specs/2026-04-15-cost-roi-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-15-cost-roi-dashboard-design.md
@@ -1,0 +1,319 @@
+# Design: Cost & ROI dashboard (Enterprise feature 4.5)
+
+**Date**: 2026-04-15
+**Status**: Draft for review
+**Parent strategy**: `docs/superpowers/specs/2026-04-13-enterprise-tier-design.md` § 4.5
+**Scope**: Dashboard page + aggregation module that tells a VP Eng (and the CFO they report to) how many PRs urateam delivered, how much engineer time was saved, how many tokens and dollars it cost, and the resulting ROI multiplier — broken down by team, repo, and pipeline, over configurable date ranges.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+- Give the VP Eng one defensible number at QBR: "urateam delivered N PRs, saved Xh of engineer time, cost $Y, ROI Z×."
+- Make every rate used in the calculation visible in the UI so the CFO can scrutinize and (optionally) recalculate with their own assumptions.
+- Support QBR-aligned custom date ranges (`?from=2026-01-01&to=2026-03-31`) and common rolling windows (7d / 30d / 90d / 365d).
+- Break down by **team**, **repo**, and **pipeline** so the operator can answer "which team/repo/pipeline drove the savings."
+- Pre-aggregate rolling-window queries via a daily rollup table so the QBR page loads in under 500ms even on deployments with 10k+ runs.
+- Zero schema burden on existing tables — reuse `pipeline_runs` and `stage_runs` and add one new `cost_rollups_daily` table.
+- Ship a CSV export matching the dashboard view so the operator can attach it to their QBR deck.
+
+### Non-goals
+- **Per-issue breakdown.** Dropped during brainstorming — every issue is one PR, so this is a re-sort of the run list, not an aggregation.
+- **Forecasting, trend lines, or moving averages.** v1 is static tables + summary card; charts are a follow-up.
+- **Dashboard charts** (sparklines, bar charts). Hold for a later polish pass.
+- **Historical rollup backfill.** Rollups start rolling forward from the first PM tick after deploy — older runs are still queryable via the custom-range (live) path but are not pre-aggregated.
+- **A new `pipeline_runs.dollars` column.** Dollar cost is computed at read time from stage tokens and the configured rate table, so customer rate changes retroactively re-price historical runs.
+- **Auth on the CSV export beyond the existing dashboard session.** The whole dashboard sits behind SSO (feature 4.1) or Basic Auth; the CSV export inherits that.
+
+## 2. Config shape
+
+New `costs` section on `AppConfig` in `packages/core/src/types.ts`:
+
+```ts
+costs: z.object({
+  /**
+   * Dollar rates per Anthropic model (or the customer's contracted override).
+   * Defaults match Anthropic list price at the time of this spec. Operators
+   * with enterprise Anthropic contracts should override with their actual rates.
+   */
+  modelPricing: z.record(z.string(), z.object({
+    inputPerMillion: z.number().positive(),
+    outputPerMillion: z.number().positive(),
+  })).default({
+    "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+    "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    "claude-haiku-4-5":  { inputPerMillion:  1, outputPerMillion:  5 },
+  }),
+  /**
+   * Fully-loaded engineer hourly rate, used to convert `timeSavedHours` into
+   * a dollar "value" figure. Default $50/hr is a conservative US eng median.
+   */
+  hourlyEngRate: z.number().positive().default(50),
+  /**
+   * Default time saved per merged PR when a pipeline doesn't override it.
+   * Defensible at 4h per PR based on DORA-ish industry research.
+   */
+  timeSavedPerPrDefault: z.number().positive().default(4),
+}).optional()
+```
+
+`PipelineConfig` gains an optional field:
+```ts
+timeSavedPerPr: z.number().positive().optional()
+```
+
+Resolution order for a given pipeline: `pipeline.timeSavedPerPr ?? config.costs?.timeSavedPerPrDefault ?? 4`.
+
+## 3. Module layout
+
+New `packages/core/src/cost/`:
+
+```
+cost/
+  index.ts       — barrel
+  types.ts       — CostSummary, BreakdownRow, BreakdownDimension, DateRange
+  rates.ts       — resolveModelRate(modelName, config): ModelRate
+                 — resolveTimeSavedPerPr(pipelineKey, config): number
+  per-run.ts     — computeRunCost(run, stages, pipelineConfig, config): {
+                     inputTokens, outputTokens, dollars, timeSavedHours
+                   }
+  aggregate.ts   — aggregateCost(db, filters, config): Promise<CostSummary>
+                 — aggregateByDimension(
+                     db, filters, dim: "team" | "repo" | "pipeline", config,
+                   ): Promise<BreakdownRow[]>
+  rollup.ts      — recomputeCostRollups(db, config): Promise<{ rowsWritten: number }>
+                 — readRollupWindow(db, from, to): Promise<RollupRow[]>
+  csv.ts         — streamCostCsv(db, filters, config): AsyncIterable<string>
+```
+
+Each file has one clear responsibility. `rates.ts` and `per-run.ts` are pure (no DB). `aggregate.ts`, `rollup.ts`, and `csv.ts` take `AnyDb`.
+
+### 3.1 `CostSummary` shape
+```ts
+interface CostSummary {
+  window: { from: Date; to: Date };
+  runs: number;
+  prsMerged: number;
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+  roiMultiplier: number;  // (timeSavedHours * hourlyEngRate) / dollars, or Infinity if dollars === 0
+}
+
+interface BreakdownRow {
+  key: string;            // "team:T1" | "repo:..." | "pipeline:auto-implement"
+  label: string;          // human-readable name
+  runs: number;
+  prsMerged: number;
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+  roiMultiplier: number;
+}
+```
+
+## 4. Data flow
+
+### 4.1 Per-run cost computation
+Single source of truth: `computeRunCost(run, stages, pipelineConfig, config)`.
+
+```ts
+function computeRunCost(
+  run: PipelineRunRow,
+  stages: StageRunRow[],
+  pipelineConfig: PipelineConfig | undefined,
+  config: AppConfig,
+): RunCost {
+  let dollars = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  for (const s of stages) {
+    const modelName =
+      pipelineConfig?.stageModels?.[s.stage] ??
+      pipelineConfig?.profile?.model ??
+      "claude-sonnet-4-6";
+    const rate = resolveModelRate(modelName, config);
+    dollars += (s.inputTokens * rate.inputPerMillion / 1_000_000)
+             + (s.outputTokens * rate.outputPerMillion / 1_000_000);
+    inputTokens += s.inputTokens;
+    outputTokens += s.outputTokens;
+  }
+  const timeSavedHours =
+    run.status === "completed"
+      ? resolveTimeSavedPerPr(run.pipelineKey, config)
+      : 0;
+  return { inputTokens, outputTokens, dollars, timeSavedHours };
+}
+```
+
+### 4.2 Aggregation path
+Two queries, in-process grouping:
+
+1. Select `pipeline_runs` in the window (`completedAt` between `from` and `to`, `status = "completed"` for PR counts — but also include retriable/failed runs for cost attribution, because the tokens still cost money).
+2. Select `stage_runs` for those run IDs via `inArray`.
+3. In TypeScript: build a run-id → stages map, walk runs, call `computeRunCost` for each, accumulate into the dimension buckets.
+4. Return a `CostSummary` (overall) and `BreakdownRow[]` per dimension.
+
+The dashboard route calls `aggregateCost` once for the summary card and `aggregateByDimension` three times (team, repo, pipeline) for the breakdown tables. These can share a single fetch of the runs+stages data — expose a single `aggregateAll(db, filters, config): Promise<{summary, byTeam, byRepo, byPipeline}>` helper that does the two SQL queries once and runs the four groupings in-process. **This is the function the dashboard route calls.**
+
+### 4.3 Rollup path
+For preset rolling windows (7d / 30d / 90d / 365d) the dashboard reads from the pre-aggregated `cost_rollups_daily` table instead of live-querying `pipeline_runs` + `stage_runs`. The rollup table is keyed on `(date, pipeline_key, linear_team_id, repo_url)` — one row per unique dimension combination per UTC day.
+
+`readRollupWindow(db, from, to)` does a single `SELECT ... WHERE date BETWEEN ... AND ...` with in-process grouping by dimension. The expected row count for a 365-day window on a 10-pipeline, 5-team, 20-repo deployment is ~3650 × 10 = 36,500 rows, but typical queries hit far fewer because most combinations are sparse.
+
+**Route logic:** if the request is a preset window, use `readRollupWindow`. If the request is a custom range, call `aggregateAll` live. The dashboard route decides which based on whether `from`/`to` align to a 7/30/90/365-day ending-now window.
+
+## 5. Schema
+
+### 5.1 New table
+```ts
+export const costRollupsDaily = sqliteTable("cost_rollups_daily", {
+  id: text("id").primaryKey(),
+  date: text("date").notNull(),                      // YYYY-MM-DD UTC
+  pipelineKey: text("pipeline_key").notNull(),
+  linearTeamId: text("linear_team_id"),              // nullable
+  repoUrl: text("repo_url").notNull(),
+  runs: integer("runs").notNull().default(0),
+  prsMerged: integer("prs_merged").notNull().default(0),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  dollars: real("dollars").notNull().default(0),
+  timeSavedHours: real("time_saved_hours").notNull().default(0),
+  computedAt: crossTimestamp("computed_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (t) => [
+  unique().on(t.date, t.pipelineKey, t.linearTeamId, t.repoUrl),
+]);
+```
+
+Indexes in migration files:
+- `idx_cost_rollups_date` on `(date)`
+- `idx_cost_rollups_date_pipeline` on `(date, pipeline_key)`
+
+Note: `real` is the Drizzle SQLite column type; Postgres uses `double precision`. The `crossTimestamp` pattern doesn't cover numeric columns, so `real` needs a driver-aware cast in `getCreateTablesDDL()` (`REAL` on SQLite, `DOUBLE PRECISION` on Postgres).
+
+### 5.2 Migration files
+- `packages/core/src/db/migrations/sqlite/009_cost_rollups.sql`
+- `packages/core/src/db/migrations/postgres/010_cost_rollups.sql`
+
+The numbering accounts for `007_sso` + `008_audit_immutability-dashboards` landing before this. Verify before writing — if SSO/audit have different numbers, adjust.
+
+### 5.3 `getCreateTablesDDL()` extension
+Append the new table with driver-aware `REAL` vs `DOUBLE PRECISION` substitution via a new `${num}` interpolation alongside the existing `${ts}`.
+
+## 6. Rollup job
+
+New PM tick step `recomputeCostRollups(db, config)` runs after `pruneExpiredSessions` (the current last step after the SSO feature). Behavior:
+
+1. Determine which days are stale:
+   - On first run after a deploy: scan `cost_rollups_daily` for the latest `date`. If none, backfill starts at `today - 30` to avoid a huge first-run.
+   - On subsequent runs: check if `today - 1` (UTC) has been rolled. If not, roll it.
+2. For each stale day:
+   - Query `pipeline_runs WHERE completedAt BETWEEN dayStart AND dayEnd`
+   - Query `stage_runs` for those runs
+   - Call `computeRunCost` per run and group by `(pipeline_key, linear_team_id, repo_url)`
+   - Upsert rows into `cost_rollups_daily` via `onConflictDoUpdate` on the unique constraint
+3. Log a pino info with `{ day, rowsWritten, rowsUpdated }`
+4. License-gated on `isFeatureLicensed("cost-roi")`; skip entirely otherwise
+5. Wrap in try/catch — rollup failure must not crash the tick
+
+**Idempotency:** re-running on the same day overwrites the existing rows (`onConflictDoUpdate`), so repeated ticks on the same day are safe. This is important because the PM tick runs every 30 min and we don't want to reconsider "is today over" at every tick.
+
+**Today's in-progress data:** the rollup only covers completed UTC days. "Today so far" is read live via `aggregateAll`. The dashboard merges: `readRollupWindow(from, today-1)` + `aggregateAll(today, now)`.
+
+## 7. Dashboard
+
+### 7.1 Route
+`packages/dashboard/src/routes/cost.ts`:
+- `GET /cost` — HTML page. Parses `from`, `to`, or a preset (`?window=30d`). Default: last 30 days
+- `GET /cost/page` — HTMX partial for updates when the user changes the date picker
+- `GET /cost/export.csv` — streams CSV with the same filters
+- All three return 404 unless `isFeatureLicensed("cost-roi")`
+
+### 7.2 View
+`packages/dashboard/src/views/cost.ts`:
+
+**Header:** preset chips (`7d` / `30d` / `90d` / `365d` / `custom`), `from`/`to` date inputs appearing only when `custom` is selected. Form submits via `hx-get="/cost/page"`.
+
+**Summary card:** one prominent card with six numbers + the ROI formula:
+```
+Last 30 days · 2026-03-16 to 2026-04-15
+
+243 PRs merged            ·  972h saved
+1.2M tokens               ·  $612 cost
+
+ROI: 972h × $50/h = $48,600 value ÷ $612 cost = 79×
+```
+
+**Three breakdown tables:** team, repo, pipeline. Each has columns: Name · Runs · PRs merged · Hours saved · Tokens · $ · ROI×. Sort desc by `dollars`.
+
+**Formula footer (collapsed by default):** click to expand. Shows:
+- Per-pipeline `timeSavedPerPr` (default or override, and the source)
+- Per-model rate (input $ / output $) — only models actually used in the window
+- `hourlyEngRate`
+- A note about how "time saved" is counted (completed PRs only)
+
+**Security:** all user-controlled strings pass through `escapeHtml` (same convention as `/audit`).
+
+**Nav:** add "Cost" to `layout.ts` after "Audit", before "Errors".
+
+### 7.3 CSV export
+`streamCostCsv(db, filters, config)` yields:
+- Header row: `completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours`
+- One row per run in the window
+- Uses the same formula-injection escape from the audit CSV (prefix `=+-@\t` with `'`)
+- Content-Disposition: `attachment; filename="cost-<from>-<to>.csv"`
+
+## 8. License gating
+
+- `cost-roi` added to the Enterprise feature set in `license.ts`
+- `/cost`, `/cost/page`, `/cost/export.csv` all 404 when unlicensed
+- PM tick `recomputeCostRollups` skipped when unlicensed
+- OSS / Pro deployments see no nav entry, no routes, no rollups, no behavior change
+
+## 9. Testing strategy
+
+### 9.1 Unit (`packages/core/src/__tests__/cost/`)
+- `rates.test.ts` — `resolveModelRate` falls back to default for unknown models, respects override
+- `per-run.test.ts` — `computeRunCost` with multiple stages, multiple models, partial stage failures
+- `aggregate.test.ts` — `aggregateAll` with seeded fixtures, three dimensions, correct grouping
+- `rollup.test.ts` — first-run backfill, idempotent re-roll, license gate, day-boundary handling (UTC)
+- `csv.test.ts` — header row, escaping, formula injection guard
+
+### 9.2 Integration
+- `cost-integration.test.ts` — end-to-end: seed 20 runs across 3 pipelines, 2 teams, 2 repos; call `aggregateAll`; assert per-team/per-repo/per-pipeline totals match hand-computed values
+
+### 9.3 Dashboard (`packages/dashboard/src/__tests__/cost.test.ts`)
+- Unlicensed → 404 on all 3 routes
+- Licensed → 200, rendered summary contains expected totals
+- Preset window uses `readRollupWindow` (mock and assert call)
+- Custom window uses `aggregateAll` (assert call)
+- CSV export content-type + filename + header row
+
+## 10. Migration and rollout
+
+### 10.1 Schema
+- New table `cost_rollups_daily` via new migration file
+- `getCreateTablesDDL()` extended with the `num` interpolation
+- Drizzle schema extended
+
+### 10.2 Feature flag
+- `cost-roi` added to `ENTERPRISE_FEATURES`
+- No behavior change for OSS/Pro
+
+### 10.3 First-run behavior
+- On the first PM tick after a licensed deploy, `recomputeCostRollups` backfills the last 30 days (up to 30 UTC-day rollup batches, each writing ~N rows where N = unique combos in that day)
+- The dashboard works immediately for custom ranges (live query) and within 30 minutes for preset rolling ranges (after the first tick)
+
+## 11. Open questions (deferred)
+
+- **Rollup backfill for historical data older than 30 days.** On-demand via a CLI command? Defer until a customer asks.
+- **Trendlines / sparklines on the summary card.** Adds chart library dependency; defer.
+- **Per-issue breakdown.** Re-sort of the run list, no aggregation value. Defer indefinitely.
+- **Forecasting "at this burn rate you'll spend $N in Q2".** Linear projection is cheap but risks looking official when it's just multiplication. Defer until someone asks.
+- **Cost alerts ("your auto-implement pipeline's cost/PR doubled this week").** Belongs in feature 4.3 territory (spend caps), not this dashboard. Defer.
+- **Multi-currency support.** Defer until a customer asks. Default USD.

--- a/packages/core/src/__tests__/cost-integration.test.ts
+++ b/packages/core/src/__tests__/cost-integration.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../db/client.js";
+import { aggregateAll } from "../cost/aggregate.js";
+import { recomputeCostRollups } from "../cost/rollup.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+function yesterdayNoonUtc(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1, 12, 0, 0,
+  ));
+}
+
+describe("cost e2e", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("aggregate matches expected totals and rollup matches live aggregation", async () => {
+    const db = await createDb({ connectionString: ":memory:" }) as any;
+
+    const config = {
+      costs: {
+        modelPricing: {
+          "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+        },
+        hourlyEngRate: 50,
+        timeSavedPerPrDefault: 4,
+      },
+      pipelineConfigs: {
+        "auto-implement": { timeSavedPerPr: 6, profile: { model: "claude-sonnet-4-6" } },
+        "quick-fix":      { profile: { model: "claude-sonnet-4-6" } },
+        "bug":            { profile: { model: "claude-sonnet-4-6" } },
+      },
+    } as any;
+
+    // Seed at yesterday-noon UTC so the completed runs land squarely inside
+    // both the aggregate window (from=2 days ago, to=now) and the rollup's
+    // yesterday-UTC day boundary, regardless of what time the test runs.
+    const completedAt = yesterdayNoonUtc();
+    const startedAt = new Date(completedAt.getTime() - 60_000);
+
+    for (let i = 0; i < 20; i++) {
+      const pipelineKey = ["auto-implement", "quick-fix", "bug"][i % 3];
+      await db.insert(pipelineRuns).values({
+        id: `r${i}`,
+        issueId: `BEC-${i}`,
+        issueTitle: "t",
+        pipelineKey,
+        repoUrl: i % 2 === 0 ? "https://github.com/acme/api" : "https://github.com/acme/web",
+        status: "completed",
+        startedAt,
+        completedAt,
+        linearTeamId: i % 2 === 0 ? "T1" : "T2",
+      });
+      await db.insert(stageRuns).values({
+        id: `s${i}`,
+        pipelineRunId: `r${i}`,
+        stage: "implement",
+        status: "completed",
+        startedAt,
+        completedAt,
+        inputTokens: 100_000,
+        outputTokens: 50_000,
+      });
+    }
+
+    const live = await aggregateAll(db, {
+      from: new Date(completedAt.getTime() - 86400_000),
+      to: new Date(),
+    }, config);
+
+    expect(live.summary.runs).toBe(20);
+    expect(live.summary.prsMerged).toBe(20);
+    expect(live.byTeam).toHaveLength(2);
+    expect(live.byRepo).toHaveLength(2);
+    expect(live.byPipeline).toHaveLength(3);
+
+    // Rollup should produce the same dollar total across all rows
+    await recomputeCostRollups(db, config);
+    const rollups = await db.select().from(costRollupsDaily);
+    expect(rollups.length).toBeGreaterThan(0);
+    const rollupTotal = rollups.reduce((acc: number, r: any) => acc + r.dollars, 0);
+    expect(rollupTotal).toBeCloseTo(live.summary.dollars, 2);
+  });
+});

--- a/packages/core/src/__tests__/cost-license.test.ts
+++ b/packages/core/src/__tests__/cost-license.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { installTestProLicense, restoreLicense } from "./helpers/license.js";
 import { isFeatureLicensed } from "../license.js";
 import * as core from "../index.js";

--- a/packages/core/src/__tests__/cost-license.test.ts
+++ b/packages/core/src/__tests__/cost-license.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+import { isFeatureLicensed } from "../license.js";
+import * as core from "../index.js";
+
+describe("cost-roi license flag + core barrel re-export", () => {
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("is gated off under pro tier", async () => {
+    await installTestProLicense("pro");
+    expect(isFeatureLicensed("cost-roi")).toBe(false);
+  });
+
+  it("is enabled under enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    expect(isFeatureLicensed("cost-roi")).toBe(true);
+  });
+
+  it("re-exports cost helpers from @urateam/core barrel", () => {
+    expect(typeof (core as Record<string, unknown>).computeRunCost).toBe("function");
+    expect(typeof (core as Record<string, unknown>).aggregateAll).toBe("function");
+    expect(typeof (core as Record<string, unknown>).resolveModelRate).toBe("function");
+  });
+});

--- a/packages/core/src/__tests__/cost-types.test.ts
+++ b/packages/core/src/__tests__/cost-types.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  CostsConfigSchema, ModelPricingSchema, PipelineConfigSchema, AppConfigSchema,
+} from "../types.js";
+
+describe("CostsConfigSchema", () => {
+  it("parses an empty object and applies defaults", () => {
+    const parsed = CostsConfigSchema.parse({});
+    expect(parsed.hourlyEngRate).toBe(50);
+    expect(parsed.timeSavedPerPrDefault).toBe(4);
+    expect(parsed.modelPricing["claude-opus-4-6"]).toEqual({ inputPerMillion: 15, outputPerMillion: 75 });
+    expect(parsed.modelPricing["claude-sonnet-4-6"]).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+    expect(parsed.modelPricing["claude-haiku-4-5"]).toEqual({ inputPerMillion: 1, outputPerMillion: 5 });
+  });
+
+  it("accepts an override", () => {
+    const parsed = CostsConfigSchema.parse({
+      hourlyEngRate: 75,
+      timeSavedPerPrDefault: 6,
+      modelPricing: {
+        "claude-opus-4-6": { inputPerMillion: 10, outputPerMillion: 50 },
+      },
+    });
+    expect(parsed.hourlyEngRate).toBe(75);
+    expect(parsed.timeSavedPerPrDefault).toBe(6);
+    expect(parsed.modelPricing["claude-opus-4-6"].inputPerMillion).toBe(10);
+  });
+
+  it("rejects non-positive rates", () => {
+    expect(() => CostsConfigSchema.parse({ hourlyEngRate: 0 })).toThrow();
+    expect(() => CostsConfigSchema.parse({ hourlyEngRate: -1 })).toThrow();
+    expect(() => CostsConfigSchema.parse({
+      modelPricing: { foo: { inputPerMillion: -1, outputPerMillion: 1 } },
+    })).toThrow();
+  });
+});
+
+describe("PipelineConfigSchema.timeSavedPerPr", () => {
+  it("accepts optional timeSavedPerPr", () => {
+    const cfg = PipelineConfigSchema.parse({
+      name: "auto-implement",
+      stages: ["implement"],
+      retry: { maxAttempts: 1, strategy: "fail-fast" },
+      review: { requiredApprovals: 1 },
+      prStrategy: "draft",
+      timeSavedPerPr: 6,
+    } as any);
+    expect(cfg.timeSavedPerPr).toBe(6);
+  });
+
+  it("accepts config without timeSavedPerPr", () => {
+    const cfg = PipelineConfigSchema.parse({
+      name: "quick-fix",
+      stages: ["implement"],
+      retry: { maxAttempts: 1, strategy: "fail-fast" },
+      review: { requiredApprovals: 1 },
+      prStrategy: "draft",
+    } as any);
+    expect(cfg.timeSavedPerPr).toBeUndefined();
+  });
+});
+
+describe("AppConfigSchema.costs", () => {
+  it("accepts optional costs field", () => {
+    const parsed = AppConfigSchema.parse({ costs: { hourlyEngRate: 100 } });
+    expect(parsed.costs?.hourlyEngRate).toBe(100);
+  });
+
+  it("accepts omitted costs", () => {
+    const parsed = AppConfigSchema.parse({});
+    expect(parsed.costs).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/cost/aggregate.test.ts
+++ b/packages/core/src/__tests__/cost/aggregate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns, stageRuns } from "../../db/schema.js";
-import { aggregateAll } from "../../cost/aggregate.js";
+import { aggregateAll, normalizeTeamId } from "../../cost/aggregate.js";
 
 let db: any;
 
@@ -32,7 +32,8 @@ beforeEach(async () => {
 
 async function seedRun(id: string, opts: {
   pipelineKey: string; teamId?: string; repoUrl: string;
-  status?: string; implementInputTokens?: number; implementOutputTokens?: number;
+  status?: string; runType?: string;
+  implementInputTokens?: number; implementOutputTokens?: number;
   completedAt: Date;
 }) {
   await db.insert(pipelineRuns).values({
@@ -40,6 +41,7 @@ async function seedRun(id: string, opts: {
     pipelineKey: opts.pipelineKey,
     repoUrl: opts.repoUrl,
     status: opts.status ?? "completed",
+    runType: opts.runType ?? "standard",
     startedAt: new Date(opts.completedAt.getTime() - 60000),
     completedAt: opts.completedAt,
     linearTeamId: opts.teamId,
@@ -118,7 +120,8 @@ describe("aggregateAll", () => {
     });
     const r = await aggregateAll(db, {
       from: new Date("2026-04-01T00:00:00Z"),
-      to: new Date("2026-04-30T23:59:59Z"),
+      // half-open upper bound: to is strictly after all seeded runs
+      to: new Date("2026-05-01T00:00:00Z"),
     }, config);
     expect(r.summary.runs).toBe(0);
   });
@@ -156,11 +159,48 @@ describe("aggregateAll", () => {
     });
     const r = await aggregateAll(db, {
       from: new Date("2026-04-01T00:00:00Z"),
-      to: new Date("2026-04-30T23:59:59Z"),
+      to: new Date("2026-05-01T00:00:00Z"),
     }, config);
     expect(r.summary.runs).toBe(1);
     expect(r.summary.prsMerged).toBe(0);
     expect(r.summary.timeSavedHours).toBe(0);
     expect(r.summary.dollars).toBeCloseTo(1.05, 2);
+  });
+
+  it("excludes review-feedback runs from prsMerged and timeSavedHours", async () => {
+    // Standard completed run
+    await seedRun("1", {
+      pipelineKey: "quick-fix", runType: "standard",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-01T10:00:00Z"),
+    });
+    // Review-feedback completed run (tokens cost money but not a new PR)
+    await seedRun("2", {
+      pipelineKey: "quick-fix", runType: "review-feedback",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 50_000, implementOutputTokens: 20_000,
+      completedAt: new Date("2026-04-01T11:00:00Z"),
+    });
+
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-05-01T00:00:00Z"),
+    }, config);
+
+    // Only the standard run counts as a merged PR
+    expect(r.summary.runs).toBe(2);
+    expect(r.summary.prsMerged).toBe(1);
+    // Only the standard run contributes time saved (4h default for quick-fix)
+    expect(r.summary.timeSavedHours).toBe(4);
+    // Both runs contribute to token cost: run1 = $1.05, run2 = 0.05M×$3 + 0.02M×$15 = $0.15+$0.30 = $0.45
+    expect(r.summary.dollars).toBeCloseTo(1.50, 2);
+  });
+
+  it("normalizeTeamId collapses null, undefined, and empty string to the same bucket", () => {
+    expect(normalizeTeamId(null)).toEqual({ key: "team:unassigned", label: "(unassigned)" });
+    expect(normalizeTeamId(undefined)).toEqual({ key: "team:unassigned", label: "(unassigned)" });
+    expect(normalizeTeamId("")).toEqual({ key: "team:unassigned", label: "(unassigned)" });
+    expect(normalizeTeamId("T1")).toEqual({ key: "team:T1", label: "T1" });
   });
 });

--- a/packages/core/src/__tests__/cost/aggregate.test.ts
+++ b/packages/core/src/__tests__/cost/aggregate.test.ts
@@ -123,6 +123,30 @@ describe("aggregateAll", () => {
     expect(r.summary.runs).toBe(0);
   });
 
+  it("truncates to maxRuns most recent and flags summary.truncated", async () => {
+    // Seed 15 runs spread across April 2026.
+    for (let i = 0; i < 15; i++) {
+      await seedRun(String(i), {
+        pipelineKey: "quick-fix",
+        repoUrl: "https://github.com/acme/api",
+        implementInputTokens: 100_000,
+        implementOutputTokens: 50_000,
+        completedAt: new Date(`2026-04-${String(i + 1).padStart(2, "0")}T10:00:00Z`),
+      });
+    }
+    const r = await aggregateAll(
+      db,
+      {
+        from: new Date("2026-04-01T00:00:00Z"),
+        to: new Date("2026-04-30T23:59:59Z"),
+      },
+      config,
+      { maxRuns: 5 },
+    );
+    expect(r.summary.truncated).toBe(true);
+    expect(r.summary.runs).toBe(5);
+  });
+
   it("counts failed runs in cost but not in prsMerged / timeSaved", async () => {
     await seedRun("1", {
       pipelineKey: "quick-fix", status: "failed",

--- a/packages/core/src/__tests__/cost/aggregate.test.ts
+++ b/packages/core/src/__tests__/cost/aggregate.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns, stageRuns } from "../../db/schema.js";
+import { aggregateAll } from "../../cost/aggregate.js";
+
+let db: any;
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+      "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": {
+      stageModels: { implement: "claude-opus-4-6" },
+      profile: { model: "claude-sonnet-4-6" },
+      timeSavedPerPr: 6,
+    } as any,
+    "quick-fix": {
+      profile: { model: "claude-sonnet-4-6" },
+    } as any,
+  },
+} as any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+async function seedRun(id: string, opts: {
+  pipelineKey: string; teamId?: string; repoUrl: string;
+  status?: string; implementInputTokens?: number; implementOutputTokens?: number;
+  completedAt: Date;
+}) {
+  await db.insert(pipelineRuns).values({
+    id, issueId: `BEC-${id}`, issueTitle: "t",
+    pipelineKey: opts.pipelineKey,
+    repoUrl: opts.repoUrl,
+    status: opts.status ?? "completed",
+    startedAt: new Date(opts.completedAt.getTime() - 60000),
+    completedAt: opts.completedAt,
+    linearTeamId: opts.teamId,
+  });
+  if (opts.implementInputTokens || opts.implementOutputTokens) {
+    await db.insert(stageRuns).values({
+      id: `s_${id}_imp`, pipelineRunId: id, stage: "implement",
+      status: "completed",
+      startedAt: new Date(opts.completedAt.getTime() - 60000),
+      completedAt: opts.completedAt,
+      inputTokens: opts.implementInputTokens ?? 0,
+      outputTokens: opts.implementOutputTokens ?? 0,
+    });
+  }
+}
+
+describe("aggregateAll", () => {
+  it("returns zero totals for an empty db", async () => {
+    const r = await aggregateAll(db, { from: new Date("2026-01-01"), to: new Date("2026-12-31") }, config);
+    expect(r.summary.runs).toBe(0);
+    expect(r.summary.dollars).toBe(0);
+    expect(r.summary.timeSavedHours).toBe(0);
+    expect(r.byTeam).toEqual([]);
+    expect(r.byRepo).toEqual([]);
+    expect(r.byPipeline).toEqual([]);
+  });
+
+  it("aggregates across pipelines with correct dollar math", async () => {
+    await seedRun("1", {
+      pipelineKey: "auto-implement", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 1_000_000, implementOutputTokens: 500_000,
+      completedAt: new Date("2026-04-01T10:00:00Z"),
+    });
+    await seedRun("2", {
+      pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-02T10:00:00Z"),
+    });
+
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-04-30T23:59:59Z"),
+    }, config);
+
+    // run 1 (opus implement): 1M × $15 + 0.5M × $75 = $52.50
+    // run 2 (sonnet implement): 0.1M × $3 + 0.05M × $15 = $1.05
+    expect(r.summary.runs).toBe(2);
+    expect(r.summary.prsMerged).toBe(2);
+    expect(r.summary.dollars).toBeCloseTo(53.55, 2);
+    // time saved: run 1 (auto-implement override = 6h) + run 2 (quick-fix default = 4h) = 10h
+    expect(r.summary.timeSavedHours).toBe(10);
+
+    // byTeam: one row (T1) with summed totals
+    expect(r.byTeam).toHaveLength(1);
+    expect(r.byTeam[0].key).toBe("team:T1");
+    expect(r.byTeam[0].dollars).toBeCloseTo(53.55, 2);
+
+    // byPipeline: two rows (auto-implement, quick-fix)
+    expect(r.byPipeline).toHaveLength(2);
+    const auto = r.byPipeline.find((b: any) => b.key === "pipeline:auto-implement")!;
+    expect(auto.dollars).toBeCloseTo(52.50, 2);
+    expect(auto.timeSavedHours).toBe(6);
+
+    // ROI = (timeSavedHours × hourlyEngRate) / dollars = (10 × 50) / 53.55 ≈ 9.34
+    expect(r.summary.roiMultiplier).toBeCloseTo(500 / 53.55, 2);
+  });
+
+  it("excludes runs outside the window", async () => {
+    await seedRun("1", {
+      pipelineKey: "quick-fix",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-01-01T10:00:00Z"),
+    });
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-04-30T23:59:59Z"),
+    }, config);
+    expect(r.summary.runs).toBe(0);
+  });
+
+  it("counts failed runs in cost but not in prsMerged / timeSaved", async () => {
+    await seedRun("1", {
+      pipelineKey: "quick-fix", status: "failed",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-01T10:00:00Z"),
+    });
+    const r = await aggregateAll(db, {
+      from: new Date("2026-04-01T00:00:00Z"),
+      to: new Date("2026-04-30T23:59:59Z"),
+    }, config);
+    expect(r.summary.runs).toBe(1);
+    expect(r.summary.prsMerged).toBe(0);
+    expect(r.summary.timeSavedHours).toBe(0);
+    expect(r.summary.dollars).toBeCloseTo(1.05, 2);
+  });
+});

--- a/packages/core/src/__tests__/cost/csv.test.ts
+++ b/packages/core/src/__tests__/cost/csv.test.ts
@@ -25,7 +25,7 @@ const config = {
 describe("streamCostCsv", () => {
   it("emits header then one row per run", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    await db.insert(pipelineRuns).values({
+    await (db as any).insert(pipelineRuns).values({
       id: "r1",
       issueId: "BEC-1",
       issueTitle: "t",
@@ -36,7 +36,7 @@ describe("streamCostCsv", () => {
       completedAt: new Date("2026-04-01T10:05:00Z"),
       linearTeamId: "T1",
     });
-    await db.insert(stageRuns).values({
+    await (db as any).insert(stageRuns).values({
       id: "s1",
       pipelineRunId: "r1",
       stage: "implement",
@@ -68,7 +68,7 @@ describe("streamCostCsv", () => {
 
   it("escapes formula-injection prefixes", async () => {
     const db = await createDb({ connectionString: ":memory:" });
-    await db.insert(pipelineRuns).values({
+    await (db as any).insert(pipelineRuns).values({
       id: "r1",
       issueId: "=HYPERLINK(evil)",
       issueTitle: "t",

--- a/packages/core/src/__tests__/cost/csv.test.ts
+++ b/packages/core/src/__tests__/cost/csv.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns, stageRuns } from "../../db/schema.js";
+import { streamCostCsv } from "../../cost/csv.js";
+
+async function collect(iter: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const chunk of iter) out += chunk;
+  return out;
+}
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "quick-fix": { profile: { model: "claude-sonnet-4-6" } } as any,
+  },
+} as any;
+
+describe("streamCostCsv", () => {
+  it("emits header then one row per run", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await db.insert(pipelineRuns).values({
+      id: "r1",
+      issueId: "BEC-1",
+      issueTitle: "t",
+      pipelineKey: "quick-fix",
+      repoUrl: "https://github.com/acme/api",
+      status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+      linearTeamId: "T1",
+    });
+    await db.insert(stageRuns).values({
+      id: "s1",
+      pipelineRunId: "r1",
+      stage: "implement",
+      status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+      inputTokens: 100_000,
+      outputTokens: 50_000,
+    });
+
+    const csv = await collect(
+      streamCostCsv(
+        db,
+        {
+          from: new Date("2026-04-01"),
+          to: new Date("2026-04-30"),
+        },
+        config,
+      ),
+    );
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe(
+      "completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours",
+    );
+    expect(lines[1]).toContain("r1");
+    expect(lines[1]).toContain("BEC-1");
+    expect(lines[1]).toContain("quick-fix");
+  });
+
+  it("escapes formula-injection prefixes", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await db.insert(pipelineRuns).values({
+      id: "r1",
+      issueId: "=HYPERLINK(evil)",
+      issueTitle: "t",
+      pipelineKey: "quick-fix",
+      repoUrl: "https://github.com/acme/api",
+      status: "completed",
+      startedAt: new Date("2026-04-01T10:00:00Z"),
+      completedAt: new Date("2026-04-01T10:05:00Z"),
+    });
+    const csv = await collect(
+      streamCostCsv(
+        db,
+        {
+          from: new Date("2026-04-01"),
+          to: new Date("2026-04-30"),
+        },
+        config,
+      ),
+    );
+    expect(csv).toContain("'=HYPERLINK(evil)");
+  });
+});

--- a/packages/core/src/__tests__/cost/csv.test.ts
+++ b/packages/core/src/__tests__/cost/csv.test.ts
@@ -83,11 +83,45 @@ describe("streamCostCsv", () => {
         db,
         {
           from: new Date("2026-04-01"),
-          to: new Date("2026-04-30"),
+          to: new Date("2026-05-01"),
         },
         config,
       ),
     );
     expect(csv).toContain("'=HYPERLINK(evil)");
+  });
+
+  it("caps CSV export at maxRuns and emits a truncation footer", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    // Seed 20 runs across April 2026.
+    for (let i = 1; i <= 20; i++) {
+      await (db as any).insert(pipelineRuns).values({
+        id: `r${i}`,
+        issueId: `BEC-${i}`,
+        issueTitle: "t",
+        pipelineKey: "quick-fix",
+        repoUrl: "https://github.com/acme/api",
+        status: "completed",
+        startedAt: new Date(`2026-04-${String(i).padStart(2, "0")}T10:00:00Z`),
+        completedAt: new Date(`2026-04-${String(i).padStart(2, "0")}T10:05:00Z`),
+        linearTeamId: "T1",
+      });
+    }
+
+    const csv = await collect(
+      streamCostCsv(
+        db,
+        { from: new Date("2026-04-01"), to: new Date("2026-05-01") },
+        config,
+        5,
+      ),
+    );
+
+    const lines = csv.split("\n").filter(Boolean);
+    // 1 header + 5 data rows + 1 truncation footer = 7 lines
+    expect(lines).toHaveLength(7);
+    expect(lines[0]).toContain("completed_at");
+    // Last line is the truncation comment
+    expect(lines[6]).toMatch(/^# truncated: 20 runs in window, exported most recent 5/);
   });
 });

--- a/packages/core/src/__tests__/cost/per-run.test.ts
+++ b/packages/core/src/__tests__/cost/per-run.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { computeRunCost } from "../../cost/per-run.js";
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+      "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": {
+      stageModels: { implement: "claude-opus-4-6" },
+      profile: { model: "claude-sonnet-4-6" },
+      timeSavedPerPr: 6,
+    } as any,
+    "quick-fix": {
+      profile: { model: "claude-sonnet-4-6" },
+    } as any,
+  },
+} as any;
+
+describe("computeRunCost", () => {
+  it("prices stages at their configured model rates", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [
+      { stage: "implement", inputTokens: 1_000_000, outputTokens: 500_000 },
+      { stage: "review", inputTokens: 100_000, outputTokens: 20_000 },
+    ] as any;
+    const cost = computeRunCost(run, stages, config);
+    // implement: 1M × $15 + 0.5M × $75 = $15 + $37.5 = $52.5
+    // review (sonnet default): 0.1M × $3 + 0.02M × $15 = $0.30 + $0.30 = $0.60
+    expect(cost.dollars).toBeCloseTo(53.1, 2);
+    expect(cost.inputTokens).toBe(1_100_000);
+    expect(cost.outputTokens).toBe(520_000);
+  });
+
+  it("assigns timeSavedHours only when run.status === 'completed'", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [{ stage: "implement", inputTokens: 0, outputTokens: 0 }] as any;
+    expect(computeRunCost(run, stages, config).timeSavedHours).toBe(6);
+  });
+
+  it("zero timeSavedHours on failed runs", () => {
+    const run = { pipelineKey: "auto-implement", status: "failed" } as any;
+    const stages = [{ stage: "implement", inputTokens: 1_000_000, outputTokens: 500_000 }] as any;
+    expect(computeRunCost(run, stages, config).timeSavedHours).toBe(0);
+  });
+
+  it("uses pipeline profile model when stageModels is empty", () => {
+    const run = { pipelineKey: "quick-fix", status: "completed" } as any;
+    const stages = [{ stage: "implement", inputTokens: 1_000_000, outputTokens: 1_000_000 }] as any;
+    const cost = computeRunCost(run, stages, config);
+    // sonnet: 1M × $3 + 1M × $15 = $18
+    expect(cost.dollars).toBeCloseTo(18, 2);
+  });
+});

--- a/packages/core/src/__tests__/cost/rates.test.ts
+++ b/packages/core/src/__tests__/cost/rates.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { resolveModelRate, resolveTimeSavedPerPr } from "../../cost/rates.js";
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+      "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": { timeSavedPerPr: 6 } as any,
+    "quick-fix": {} as any,
+  },
+} as any;
+
+describe("resolveModelRate", () => {
+  it("returns configured rate", () => {
+    const r = resolveModelRate("claude-opus-4-6", config);
+    expect(r).toEqual({ inputPerMillion: 15, outputPerMillion: 75 });
+  });
+
+  it("falls back to sonnet when model is unknown", () => {
+    const r = resolveModelRate("nonexistent-model", config);
+    expect(r).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+  });
+
+  it("uses built-in sonnet default when config has no sonnet", () => {
+    const r = resolveModelRate("unknown", { costs: { modelPricing: {}, hourlyEngRate: 50, timeSavedPerPrDefault: 4 } } as any);
+    expect(r).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+  });
+
+  it("uses built-in default when config has no costs", () => {
+    const r = resolveModelRate("claude-opus-4-6", {} as any);
+    // Falls through to built-in sonnet default since no modelPricing provided at all
+    expect(r).toEqual({ inputPerMillion: 3, outputPerMillion: 15 });
+  });
+});
+
+describe("resolveTimeSavedPerPr", () => {
+  it("uses pipeline override when set", () => {
+    expect(resolveTimeSavedPerPr("auto-implement", config)).toBe(6);
+  });
+
+  it("uses costs default when pipeline has no override", () => {
+    expect(resolveTimeSavedPerPr("quick-fix", config)).toBe(4);
+  });
+
+  it("uses built-in default (4h) when neither pipeline nor costs config set", () => {
+    expect(resolveTimeSavedPerPr("unknown", {} as any)).toBe(4);
+  });
+});

--- a/packages/core/src/__tests__/cost/rollup.test.ts
+++ b/packages/core/src/__tests__/cost/rollup.test.ts
@@ -74,6 +74,61 @@ describe("recomputeCostRollups", () => {
     expect(rows[0].runs).toBe(1);
   });
 
+  it("dedupes rollup rows when linearTeamId is null (empty-string sentinel)", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    // Seed two completed runs with no team assigned, same pipeline + repo.
+    await db.insert(pipelineRuns).values({
+      id: "u1",
+      issueId: "BEC-u1",
+      issueTitle: "t",
+      pipelineKey: "quick-fix",
+      repoUrl: "https://github.com/acme/api",
+      status: "completed",
+      startedAt: new Date(yesterday.getTime() - 60000),
+      completedAt: yesterday,
+      linearTeamId: null,
+    });
+    await db.insert(stageRuns).values({
+      id: "s_u1",
+      pipelineRunId: "u1",
+      stage: "implement",
+      status: "completed",
+      startedAt: new Date(yesterday.getTime() - 60000),
+      completedAt: yesterday,
+      inputTokens: 100_000,
+      outputTokens: 50_000,
+    });
+    await db.insert(pipelineRuns).values({
+      id: "u2",
+      issueId: "BEC-u2",
+      issueTitle: "t",
+      pipelineKey: "quick-fix",
+      repoUrl: "https://github.com/acme/api",
+      status: "completed",
+      startedAt: new Date(yesterday.getTime() - 60000),
+      completedAt: yesterday,
+      linearTeamId: null,
+    });
+    await db.insert(stageRuns).values({
+      id: "s_u2",
+      pipelineRunId: "u2",
+      stage: "implement",
+      status: "completed",
+      startedAt: new Date(yesterday.getTime() - 60000),
+      completedAt: yesterday,
+      inputTokens: 100_000,
+      outputTokens: 50_000,
+    });
+
+    // Running twice must not produce duplicate rows for the unassigned bucket.
+    await recomputeCostRollups(db, config);
+    await recomputeCostRollups(db, config);
+    const rows = await db.select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].linearTeamId).toBe("");
+    expect(rows[0].runs).toBe(2);
+  });
+
   it("readRollupWindow returns rows inside the window", async () => {
     const yesterday = new Date(Date.now() - 86400_000);
     await seedCompletedRun("r1", yesterday);

--- a/packages/core/src/__tests__/cost/rollup.test.ts
+++ b/packages/core/src/__tests__/cost/rollup.test.ts
@@ -138,4 +138,69 @@ describe("recomputeCostRollups", () => {
     const rows = await readRollupWindow(db, from, to);
     expect(rows.length).toBeGreaterThan(0);
   });
+
+  it("backfills up to 30 days on first run when rollup table is empty", async () => {
+    // Seed runs on 3 different past days: 5, 10, and 20 days ago.
+    const days = [5, 10, 20];
+    for (const d of days) {
+      // Place completedAt at noon UTC on that day to ensure it falls in the day boundary.
+      const t = new Date(Date.now() - d * 86400_000);
+      t.setUTCHours(12, 0, 0, 0);
+      await seedCompletedRun(`r_back_${d}`, t);
+    }
+
+    const result = await recomputeCostRollups(db, config);
+    expect(result.rowsWritten).toBeGreaterThan(0);
+
+    const rows = await db.select().from(costRollupsDaily);
+    // There should be a rollup row for each of the 3 seeded days.
+    const dates = rows.map((r: any) => r.date);
+    for (const d of days) {
+      const t = new Date(Date.now() - d * 86400_000);
+      const expected = t.toISOString().slice(0, 10);
+      expect(dates).toContain(expected);
+    }
+  });
+
+  it("backfills only missing days when rollup table has some entries", async () => {
+    const now = new Date();
+    // Pre-seed a rollup row for 3 days ago (the "already rolled" base).
+    const day3 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 3));
+    const day3Str = day3.toISOString().slice(0, 10);
+
+    await db.insert(costRollupsDaily).values({
+      id: "cr_pre",
+      date: day3Str,
+      pipelineKey: "quick-fix",
+      linearTeamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      runs: 99, // sentinel value — this row pre-exists from a prior run
+      prsMerged: 99,
+      inputTokens: 0, outputTokens: 0, dollars: 0, timeSavedHours: 0,
+      computedAt: new Date(),
+    });
+
+    // Seed actual pipeline runs for the 2 missing days (2 days ago and yesterday).
+    const day2 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 2, 12));
+    const day1 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1, 12));
+    await seedCompletedRun("r_n2", day2);
+    await seedCompletedRun("r_n1", day1);
+
+    await recomputeCostRollups(db, config);
+
+    const rows = await db.select().from(costRollupsDaily);
+    const dates = rows.map((r: any) => r.date);
+
+    const day2Str = day2.toISOString().slice(0, 10);
+    const day1Str = day1.toISOString().slice(0, 10);
+
+    // Rows for the two new days should have been backfilled.
+    expect(dates).toContain(day2Str);
+    expect(dates).toContain(day1Str);
+
+    // The pre-seeded day3 row should still exist (untouched, since latest+1 = day2).
+    expect(dates).toContain(day3Str);
+    const day3Row = rows.find((r: any) => r.date === day3Str);
+    expect(day3Row?.runs).toBe(99); // sentinel value preserved — not re-rolled
+  });
 });

--- a/packages/core/src/__tests__/cost/rollup.test.ts
+++ b/packages/core/src/__tests__/cost/rollup.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../../db/schema.js";
+import { recomputeCostRollups, readRollupWindow } from "../../cost/rollup.js";
+
+let db: any;
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "quick-fix": { profile: { model: "claude-sonnet-4-6" } } as any,
+  },
+} as any;
+
+async function seedCompletedRun(id: string, completedAt: Date) {
+  await db.insert(pipelineRuns).values({
+    id,
+    issueId: `BEC-${id}`,
+    issueTitle: "t",
+    pipelineKey: "quick-fix",
+    repoUrl: "https://github.com/acme/api",
+    status: "completed",
+    startedAt: new Date(completedAt.getTime() - 60000),
+    completedAt,
+    linearTeamId: "T1",
+  });
+  await db.insert(stageRuns).values({
+    id: `s_${id}`,
+    pipelineRunId: id,
+    stage: "implement",
+    status: "completed",
+    startedAt: new Date(completedAt.getTime() - 60000),
+    completedAt,
+    inputTokens: 100_000,
+    outputTokens: 50_000,
+  });
+}
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+describe("recomputeCostRollups", () => {
+  it("writes one row per (date, pipeline, team, repo) for yesterday", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    await seedCompletedRun("r1", yesterday);
+    await seedCompletedRun("r2", yesterday);
+    const result = await recomputeCostRollups(db, config);
+    expect(result.rowsWritten).toBeGreaterThan(0);
+    const rows = await db.select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].runs).toBe(2);
+    expect(rows[0].prsMerged).toBe(2);
+    expect(rows[0].inputTokens).toBe(200_000);
+    expect(rows[0].outputTokens).toBe(100_000);
+    // sonnet: 0.2M × $3 + 0.1M × $15 = $0.60 + $1.50 = $2.10
+    expect(rows[0].dollars).toBeCloseTo(2.10, 2);
+    expect(rows[0].timeSavedHours).toBe(8);
+  });
+
+  it("is idempotent — re-running on the same day doesn't double-count", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    await seedCompletedRun("r1", yesterday);
+    await recomputeCostRollups(db, config);
+    await recomputeCostRollups(db, config);
+    const rows = await db.select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].runs).toBe(1);
+  });
+
+  it("readRollupWindow returns rows inside the window", async () => {
+    const yesterday = new Date(Date.now() - 86400_000);
+    await seedCompletedRun("r1", yesterday);
+    await recomputeCostRollups(db, config);
+    const from = new Date(Date.now() - 7 * 86400_000);
+    const to = new Date();
+    const rows = await readRollupWindow(db, from, to);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/__tests__/db-cost-rollups-schema.test.ts
+++ b/packages/core/src/__tests__/db-cost-rollups-schema.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { costRollupsDaily } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("cost_rollups_daily schema", () => {
+  it("creates table with the expected columns", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const cols = (db as any).all(sql`PRAGMA table_info(cost_rollups_daily)`) as Array<{name: string}>;
+    expect(cols.map(c => c.name).sort()).toEqual([
+      "computed_at", "date", "dollars", "id", "input_tokens", "linear_team_id",
+      "output_tokens", "pipeline_key", "prs_merged", "repo_url", "runs", "time_saved_hours",
+    ]);
+  });
+
+  it("inserts and reads back a row", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(costRollupsDaily).values({
+      id: "r_1", date: "2026-04-01", pipelineKey: "auto-implement",
+      linearTeamId: "T1", repoUrl: "https://github.com/x/y",
+      runs: 5, prsMerged: 4, inputTokens: 1000, outputTokens: 500,
+      dollars: 12.34, timeSavedHours: 16,
+    });
+    const rows = await (db as any).select().from(costRollupsDaily);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dollars).toBeCloseTo(12.34, 2);
+    expect(rows[0].timeSavedHours).toBe(16);
+  });
+});

--- a/packages/core/src/__tests__/pm-cost-rollup-step.test.ts
+++ b/packages/core/src/__tests__/pm-cost-rollup-step.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPmScheduler } from "../pm/scheduler.js";
+import { createDb } from "../db/client.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+function stubActions() {
+  return {
+    evaluateBudget: vi.fn().mockResolvedValue({
+      scopes: [
+        {
+          scope: { kind: "global" as const },
+          scopeLabel: "global",
+          limit: 100,
+          used: 0,
+          percent: 0,
+          tier: "ok" as const,
+        },
+      ],
+      worstTier: "ok" as const,
+      promoteBlocked: false,
+      activeCount: 0,
+    }),
+    recoverRetriableRuns: vi.fn().mockResolvedValue({ recovered: [], exhausted: [] }),
+    recoverStuckInProgressIssues: vi.fn().mockResolvedValue([]),
+    triageNewIssues: vi.fn().mockResolvedValue([]),
+    resolveApprovals: vi.fn().mockResolvedValue({ resolved: 0, stillPending: 0 }),
+    promoteReadyIssues: vi.fn().mockResolvedValue([]),
+    deprioritizeStaleIssues: vi.fn().mockResolvedValue([]),
+    cancelAbandonedIssues: vi.fn().mockResolvedValue([]),
+    postDigest: vi.fn().mockResolvedValue(undefined),
+    getActiveFileMaps: vi.fn().mockResolvedValue(new Map()),
+    predictConflict: vi.fn().mockResolvedValue({ overlapRisk: "none", likelyFiles: [], reasoning: "" }),
+  };
+}
+
+function baseConfig(extra: Record<string, unknown> = {}): any {
+  return {
+    enabled: true,
+    cronIntervalMs: 1800000,
+    triageBatchSize: 3,
+    maxInFlight: 3,
+    dailyTokenBudget: 100,
+    slackChannelId: "C123",
+    teamIds: ["team-1"],
+    ...extra,
+  };
+}
+
+function yesterdayNoonUtc(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1, 12, 0, 0,
+  ));
+}
+
+describe("pm tick cost rollup step", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("writes cost_rollups_daily rows for yesterday's completed runs", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+
+    const completedAt = yesterdayNoonUtc();
+    const startedAt = new Date(completedAt.getTime() - 3600 * 1000);
+
+    await (db as any).insert(pipelineRuns).values({
+      id: "run-1",
+      issueId: "ISSUE-1",
+      issueTitle: "test issue",
+      pipelineKey: "auto-implement",
+      repoUrl: "https://github.com/acme/app",
+      branch: "agent/ISSUE-1",
+      status: "completed",
+      startedAt,
+      completedAt,
+      totalInputTokens: 1000,
+      totalOutputTokens: 500,
+      linearTeamId: "team-1",
+    });
+
+    await (db as any).insert(stageRuns).values({
+      id: "stage-1",
+      pipelineRunId: "run-1",
+      stage: "implement",
+      status: "completed",
+      startedAt,
+      completedAt,
+      inputTokens: 1000,
+      outputTokens: 500,
+      turns: 3,
+    });
+
+    const scheduler = createPmScheduler({
+      config: baseConfig(),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await scheduler.tick();
+
+    const rows = await (db as any).select().from(costRollupsDaily);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].pipelineKey).toBe("auto-implement");
+    expect(rows[0].runs).toBe(1);
+  });
+
+  it("tick does not throw when rollup fails", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).run?.("DROP TABLE cost_rollups_daily");
+
+    const scheduler = createPmScheduler({
+      config: baseConfig(),
+      db: db as any,
+      linearApiKey: "",
+      slackBotToken: "",
+      actions: stubActions() as any,
+    });
+
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -1,4 +1,4 @@
-import { and, gte, lt, lte, inArray } from "drizzle-orm";
+import { and, gte, lt, inArray } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -2,7 +2,12 @@ import { and, gte, lte, inArray } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
+import { createLogger } from "../logger.js";
 import type { AggregateResult, BreakdownRow, CostSummary } from "./types.js";
+
+const log = createLogger({ component: "cost.aggregate" });
+
+const DEFAULT_MAX_RUNS = 10_000;
 
 export interface AggregateFilters {
   from: Date;
@@ -35,8 +40,10 @@ export async function aggregateAll(
   db: AnyDb,
   filters: AggregateFilters,
   config: CostConfig,
+  opts: { maxRuns?: number } = {},
 ): Promise<AggregateResult> {
   const hourlyRate = config.costs?.hourlyEngRate ?? 50;
+  const maxRuns = opts.maxRuns ?? DEFAULT_MAX_RUNS;
 
   const runs = await db.select().from(pipelineRuns).where(
     and(
@@ -44,6 +51,22 @@ export async function aggregateAll(
       lte(pipelineRuns.completedAt, filters.to),
     ),
   );
+
+  let truncated = false;
+  if (runs.length > maxRuns) {
+    log.warn(
+      { runs: runs.length, maxRuns, from: filters.from, to: filters.to },
+      "aggregateAll: runs exceed cap, truncating to most recent",
+    );
+    // Sort by completedAt DESC (nulls last) and keep only the most recent `maxRuns`.
+    runs.sort((a: any, b: any) => {
+      const ta = a.completedAt ? new Date(a.completedAt).getTime() : 0;
+      const tb = b.completedAt ? new Date(b.completedAt).getTime() : 0;
+      return tb - ta;
+    });
+    runs.splice(maxRuns);
+    truncated = true;
+  }
 
   if (runs.length === 0) {
     return {
@@ -70,6 +93,7 @@ export async function aggregateAll(
     window: { from: filters.from, to: filters.to },
     runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
     dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+    ...(truncated ? { truncated: true } : {}),
   };
   const byTeam = new Map<string, BreakdownRow>();
   const byRepo = new Map<string, BreakdownRow>();

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -1,4 +1,4 @@
-import { and, gte, lte, inArray } from "drizzle-orm";
+import { and, gte, lt, lte, inArray } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
@@ -8,6 +8,15 @@ import type { AggregateResult, BreakdownRow, CostSummary } from "./types.js";
 const log = createLogger({ component: "cost.aggregate" });
 
 const DEFAULT_MAX_RUNS = 10_000;
+
+const UNASSIGNED_TEAM = "(unassigned)";
+
+export function normalizeTeamId(id: string | null | undefined): { key: string; label: string } {
+  if (id === null || id === undefined || id === "") {
+    return { key: "team:unassigned", label: UNASSIGNED_TEAM };
+  }
+  return { key: `team:${id}`, label: id };
+}
 
 export interface AggregateFilters {
   from: Date;
@@ -48,7 +57,8 @@ export async function aggregateAll(
   const runs = await db.select().from(pipelineRuns).where(
     and(
       gte(pipelineRuns.completedAt, filters.from),
-      lte(pipelineRuns.completedAt, filters.to),
+      // half-open [from, to) — matches rollup.ts convention and avoids double-counting at the boundary
+      lt(pipelineRuns.completedAt, filters.to),
     ),
   );
 
@@ -103,34 +113,34 @@ export async function aggregateAll(
     const runStages = stagesByRun.get(run.id) ?? [];
     const cost = computeRunCost(run as any, runStages as any, config);
 
+    const isMergedPr = run.status === "completed" && run.runType !== "review-feedback";
     summary.runs += 1;
     summary.inputTokens += cost.inputTokens;
     summary.outputTokens += cost.outputTokens;
     summary.dollars += cost.dollars;
     summary.timeSavedHours += cost.timeSavedHours;
-    if (run.status === "completed") summary.prsMerged += 1;
+    if (isMergedPr) summary.prsMerged += 1;
 
-    const teamKey = `team:${run.linearTeamId ?? "unassigned"}`;
-    const teamLabel = run.linearTeamId ?? "(unassigned)";
+    const { key: teamKey, label: teamLabel } = normalizeTeamId(run.linearTeamId);
     if (!byTeam.has(teamKey)) byTeam.set(teamKey, emptyBucket(teamKey, teamLabel));
     const tb = byTeam.get(teamKey)!;
     tb.runs += 1; tb.inputTokens += cost.inputTokens; tb.outputTokens += cost.outputTokens;
     tb.dollars += cost.dollars; tb.timeSavedHours += cost.timeSavedHours;
-    if (run.status === "completed") tb.prsMerged += 1;
+    if (isMergedPr) tb.prsMerged += 1;
 
     const repoKey = `repo:${run.repoUrl}`;
     if (!byRepo.has(repoKey)) byRepo.set(repoKey, emptyBucket(repoKey, run.repoUrl));
     const rb = byRepo.get(repoKey)!;
     rb.runs += 1; rb.inputTokens += cost.inputTokens; rb.outputTokens += cost.outputTokens;
     rb.dollars += cost.dollars; rb.timeSavedHours += cost.timeSavedHours;
-    if (run.status === "completed") rb.prsMerged += 1;
+    if (isMergedPr) rb.prsMerged += 1;
 
     const pipelineKey = `pipeline:${run.pipelineKey}`;
     if (!byPipeline.has(pipelineKey)) byPipeline.set(pipelineKey, emptyBucket(pipelineKey, run.pipelineKey));
     const pb = byPipeline.get(pipelineKey)!;
     pb.runs += 1; pb.inputTokens += cost.inputTokens; pb.outputTokens += cost.outputTokens;
     pb.dollars += cost.dollars; pb.timeSavedHours += cost.timeSavedHours;
-    if (run.status === "completed") pb.prsMerged += 1;
+    if (isMergedPr) pb.prsMerged += 1;
   }
 
   summary.roiMultiplier = finalizeRoi(summary, hourlyRate);

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -1,0 +1,125 @@
+import { and, gte, lte, inArray } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { computeRunCost } from "./per-run.js";
+import type { AggregateResult, BreakdownRow, CostSummary } from "./types.js";
+
+export interface AggregateFilters {
+  from: Date;
+  to: Date;
+}
+
+interface CostConfig {
+  costs?: {
+    hourlyEngRate?: number;
+    modelPricing?: Record<string, { inputPerMillion: number; outputPerMillion: number }>;
+    timeSavedPerPrDefault?: number;
+  };
+  pipelineConfigs?: Record<string, any>;
+}
+
+function emptyBucket(key: string, label: string): BreakdownRow {
+  return {
+    key, label, runs: 0, prsMerged: 0,
+    inputTokens: 0, outputTokens: 0,
+    dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+  };
+}
+
+function finalizeRoi(row: { dollars: number; timeSavedHours: number }, hourlyRate: number): number {
+  if (row.dollars === 0) return row.timeSavedHours > 0 ? Infinity : 0;
+  return (row.timeSavedHours * hourlyRate) / row.dollars;
+}
+
+export async function aggregateAll(
+  db: AnyDb,
+  filters: AggregateFilters,
+  config: CostConfig,
+): Promise<AggregateResult> {
+  const hourlyRate = config.costs?.hourlyEngRate ?? 50;
+
+  const runs = await db.select().from(pipelineRuns).where(
+    and(
+      gte(pipelineRuns.completedAt, filters.from),
+      lte(pipelineRuns.completedAt, filters.to),
+    ),
+  );
+
+  if (runs.length === 0) {
+    return {
+      summary: {
+        window: { from: filters.from, to: filters.to },
+        runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
+        dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+      },
+      byTeam: [], byRepo: [], byPipeline: [],
+    };
+  }
+
+  const runIds = runs.map((r: any) => r.id);
+  const stages = await db.select().from(stageRuns).where(inArray(stageRuns.pipelineRunId, runIds));
+
+  const stagesByRun = new Map<string, any[]>();
+  for (const s of stages) {
+    const arr = stagesByRun.get(s.pipelineRunId) ?? [];
+    arr.push(s);
+    stagesByRun.set(s.pipelineRunId, arr);
+  }
+
+  const summary: CostSummary = {
+    window: { from: filters.from, to: filters.to },
+    runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
+    dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+  };
+  const byTeam = new Map<string, BreakdownRow>();
+  const byRepo = new Map<string, BreakdownRow>();
+  const byPipeline = new Map<string, BreakdownRow>();
+
+  for (const run of runs) {
+    const runStages = stagesByRun.get(run.id) ?? [];
+    const cost = computeRunCost(run as any, runStages as any, config);
+
+    summary.runs += 1;
+    summary.inputTokens += cost.inputTokens;
+    summary.outputTokens += cost.outputTokens;
+    summary.dollars += cost.dollars;
+    summary.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") summary.prsMerged += 1;
+
+    const teamKey = `team:${run.linearTeamId ?? "unassigned"}`;
+    const teamLabel = run.linearTeamId ?? "(unassigned)";
+    if (!byTeam.has(teamKey)) byTeam.set(teamKey, emptyBucket(teamKey, teamLabel));
+    const tb = byTeam.get(teamKey)!;
+    tb.runs += 1; tb.inputTokens += cost.inputTokens; tb.outputTokens += cost.outputTokens;
+    tb.dollars += cost.dollars; tb.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") tb.prsMerged += 1;
+
+    const repoKey = `repo:${run.repoUrl}`;
+    if (!byRepo.has(repoKey)) byRepo.set(repoKey, emptyBucket(repoKey, run.repoUrl));
+    const rb = byRepo.get(repoKey)!;
+    rb.runs += 1; rb.inputTokens += cost.inputTokens; rb.outputTokens += cost.outputTokens;
+    rb.dollars += cost.dollars; rb.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") rb.prsMerged += 1;
+
+    const pipelineKey = `pipeline:${run.pipelineKey}`;
+    if (!byPipeline.has(pipelineKey)) byPipeline.set(pipelineKey, emptyBucket(pipelineKey, run.pipelineKey));
+    const pb = byPipeline.get(pipelineKey)!;
+    pb.runs += 1; pb.inputTokens += cost.inputTokens; pb.outputTokens += cost.outputTokens;
+    pb.dollars += cost.dollars; pb.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") pb.prsMerged += 1;
+  }
+
+  summary.roiMultiplier = finalizeRoi(summary, hourlyRate);
+  const sort = (a: BreakdownRow, b: BreakdownRow) => b.dollars - a.dollars;
+  const finalize = (rows: BreakdownRow[]) => {
+    for (const r of rows) r.roiMultiplier = finalizeRoi(r, hourlyRate);
+    return rows.sort(sort);
+  };
+
+  return {
+    summary,
+    byTeam: finalize(Array.from(byTeam.values())),
+    byRepo: finalize(Array.from(byRepo.values())),
+    byPipeline: finalize(Array.from(byPipeline.values())),
+  };
+}

--- a/packages/core/src/cost/csv.ts
+++ b/packages/core/src/cost/csv.ts
@@ -1,0 +1,78 @@
+import type { AnyDb } from "../db/client.js";
+import { and, gte, lte, inArray } from "drizzle-orm";
+import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { computeRunCost } from "./per-run.js";
+
+const HEADER =
+  "completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours";
+
+const FORMULA_PREFIX = /^[=+\-@\t]/;
+
+function escapeCsvField(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  let s = String(value);
+  if (FORMULA_PREFIX.test(s)) s = "'" + s;
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export interface CsvFilters {
+  from: Date;
+  to: Date;
+}
+
+interface CostConfig {
+  costs?: any;
+  pipelineConfigs?: Record<string, any>;
+}
+
+export async function* streamCostCsv(
+  db: AnyDb,
+  filters: CsvFilters,
+  config: CostConfig,
+): AsyncIterable<string> {
+  yield HEADER + "\n";
+
+  const runs = await db
+    .select()
+    .from(pipelineRuns)
+    .where(
+      and(
+        gte(pipelineRuns.completedAt, filters.from),
+        lte(pipelineRuns.completedAt, filters.to),
+      ),
+    );
+  if (runs.length === 0) return;
+
+  const runIds = runs.map((r: any) => r.id);
+  const stages = await db
+    .select()
+    .from(stageRuns)
+    .where(inArray(stageRuns.pipelineRunId, runIds));
+  const stagesByRun = new Map<string, any[]>();
+  for (const s of stages) {
+    const arr = stagesByRun.get(s.pipelineRunId) ?? [];
+    arr.push(s);
+    stagesByRun.set(s.pipelineRunId, arr);
+  }
+
+  for (const run of runs) {
+    const runStages = stagesByRun.get(run.id) ?? [];
+    const cost = computeRunCost(run as any, runStages as any, config);
+    const fields = [
+      run.completedAt?.toISOString() ?? "",
+      run.id,
+      run.issueId,
+      run.pipelineKey,
+      run.linearTeamId ?? "",
+      run.repoUrl,
+      cost.inputTokens,
+      cost.outputTokens,
+      cost.dollars.toFixed(4),
+      cost.timeSavedHours,
+    ].map(escapeCsvField);
+    yield fields.join(",") + "\n";
+  }
+}

--- a/packages/core/src/cost/csv.ts
+++ b/packages/core/src/cost/csv.ts
@@ -1,5 +1,5 @@
 import type { AnyDb } from "../db/client.js";
-import { and, gte, lte, inArray } from "drizzle-orm";
+import { and, gte, lt, inArray } from "drizzle-orm";
 import { pipelineRuns, stageRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 
@@ -28,10 +28,13 @@ interface CostConfig {
   pipelineConfigs?: Record<string, any>;
 }
 
+const DEFAULT_CSV_MAX_RUNS = 10_000;
+
 export async function* streamCostCsv(
   db: AnyDb,
   filters: CsvFilters,
   config: CostConfig,
+  maxRuns: number = DEFAULT_CSV_MAX_RUNS,
 ): AsyncIterable<string> {
   yield HEADER + "\n";
 
@@ -41,10 +44,24 @@ export async function* streamCostCsv(
     .where(
       and(
         gte(pipelineRuns.completedAt, filters.from),
-        lte(pipelineRuns.completedAt, filters.to),
+        // half-open [from, to) — matches rollup.ts convention and avoids double-counting at the boundary
+        lt(pipelineRuns.completedAt, filters.to),
       ),
     );
   if (runs.length === 0) return;
+
+  const totalRuns = runs.length;
+  let truncated = false;
+  if (runs.length > maxRuns) {
+    // Sort by completedAt DESC (nulls last) and keep only the most recent maxRuns.
+    runs.sort((a: any, b: any) => {
+      const ta = a.completedAt ? new Date(a.completedAt).getTime() : 0;
+      const tb = b.completedAt ? new Date(b.completedAt).getTime() : 0;
+      return tb - ta;
+    });
+    runs.splice(maxRuns);
+    truncated = true;
+  }
 
   const runIds = runs.map((r: any) => r.id);
   const stages = await db
@@ -74,5 +91,9 @@ export async function* streamCostCsv(
       cost.timeSavedHours,
     ].map(escapeCsvField);
     yield fields.join(",") + "\n";
+  }
+
+  if (truncated) {
+    yield `# truncated: ${totalRuns} runs in window, exported most recent ${maxRuns}. Narrow date range for complete export.\n`;
   }
 }

--- a/packages/core/src/cost/index.ts
+++ b/packages/core/src/cost/index.ts
@@ -3,3 +3,4 @@ export * from "./rates.js";
 export * from "./per-run.js";
 export * from "./aggregate.js";
 export * from "./rollup.js";
+export * from "./csv.js";

--- a/packages/core/src/cost/index.ts
+++ b/packages/core/src/cost/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./rates.js";
 export * from "./per-run.js";
+export * from "./aggregate.js";

--- a/packages/core/src/cost/index.ts
+++ b/packages/core/src/cost/index.ts
@@ -1,2 +1,3 @@
 export * from "./types.js";
 export * from "./rates.js";
+export * from "./per-run.js";

--- a/packages/core/src/cost/index.ts
+++ b/packages/core/src/cost/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./rates.js";

--- a/packages/core/src/cost/index.ts
+++ b/packages/core/src/cost/index.ts
@@ -2,3 +2,4 @@ export * from "./types.js";
 export * from "./rates.js";
 export * from "./per-run.js";
 export * from "./aggregate.js";
+export * from "./rollup.js";

--- a/packages/core/src/cost/per-run.ts
+++ b/packages/core/src/cost/per-run.ts
@@ -4,6 +4,7 @@ import type { RunCost } from "./types.js";
 interface PipelineRunRow {
   pipelineKey: string;
   status: string;
+  runType?: string | null;
 }
 
 interface StageRunRow {
@@ -46,6 +47,8 @@ export function computeRunCost(
     outputTokens += s.outputTokens;
   }
   const timeSavedHours =
-    run.status === "completed" ? resolveTimeSavedPerPr(run.pipelineKey, config) : 0;
+    run.status === "completed" && run.runType !== "review-feedback"
+      ? resolveTimeSavedPerPr(run.pipelineKey, config)
+      : 0;
   return { inputTokens, outputTokens, dollars, timeSavedHours };
 }

--- a/packages/core/src/cost/per-run.ts
+++ b/packages/core/src/cost/per-run.ts
@@ -1,0 +1,51 @@
+import { resolveModelRate, resolveTimeSavedPerPr } from "./rates.js";
+import type { RunCost } from "./types.js";
+
+interface PipelineRunRow {
+  pipelineKey: string;
+  status: string;
+}
+
+interface StageRunRow {
+  stage: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+interface CostConfig {
+  costs?: {
+    modelPricing?: Record<string, { inputPerMillion: number; outputPerMillion: number }>;
+    hourlyEngRate?: number;
+    timeSavedPerPrDefault?: number;
+  };
+  pipelineConfigs?: Record<string, {
+    stageModels?: Record<string, string>;
+    profile?: { model?: string };
+    timeSavedPerPr?: number;
+  }>;
+}
+
+export function computeRunCost(
+  run: PipelineRunRow,
+  stages: StageRunRow[],
+  config: CostConfig,
+): RunCost {
+  const pc = config.pipelineConfigs?.[run.pipelineKey];
+  let dollars = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  for (const s of stages) {
+    const modelName =
+      pc?.stageModels?.[s.stage] ??
+      pc?.profile?.model ??
+      "claude-sonnet-4-6";
+    const rate = resolveModelRate(modelName, config);
+    dollars += (s.inputTokens * rate.inputPerMillion) / 1_000_000;
+    dollars += (s.outputTokens * rate.outputPerMillion) / 1_000_000;
+    inputTokens += s.inputTokens;
+    outputTokens += s.outputTokens;
+  }
+  const timeSavedHours =
+    run.status === "completed" ? resolveTimeSavedPerPr(run.pipelineKey, config) : 0;
+  return { inputTokens, outputTokens, dollars, timeSavedHours };
+}

--- a/packages/core/src/cost/rates.ts
+++ b/packages/core/src/cost/rates.ts
@@ -1,0 +1,36 @@
+import type { ModelRate } from "./types.js";
+
+const BUILTIN_SONNET: ModelRate = { inputPerMillion: 3, outputPerMillion: 15 };
+
+/**
+ * Resolve the $/M-token rate for a given model. Lookup order:
+ * 1. config.costs.modelPricing[modelName] — configured explicit rate
+ * 2. config.costs.modelPricing["claude-sonnet-4-6"] — fallback to sonnet
+ * 3. Built-in sonnet default ($3/$15 per M) — for deployments with no costs config
+ */
+export function resolveModelRate(
+  modelName: string,
+  config: { costs?: { modelPricing?: Record<string, ModelRate> } },
+): ModelRate {
+  const table = config.costs?.modelPricing;
+  if (!table) return BUILTIN_SONNET;
+  return table[modelName] ?? table["claude-sonnet-4-6"] ?? BUILTIN_SONNET;
+}
+
+/**
+ * Resolve the `timeSavedPerPr` hours for a given pipeline. Lookup order:
+ * 1. pipelineConfigs[pipelineKey].timeSavedPerPr
+ * 2. config.costs.timeSavedPerPrDefault
+ * 3. Built-in default (4h)
+ */
+export function resolveTimeSavedPerPr(
+  pipelineKey: string,
+  config: {
+    costs?: { timeSavedPerPrDefault?: number };
+    pipelineConfigs?: Record<string, { timeSavedPerPr?: number }>;
+  },
+): number {
+  const override = config.pipelineConfigs?.[pipelineKey]?.timeSavedPerPr;
+  if (override !== undefined) return override;
+  return config.costs?.timeSavedPerPrDefault ?? 4;
+}

--- a/packages/core/src/cost/rollup.ts
+++ b/packages/core/src/cost/rollup.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, gte, lte, inArray } from "drizzle-orm";
+import { and, gte, lt, lte, inArray } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
@@ -18,7 +18,8 @@ interface CostConfig {
 
 function dayBounds(dateStr: string): { start: Date; end: Date } {
   const start = new Date(dateStr + "T00:00:00.000Z");
-  const end = new Date(dateStr + "T23:59:59.999Z");
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
   return { start, end };
 }
 
@@ -41,7 +42,7 @@ export async function recomputeCostRollups(
   const runs = await db.select().from(pipelineRuns).where(
     and(
       gte(pipelineRuns.completedAt, start),
-      lte(pipelineRuns.completedAt, end),
+      lt(pipelineRuns.completedAt, end),
     ),
   );
 
@@ -63,7 +64,7 @@ export async function recomputeCostRollups(
   }
 
   const buckets = new Map<string, {
-    pipelineKey: string; linearTeamId: string | null; repoUrl: string;
+    pipelineKey: string; linearTeamId: string; repoUrl: string;
     runs: number; prsMerged: number; inputTokens: number; outputTokens: number;
     dollars: number; timeSavedHours: number;
   }>();
@@ -71,12 +72,17 @@ export async function recomputeCostRollups(
   for (const run of runs) {
     const runStages = stagesByRun.get(run.id) ?? [];
     const cost = computeRunCost(run as any, runStages as any, config);
+    // Sentinel "" (empty string) instead of NULL for linearTeamId so that
+    // the composite UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+    // fires onConflictDoUpdate for unassigned runs. Both SQLite and Postgres
+    // treat NULL ≠ NULL in composite uniques, which would otherwise cause
+    // duplicate rollup rows for the "(unassigned)" bucket on every PM tick.
     const key = `${run.pipelineKey}|${run.linearTeamId ?? ""}|${run.repoUrl}`;
     let b = buckets.get(key);
     if (!b) {
       b = {
         pipelineKey: run.pipelineKey,
-        linearTeamId: run.linearTeamId ?? null,
+        linearTeamId: run.linearTeamId ?? "",
         repoUrl: run.repoUrl,
         runs: 0, prsMerged: 0,
         inputTokens: 0, outputTokens: 0,

--- a/packages/core/src/cost/rollup.ts
+++ b/packages/core/src/cost/rollup.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { and, gte, lt, lte, inArray } from "drizzle-orm";
+import { and, gte, lt, lte, inArray, max } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { createLogger } from "../logger.js";
 
 const log = createLogger({ component: "cost.rollup" });
+
+const MAX_BACKFILL_DAYS = 30;
 
 interface CostConfig {
   costs?: {
@@ -27,16 +29,22 @@ function utcDateStr(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-export async function recomputeCostRollups(
+/** Add `days` UTC days to a date string (YYYY-MM-DD) and return a new date string. */
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + "T00:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return utcDateStr(d);
+}
+
+/**
+ * Roll up cost data for a single UTC day into cost_rollups_daily.
+ * Idempotent — uses onConflictDoUpdate.
+ */
+async function rollOneDay(
   db: AnyDb,
+  dateStr: string,
   config: CostConfig,
-): Promise<{ rowsWritten: number }> {
-  // Determine yesterday (UTC). Rollups only cover completed UTC days.
-  const now = new Date();
-  const yesterdayUtc = new Date(Date.UTC(
-    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1,
-  ));
-  const dateStr = utcDateStr(yesterdayUtc);
+): Promise<number> {
   const { start, end } = dayBounds(dateStr);
 
   const runs = await db.select().from(pipelineRuns).where(
@@ -48,7 +56,7 @@ export async function recomputeCostRollups(
 
   if (runs.length === 0) {
     log.info({ date: dateStr, rowsWritten: 0 }, "no runs to roll up");
-    return { rowsWritten: 0 };
+    return 0;
   }
 
   const runIds = runs.map((r: any) => r.id);
@@ -95,7 +103,7 @@ export async function recomputeCostRollups(
     b.outputTokens += cost.outputTokens;
     b.dollars += cost.dollars;
     b.timeSavedHours += cost.timeSavedHours;
-    if (run.status === "completed") b.prsMerged += 1;
+    if (run.status === "completed" && run.runType !== "review-feedback") b.prsMerged += 1;
   }
 
   let rowsWritten = 0;
@@ -134,7 +142,65 @@ export async function recomputeCostRollups(
   }
 
   log.info({ date: dateStr, rowsWritten }, "cost rollup complete");
-  return { rowsWritten };
+  return rowsWritten;
+}
+
+export async function recomputeCostRollups(
+  db: AnyDb,
+  config: CostConfig,
+): Promise<{ rowsWritten: number }> {
+  // Determine yesterday (UTC). Rollups only cover completed UTC days.
+  const now = new Date();
+  const yesterdayUtc = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1,
+  ));
+  const yesterdayStr = utcDateStr(yesterdayUtc);
+
+  // Find the latest date already in the rollup table.
+  const [latestRow] = await db.select({ latestDate: max(costRollupsDaily.date) }).from(costRollupsDaily);
+  const latestDate: string | null = latestRow?.latestDate ?? null;
+
+  // Determine the set of dates to roll.
+  let datesToRoll: string[];
+
+  if (latestDate === null) {
+    // First run: backfill up to MAX_BACKFILL_DAYS before yesterday, inclusive.
+    const firstDate = addDays(yesterdayStr, -(MAX_BACKFILL_DAYS - 1));
+    datesToRoll = [];
+    let d = firstDate;
+    while (d <= yesterdayStr) {
+      datesToRoll.push(d);
+      d = addDays(d, 1);
+    }
+    log.info({ firstDate, yesterdayStr, days: datesToRoll.length }, "cost rollup: first run, backfilling");
+  } else if (latestDate < yesterdayStr) {
+    // Some entries exist but there's a gap. Fill from latest+1 through yesterday.
+    // Cap at MAX_BACKFILL_DAYS to avoid runaway on pathological stale dates.
+    const rawFirstDate = addDays(latestDate, 1);
+    const cappedFirstDate = addDays(yesterdayStr, -(MAX_BACKFILL_DAYS - 1));
+    const firstDate = rawFirstDate > cappedFirstDate ? rawFirstDate : cappedFirstDate;
+    datesToRoll = [];
+    let d = firstDate;
+    while (d <= yesterdayStr) {
+      datesToRoll.push(d);
+      d = addDays(d, 1);
+    }
+    log.info({ latestDate, firstDate, yesterdayStr, days: datesToRoll.length }, "cost rollup: backfilling missing days");
+  } else if (latestDate === yesterdayStr) {
+    // Already up to date — re-roll yesterday for idempotency (tick runs multiple times/day).
+    datesToRoll = [yesterdayStr];
+  } else {
+    // latestDate > yesterdayStr — shouldn't happen but be defensive.
+    log.warn({ latestDate, yesterdayStr }, "cost rollup: latest date is in the future, skipping");
+    return { rowsWritten: 0 };
+  }
+
+  let totalRowsWritten = 0;
+  for (const dateStr of datesToRoll) {
+    totalRowsWritten += await rollOneDay(db, dateStr, config);
+  }
+
+  return { rowsWritten: totalRowsWritten };
 }
 
 export async function readRollupWindow(

--- a/packages/core/src/cost/rollup.ts
+++ b/packages/core/src/cost/rollup.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { and, gte, lte, inArray } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { computeRunCost } from "./per-run.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "cost.rollup" });
+
+interface CostConfig {
+  costs?: {
+    modelPricing?: Record<string, { inputPerMillion: number; outputPerMillion: number }>;
+    timeSavedPerPrDefault?: number;
+    hourlyEngRate?: number;
+  };
+  pipelineConfigs?: Record<string, any>;
+}
+
+function dayBounds(dateStr: string): { start: Date; end: Date } {
+  const start = new Date(dateStr + "T00:00:00.000Z");
+  const end = new Date(dateStr + "T23:59:59.999Z");
+  return { start, end };
+}
+
+function utcDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function recomputeCostRollups(
+  db: AnyDb,
+  config: CostConfig,
+): Promise<{ rowsWritten: number }> {
+  // Determine yesterday (UTC). Rollups only cover completed UTC days.
+  const now = new Date();
+  const yesterdayUtc = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1,
+  ));
+  const dateStr = utcDateStr(yesterdayUtc);
+  const { start, end } = dayBounds(dateStr);
+
+  const runs = await db.select().from(pipelineRuns).where(
+    and(
+      gte(pipelineRuns.completedAt, start),
+      lte(pipelineRuns.completedAt, end),
+    ),
+  );
+
+  if (runs.length === 0) {
+    log.info({ date: dateStr, rowsWritten: 0 }, "no runs to roll up");
+    return { rowsWritten: 0 };
+  }
+
+  const runIds = runs.map((r: any) => r.id);
+  const stages = await db.select().from(stageRuns).where(
+    inArray(stageRuns.pipelineRunId, runIds),
+  );
+
+  const stagesByRun = new Map<string, any[]>();
+  for (const s of stages) {
+    const arr = stagesByRun.get(s.pipelineRunId) ?? [];
+    arr.push(s);
+    stagesByRun.set(s.pipelineRunId, arr);
+  }
+
+  const buckets = new Map<string, {
+    pipelineKey: string; linearTeamId: string | null; repoUrl: string;
+    runs: number; prsMerged: number; inputTokens: number; outputTokens: number;
+    dollars: number; timeSavedHours: number;
+  }>();
+
+  for (const run of runs) {
+    const runStages = stagesByRun.get(run.id) ?? [];
+    const cost = computeRunCost(run as any, runStages as any, config);
+    const key = `${run.pipelineKey}|${run.linearTeamId ?? ""}|${run.repoUrl}`;
+    let b = buckets.get(key);
+    if (!b) {
+      b = {
+        pipelineKey: run.pipelineKey,
+        linearTeamId: run.linearTeamId ?? null,
+        repoUrl: run.repoUrl,
+        runs: 0, prsMerged: 0,
+        inputTokens: 0, outputTokens: 0,
+        dollars: 0, timeSavedHours: 0,
+      };
+      buckets.set(key, b);
+    }
+    b.runs += 1;
+    b.inputTokens += cost.inputTokens;
+    b.outputTokens += cost.outputTokens;
+    b.dollars += cost.dollars;
+    b.timeSavedHours += cost.timeSavedHours;
+    if (run.status === "completed") b.prsMerged += 1;
+  }
+
+  let rowsWritten = 0;
+  for (const b of buckets.values()) {
+    await db.insert(costRollupsDaily).values({
+      id: `cr_${randomUUID()}`,
+      date: dateStr,
+      pipelineKey: b.pipelineKey,
+      linearTeamId: b.linearTeamId,
+      repoUrl: b.repoUrl,
+      runs: b.runs,
+      prsMerged: b.prsMerged,
+      inputTokens: b.inputTokens,
+      outputTokens: b.outputTokens,
+      dollars: b.dollars,
+      timeSavedHours: b.timeSavedHours,
+      computedAt: new Date(),
+    }).onConflictDoUpdate({
+      target: [
+        costRollupsDaily.date,
+        costRollupsDaily.pipelineKey,
+        costRollupsDaily.linearTeamId,
+        costRollupsDaily.repoUrl,
+      ],
+      set: {
+        runs: b.runs,
+        prsMerged: b.prsMerged,
+        inputTokens: b.inputTokens,
+        outputTokens: b.outputTokens,
+        dollars: b.dollars,
+        timeSavedHours: b.timeSavedHours,
+        computedAt: new Date(),
+      },
+    });
+    rowsWritten += 1;
+  }
+
+  log.info({ date: dateStr, rowsWritten }, "cost rollup complete");
+  return { rowsWritten };
+}
+
+export async function readRollupWindow(
+  db: AnyDb,
+  from: Date,
+  to: Date,
+): Promise<any[]> {
+  const fromDate = utcDateStr(from);
+  const toDate = utcDateStr(to);
+  return await db.select().from(costRollupsDaily).where(
+    and(
+      gte(costRollupsDaily.date, fromDate),
+      lte(costRollupsDaily.date, toDate),
+    ),
+  );
+}

--- a/packages/core/src/cost/types.ts
+++ b/packages/core/src/cost/types.ts
@@ -19,6 +19,8 @@ export interface CostSummary {
   dollars: number;
   timeSavedHours: number;
   roiMultiplier: number;
+  /** Set when the underlying query exceeded the row cap and was truncated. */
+  truncated?: boolean;
 }
 
 export type BreakdownDimension = "team" | "repo" | "pipeline";

--- a/packages/core/src/cost/types.ts
+++ b/packages/core/src/cost/types.ts
@@ -1,0 +1,43 @@
+export interface ModelRate {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+export interface RunCost {
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+}
+
+export interface CostSummary {
+  window: { from: Date; to: Date };
+  runs: number;
+  prsMerged: number;
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+  roiMultiplier: number;
+}
+
+export type BreakdownDimension = "team" | "repo" | "pipeline";
+
+export interface BreakdownRow {
+  key: string;
+  label: string;
+  runs: number;
+  prsMerged: number;
+  inputTokens: number;
+  outputTokens: number;
+  dollars: number;
+  timeSavedHours: number;
+  roiMultiplier: number;
+}
+
+export interface AggregateResult {
+  summary: CostSummary;
+  byTeam: BreakdownRow[];
+  byRepo: BreakdownRow[];
+  byPipeline: BreakdownRow[];
+}

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -69,6 +69,7 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
   const ts = driver === "postgres" ? "TIMESTAMPTZ" : "INTEGER";
   const now = driver === "postgres" ? "now()" : "unixepoch()";
   const bool = driver === "postgres" ? "BOOLEAN" : "INTEGER";
+  const num = driver === "postgres" ? "DOUBLE PRECISION" : "REAL";
 
   return `
   CREATE TABLE IF NOT EXISTS pipeline_runs (
@@ -202,6 +203,24 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
 
   CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_user_id ON dashboard_sessions(user_id);
   CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires_at ON dashboard_sessions(expires_at);
+
+  CREATE TABLE IF NOT EXISTS cost_rollups_daily (
+    id TEXT PRIMARY KEY,
+    date TEXT NOT NULL,
+    pipeline_key TEXT NOT NULL,
+    linear_team_id TEXT,
+    repo_url TEXT NOT NULL,
+    runs INTEGER NOT NULL DEFAULT 0,
+    prs_merged INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    dollars ${num} NOT NULL DEFAULT 0,
+    time_saved_hours ${num} NOT NULL DEFAULT 0,
+    computed_at ${ts} NOT NULL,
+    UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+  );
+  CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
+  CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);
 `;
 }
 

--- a/packages/core/src/db/migrations/postgres/008_cost_rollups.sql
+++ b/packages/core/src/db/migrations/postgres/008_cost_rollups.sql
@@ -1,0 +1,19 @@
+-- Enterprise feature 4.5: cost rollups
+CREATE TABLE IF NOT EXISTS cost_rollups_daily (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  pipeline_key TEXT NOT NULL,
+  linear_team_id TEXT,
+  repo_url TEXT NOT NULL,
+  runs INTEGER NOT NULL DEFAULT 0,
+  prs_merged INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  dollars DOUBLE PRECISION NOT NULL DEFAULT 0,
+  time_saved_hours DOUBLE PRECISION NOT NULL DEFAULT 0,
+  computed_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);

--- a/packages/core/src/db/migrations/sqlite/007_cost_rollups.sql
+++ b/packages/core/src/db/migrations/sqlite/007_cost_rollups.sql
@@ -1,0 +1,19 @@
+-- Enterprise feature 4.5: cost rollups
+CREATE TABLE IF NOT EXISTS cost_rollups_daily (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  pipeline_key TEXT NOT NULL,
+  linear_team_id TEXT,
+  repo_url TEXT NOT NULL,
+  runs INTEGER NOT NULL DEFAULT 0,
+  prs_merged INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  dollars REAL NOT NULL DEFAULT 0,
+  time_saved_hours REAL NOT NULL DEFAULT 0,
+  computed_at INTEGER NOT NULL,
+  UNIQUE (date, pipeline_key, linear_team_id, repo_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
+CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { customType, sqliteTable, text, integer, unique } from "drizzle-orm/sqlite-core";
+import { customType, sqliteTable, text, integer, real, unique } from "drizzle-orm/sqlite-core";
 
 /**
  * Active driver mode for cross-database timestamp serialization.
@@ -203,3 +203,23 @@ export const dashboardSessions = sqliteTable("dashboard_sessions", {
     .notNull()
     .$defaultFn(() => new Date()),
 });
+
+/** Enterprise feature 4.5: pre-aggregated daily cost rollups for the /cost dashboard. */
+export const costRollupsDaily = sqliteTable("cost_rollups_daily", {
+  id: text("id").primaryKey(),
+  date: text("date").notNull(),
+  pipelineKey: text("pipeline_key").notNull(),
+  linearTeamId: text("linear_team_id"),
+  repoUrl: text("repo_url").notNull(),
+  runs: integer("runs").notNull().default(0),
+  prsMerged: integer("prs_merged").notNull().default(0),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  dollars: real("dollars").notNull().default(0),
+  timeSavedHours: real("time_saved_hours").notNull().default(0),
+  computedAt: crossTimestamp("computed_at")
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (t) => [
+  unique().on(t.date, t.pipelineKey, t.linearTeamId, t.repoUrl),
+]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export { checkLicense, isFeatureLicensed, type LicenseStatus } from "./license.j
 export * from "./audit/index.js";
 export * from "./auth/index.js";
 export * from "./policy/index.js";
+export * from "./cost/index.js";
 export { computeConfigFingerprint } from "./audit/config-fingerprint.js";
 export { rootLogger, createLogger, addLogStream } from "./logger.js";
 export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db } from "./db/index.js";

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -40,6 +40,7 @@ const ENTERPRISE_FEATURES = [
   "spend-caps",
   "rbac",
   "cost-dashboard",
+  "cost-roi",
   "org-policy",
   "pm-agent-governance",
 ];

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -24,6 +24,7 @@ import { sql } from "drizzle-orm";
 import { createLogger } from "../logger.js";
 import { logAuditEvent, budgetRefusedEvent, pruneAuditLog } from "../audit/index.js";
 import { pruneExpiredSessions } from "../auth/index.js";
+import { recomputeCostRollups } from "../cost/index.js";
 
 const log = createLogger({ component: "PmAgent:scheduler" });
 
@@ -485,6 +486,16 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           }
         } catch (err) {
           log.warn({ err }, "session prune failed");
+        }
+
+        // Cost & ROI daily rollup (no-op if unlicensed).
+        // Wrapped in try/catch — rollup failure must not crash the tick.
+        try {
+          if (isFeatureLicensed("cost-roi")) {
+            await recomputeCostRollups(db, config as any);
+          }
+        } catch (err) {
+          log.warn({ err }, "cost rollup failed");
         }
 
       log.info({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,6 +85,9 @@ export const PipelineConfigSchema = z.object({
   failOnAutoCommit: z.boolean().optional(),
   /** Optional org-policy guardrails (path blocklist, per-issue cost cap, mandatory reviewers). */
   policy: z.lazy(() => PolicySchema).optional(),
+  /** Hours of engineer time saved when this pipeline merges a PR.
+   *  Overrides costs.timeSavedPerPrDefault for this specific pipeline. */
+  timeSavedPerPr: z.number().positive().optional(),
 });
 export type PipelineConfig = z.infer<typeof PipelineConfigSchema>;
 
@@ -419,6 +422,24 @@ export const AuditEventSchema = z.object({
 });
 export type AuditEvent = z.infer<typeof AuditEventSchema>;
 
+// --- Cost / ROI ---
+export const ModelPricingSchema = z.object({
+  inputPerMillion: z.number().positive(),
+  outputPerMillion: z.number().positive(),
+});
+export type ModelPricing = z.infer<typeof ModelPricingSchema>;
+
+export const CostsConfigSchema = z.object({
+  modelPricing: z.record(z.string(), ModelPricingSchema).default({
+    "claude-opus-4-6":   { inputPerMillion: 15, outputPerMillion: 75 },
+    "claude-sonnet-4-6": { inputPerMillion:  3, outputPerMillion: 15 },
+    "claude-haiku-4-5":  { inputPerMillion:  1, outputPerMillion:  5 },
+  }),
+  hourlyEngRate: z.number().positive().default(50),
+  timeSavedPerPrDefault: z.number().positive().default(4),
+});
+export type CostsConfig = z.infer<typeof CostsConfigSchema>;
+
 /**
  * Top-level application config schema. Currently only scopes the audit log
  * section introduced with the audit-log feature; additional sections can be
@@ -443,5 +464,6 @@ export const AppConfigSchema = z.object({
     retentionDays: z.number().int().positive().optional().default(365),
   }).optional(),
   sso: SsoConfigSchema.optional(),
+  costs: CostsConfigSchema.optional(),
 });
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/dashboard/src/__tests__/cost.test.ts
+++ b/packages/dashboard/src/__tests__/cost.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { createDashboard } from "../server.js";
+import { createDb } from "@urateam/core";
+import type { Db } from "@urateam/core";
+import { pipelineRuns, stageRuns } from "@urateam/core/dist/db/schema.js";
+import { _resetLicenseCache } from "@urateam/core/dist/license.js";
+
+// ---------------- license test helper (inlined from audit.test.ts) ----------------
+function b64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(privateKey: KeyObject, payload: object): string {
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const headerB64 = b64url(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = sign(null, Buffer.from(signingInput), privateKey);
+  return `${signingInput}.${b64url(sig)}`;
+}
+
+let savedPublicKey: string | undefined;
+let savedEnv: string | undefined;
+
+async function installEnterpriseLicense(): Promise<void> {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyB64 = Buffer.from(
+    publicKey.export({ format: "der", type: "spki" }),
+  ).toString("base64");
+
+  const mod = await import("@urateam/core/dist/license-public-key.js");
+  if (savedPublicKey === undefined) {
+    savedPublicKey = (mod as { LICENSE_PUBLIC_KEY_DER_B64: string })
+      .LICENSE_PUBLIC_KEY_DER_B64;
+  }
+  Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+    value: publicKeyB64,
+    writable: true,
+    configurable: true,
+  });
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = makeJwt(privateKey, {
+    iss: "urateam.dev",
+    sub: "cust_test",
+    tier: "enterprise",
+    seats: 25,
+    iat: now,
+    exp: now + 86_400,
+  });
+
+  if (savedEnv === undefined) savedEnv = process.env.URATEAM_LICENSE_KEY;
+  process.env.URATEAM_LICENSE_KEY = jwt;
+  _resetLicenseCache();
+}
+
+async function restoreLicense(): Promise<void> {
+  if (savedPublicKey !== undefined) {
+    const mod = await import("@urateam/core/dist/license-public-key.js");
+    Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+      value: savedPublicKey,
+      writable: true,
+      configurable: true,
+    });
+    savedPublicKey = undefined;
+  }
+  if (savedEnv === undefined) {
+    delete process.env.URATEAM_LICENSE_KEY;
+  } else {
+    process.env.URATEAM_LICENSE_KEY = savedEnv;
+    savedEnv = undefined;
+  }
+  _resetLicenseCache();
+}
+
+function basicAuthHeader(u: string, p: string): string {
+  return "Basic " + Buffer.from(`${u}:${p}`).toString("base64");
+}
+
+const AUTH = { Authorization: basicAuthHeader("admin", "secret") };
+
+const testCosts = {
+  modelPricing: {
+    "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+  },
+  hourlyEngRate: 50,
+  timeSavedPerPrDefault: 4,
+};
+
+const testPipelineConfigs: Record<string, any> = {
+  "quick-fix": { profile: { model: "claude-sonnet-4-6" } },
+};
+
+async function seedCompletedRun(db: Db): Promise<void> {
+  const now = new Date();
+  const started = new Date(now.getTime() - 60_000);
+  await (db as any).insert(pipelineRuns).values({
+    id: "run-cost-1",
+    issueId: "BEC-1",
+    issueTitle: "seed",
+    pipelineKey: "quick-fix",
+    repoUrl: "https://github.com/acme/api",
+    status: "completed",
+    startedAt: started,
+    completedAt: now,
+    linearTeamId: "T1",
+  });
+  await (db as any).insert(stageRuns).values({
+    id: "stage-cost-1",
+    pipelineRunId: "run-cost-1",
+    stage: "implement",
+    status: "completed",
+    startedAt: started,
+    completedAt: now,
+    inputTokens: 100_000,
+    outputTokens: 50_000,
+  });
+}
+
+// ---------------- tests ----------------
+describe("cost route — unlicensed", () => {
+  beforeEach(async () => {
+    await restoreLicense();
+  });
+
+  it("returns 404 for GET /cost when feature is not licensed", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const app = createDashboard({
+      db,
+      pipelineConfigs: testPipelineConfigs,
+      repoConfigs: {},
+      costs: testCosts,
+      auth: { username: "admin", password: "secret" },
+    });
+    const res = await app.request("/cost", { headers: AUTH });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for GET /cost/page when feature is not licensed", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const app = createDashboard({
+      db,
+      pipelineConfigs: testPipelineConfigs,
+      repoConfigs: {},
+      costs: testCosts,
+      auth: { username: "admin", password: "secret" },
+    });
+    const res = await app.request("/cost/page", { headers: AUTH });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for GET /cost/export.csv when feature is not licensed", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const app = createDashboard({
+      db,
+      pipelineConfigs: testPipelineConfigs,
+      repoConfigs: {},
+      costs: testCosts,
+      auth: { username: "admin", password: "secret" },
+    });
+    const res = await app.request("/cost/export.csv", { headers: AUTH });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("cost route — licensed (enterprise)", () => {
+  beforeEach(async () => {
+    await installEnterpriseLicense();
+  });
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("GET /cost returns 200 and renders summary with seeded run", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await seedCompletedRun(db);
+
+    const app = createDashboard({
+      db,
+      pipelineConfigs: testPipelineConfigs,
+      repoConfigs: {},
+      costs: testCosts,
+      auth: { username: "admin", password: "secret" },
+    });
+
+    const res = await app.request("/cost", { headers: AUTH });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("PRs merged");
+    expect(html).toContain("quick-fix");
+    expect(html).toMatch(/\$\d/);
+    expect(html).toContain("Cost");
+  });
+
+  it("GET /cost/export.csv returns 200 text/csv with header row and disposition", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await seedCompletedRun(db);
+
+    const app = createDashboard({
+      db,
+      pipelineConfigs: testPipelineConfigs,
+      repoConfigs: {},
+      costs: testCosts,
+      auth: { username: "admin", password: "secret" },
+    });
+
+    const res = await app.request("/cost/export.csv", { headers: AUTH });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/csv");
+    const disposition = res.headers.get("content-disposition") ?? "";
+    expect(disposition).toMatch(/attachment; filename="cost-\d{4}-\d{2}-\d{2}-\d{4}-\d{2}-\d{2}\.csv"/);
+
+    const body = await res.text();
+    expect(body).toContain(
+      "completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours",
+    );
+    expect(body).toContain("run-cost-1");
+  });
+});

--- a/packages/dashboard/src/routes/cost.ts
+++ b/packages/dashboard/src/routes/cost.ts
@@ -1,0 +1,115 @@
+import { Hono } from "hono";
+import type { Db, CostsConfig, PipelineConfig } from "@urateam/core";
+import { isFeatureLicensed, aggregateAll, streamCostCsv } from "@urateam/core";
+import { layout } from "../views/layout.js";
+import { renderCostPage } from "../views/cost.js";
+
+export interface CostRouterDeps {
+  db: Db;
+  costs?: CostsConfig;
+  pipelineConfigs?: Record<string, PipelineConfig>;
+  basePath?: string;
+}
+
+function parseWindow(url: URL): { from: Date; to: Date; preset: string } {
+  const preset = url.searchParams.get("window") ?? "30d";
+  const now = new Date();
+  let from: Date;
+  let to: Date = now;
+  if (preset === "custom") {
+    const fromStr = url.searchParams.get("from");
+    const toStr = url.searchParams.get("to");
+    from = fromStr ? new Date(fromStr) : new Date(now.getTime() - 30 * 86_400_000);
+    to = toStr ? new Date(toStr) : now;
+    if (isNaN(from.getTime())) from = new Date(now.getTime() - 30 * 86_400_000);
+    if (isNaN(to.getTime())) to = now;
+  } else {
+    const days = preset === "7d" ? 7 : preset === "90d" ? 90 : preset === "365d" ? 365 : 30;
+    from = new Date(now.getTime() - days * 86_400_000);
+  }
+  return { from, to, preset };
+}
+
+export function createCostRouter(deps: CostRouterDeps): Hono {
+  const router = new Hono();
+  const basePath = deps.basePath ?? "";
+  const costs = deps.costs ?? {
+    modelPricing: {},
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  };
+  const pipelineConfigs = deps.pipelineConfigs ?? {};
+
+  // Gate every cost route behind the license feature flag.
+  router.use("/cost", async (c, next) => {
+    if (!isFeatureLicensed("cost-roi")) return c.notFound();
+    await next();
+  });
+  router.use("/cost/*", async (c, next) => {
+    if (!isFeatureLicensed("cost-roi")) return c.notFound();
+    await next();
+  });
+
+  router.get("/cost", async (c) => {
+    const url = new URL(c.req.url);
+    const filters = parseWindow(url);
+    const result = await aggregateAll(
+      deps.db as any,
+      { from: filters.from, to: filters.to },
+      { costs, pipelineConfigs },
+    );
+    const content = renderCostPage({ result, filters, costs, basePath });
+    if (c.req.header("HX-Request")) return c.html(content);
+    return c.html(layout("Cost & ROI", content, basePath));
+  });
+
+  router.get("/cost/page", async (c) => {
+    const url = new URL(c.req.url);
+    const filters = parseWindow(url);
+    const result = await aggregateAll(
+      deps.db as any,
+      { from: filters.from, to: filters.to },
+      { costs, pipelineConfigs },
+    );
+    return c.html(renderCostPage({ result, filters, costs, basePath, partial: true }));
+  });
+
+  router.get("/cost/export.csv", async (c) => {
+    const url = new URL(c.req.url);
+    const { from, to } = parseWindow(url);
+
+    const iter = streamCostCsv(
+      deps.db as any,
+      { from, to },
+      { costs, pipelineConfigs },
+    )[Symbol.asyncIterator]();
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const { value, done } = await iter.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(value));
+      },
+      async cancel() {
+        if (typeof iter.return === "function") await iter.return();
+      },
+    });
+
+    const fromStr = from.toISOString().slice(0, 10);
+    const toStr = to.toISOString().slice(0, 10);
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="cost-${fromStr}-${toStr}.csv"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  });
+
+  return router;
+}

--- a/packages/dashboard/src/routes/cost.ts
+++ b/packages/dashboard/src/routes/cost.ts
@@ -15,12 +15,16 @@ function parseWindow(url: URL): { from: Date; to: Date; preset: string } {
   const preset = url.searchParams.get("window") ?? "30d";
   const now = new Date();
   let from: Date;
-  let to: Date = now;
+  // Half-open interval [from, to) — add 1s to "now" so runs completing at the
+  // current second are still included in the window. SQLite stores timestamps
+  // as epoch seconds (integer), so a 1ms buffer would still floor to the same
+  // second and exclude runs that completed within the current second.
+  let to: Date = new Date(now.getTime() + 1000);
   if (preset === "custom") {
     const fromStr = url.searchParams.get("from");
     const toStr = url.searchParams.get("to");
     from = fromStr ? new Date(fromStr) : new Date(now.getTime() - 30 * 86_400_000);
-    to = toStr ? new Date(toStr) : now;
+    to = toStr ? new Date(toStr) : new Date(now.getTime() + 1000);
     if (isNaN(from.getTime())) from = new Date(now.getTime() - 30 * 86_400_000);
     if (isNaN(to.getTime())) to = now;
   } else {

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -8,6 +8,7 @@ import type {
   RepoConfig,
   SsoConfig,
   WorkosClient,
+  CostsConfig,
 } from "@urateam/core";
 import { createRunsRouter } from "./routes/runs.js";
 import { createTokensRouter } from "./routes/tokens.js";
@@ -17,6 +18,7 @@ import { createCoordinationRouter } from "./routes/coordination.js";
 import { createAuditRouter } from "./routes/audit.js";
 import { createAuthRouter } from "./routes/auth.js";
 import { createSsoMiddleware } from "./middleware/sso.js";
+import { createCostRouter } from "./routes/cost.js";
 
 const logger = createLogger({ component: "dashboard" });
 
@@ -24,6 +26,8 @@ export interface DashboardConfig {
   db: Db;
   pipelineConfigs: Record<string, PipelineConfig>;
   repoConfigs: Record<string, RepoConfig>;
+  /** Optional costs config for the Cost & ROI dashboard (enterprise). */
+  costs?: CostsConfig;
   auth?: { username: string; password: string };
   /**
    * Optional SSO configuration. When the `sso` feature is licensed AND
@@ -217,6 +221,14 @@ export function createDashboard(config: DashboardConfig): Hono {
 
   const auditRouter = createAuditRouter(config.db, basePath);
   app.route("/", auditRouter);
+
+  const costRouter = createCostRouter({
+    db: config.db,
+    costs: config.costs,
+    pipelineConfigs: config.pipelineConfigs,
+    basePath,
+  });
+  app.route("/", costRouter);
 
   return app;
 }

--- a/packages/dashboard/src/views/cost.ts
+++ b/packages/dashboard/src/views/cost.ts
@@ -1,0 +1,165 @@
+import type { AggregateResult, BreakdownRow, CostsConfig } from "@urateam/core";
+import { escapeHtml } from "./layout.js";
+
+export interface CostFilters {
+  from: Date;
+  to: Date;
+  preset: string;
+}
+
+export interface RenderCostPageArgs {
+  result: AggregateResult;
+  filters: CostFilters;
+  costs: CostsConfig;
+  basePath?: string;
+  /** When true, render only the body (HTMX partial). */
+  partial?: boolean;
+}
+
+function fmtNumber(n: number): string {
+  if (!isFinite(n)) return "∞";
+  return n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+}
+
+function fmtHours(n: number): string {
+  if (!isFinite(n)) return "∞";
+  return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+}
+
+function fmtDollars(n: number): string {
+  if (!isFinite(n)) return "∞";
+  return "$" + n.toFixed(2);
+}
+
+function fmtRoi(n: number): string {
+  if (!isFinite(n)) return "∞";
+  return n.toFixed(1) + "×";
+}
+
+function renderBreakdownTable(title: string, rows: BreakdownRow[]): string {
+  const body =
+    rows.length === 0
+      ? '<tr><td colspan="7" style="text-align:center;color:#999;padding:1rem;">No data</td></tr>'
+      : rows
+          .map(
+            (r) => `<tr>
+            <td>${escapeHtml(r.label)}</td>
+            <td>${fmtNumber(r.runs)}</td>
+            <td>${fmtNumber(r.prsMerged)}</td>
+            <td>${fmtHours(r.timeSavedHours)}</td>
+            <td>${fmtNumber(r.inputTokens + r.outputTokens)}</td>
+            <td>${fmtDollars(r.dollars)}</td>
+            <td>${fmtRoi(r.roiMultiplier)}</td>
+          </tr>`,
+          )
+          .join("\n");
+
+  return `<h3>${escapeHtml(title)}</h3>
+    <div class="table-wrapper">
+      <table class="cost-breakdown">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Runs</th>
+            <th>PRs merged</th>
+            <th>Hours saved</th>
+            <th>Tokens</th>
+            <th>Cost</th>
+            <th>ROI</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${body}
+        </tbody>
+      </table>
+    </div>`;
+}
+
+function buildExportHref(
+  basePath: string,
+  filters: CostFilters,
+): string {
+  const from = filters.from.toISOString().slice(0, 10);
+  const to = filters.to.toISOString().slice(0, 10);
+  const params = new URLSearchParams({
+    window: filters.preset,
+    from,
+    to,
+  });
+  return `${basePath}/cost/export.csv?${params.toString()}`;
+}
+
+/**
+ * Render the cost & ROI page. When `partial` is true, emits only the body
+ * (summary + tables) so HTMX can swap it into #cost-body.
+ */
+export function renderCostPage(args: RenderCostPageArgs): string {
+  const { result, filters, costs, partial } = args;
+  const basePath = args.basePath ?? "";
+  const { summary, byTeam, byRepo, byPipeline } = result;
+  const hourlyRate = costs.hourlyEngRate ?? 50;
+  const value = summary.timeSavedHours * hourlyRate;
+
+  const bodyInner = `<div class="summary-card">
+      <p><strong>${fmtNumber(summary.prsMerged)} PRs merged</strong>
+         &middot; <strong>${fmtHours(summary.timeSavedHours)}h saved</strong>
+         &middot; <strong>${fmtNumber(summary.runs)} runs</strong></p>
+      <p>${fmtNumber(summary.inputTokens + summary.outputTokens)} tokens
+         &middot; ${fmtDollars(summary.dollars)} cost</p>
+      <p><strong>ROI:</strong> ${fmtHours(summary.timeSavedHours)}h &times; ${fmtDollars(hourlyRate)}/h
+         = ${fmtDollars(value)} value &divide; ${fmtDollars(summary.dollars)} cost
+         = ${fmtRoi(summary.roiMultiplier)}</p>
+    </div>
+    ${renderBreakdownTable("By team", byTeam)}
+    ${renderBreakdownTable("By repo", byRepo)}
+    ${renderBreakdownTable("By pipeline", byPipeline)}
+    <details class="cost-formula">
+      <summary>Formula</summary>
+      <p>Time saved per PR is ${fmtNumber(costs.timeSavedPerPrDefault ?? 4)}h by default, overridable per pipeline via <code>timeSavedPerPr</code>.</p>
+      <p>Dollar cost is computed per-stage from each stage's model:</p>
+      <ul>
+        ${Object.entries(costs.modelPricing ?? {})
+          .map(
+            ([model, rate]) =>
+              `<li><code>${escapeHtml(model)}</code>: $${escapeHtml(String(rate.inputPerMillion))}/M input, $${escapeHtml(String(rate.outputPerMillion))}/M output</li>`,
+          )
+          .join("")}
+      </ul>
+      <p>Hourly engineer rate (for ROI): ${fmtDollars(hourlyRate)}</p>
+      <p>ROI = (hours saved &times; hourly rate) &divide; dollar cost</p>
+    </details>`;
+
+  if (partial) {
+    return bodyInner;
+  }
+
+  const exportHref = buildExportHref(basePath, filters);
+  const opt = (val: string, label: string) =>
+    `<option value="${val}"${filters.preset === val ? " selected" : ""}>${escapeHtml(label)}</option>`;
+
+  return `<div id="cost">
+    <form method="get" action="${basePath}/cost" class="cost-filters"
+          hx-get="${basePath}/cost/page" hx-trigger="change" hx-target="#cost-body">
+      <label>Window
+        <select name="window">
+          ${opt("7d", "Last 7 days")}
+          ${opt("30d", "Last 30 days")}
+          ${opt("90d", "Last 90 days")}
+          ${opt("365d", "Last 365 days")}
+          ${opt("custom", "Custom")}
+        </select>
+      </label>
+      ${
+        filters.preset === "custom"
+          ? `<input type="date" name="from" value="${escapeHtml(filters.from.toISOString().slice(0, 10))}">
+             <input type="date" name="to" value="${escapeHtml(filters.to.toISOString().slice(0, 10))}">`
+          : ""
+      }
+      <button type="submit">Apply</button>
+      <a class="btn" href="${escapeHtml(exportHref)}">Export CSV</a>
+    </form>
+    <div id="cost-body">
+      ${bodyInner}
+    </div>
+  </div>`;
+}

--- a/packages/dashboard/src/views/cost.ts
+++ b/packages/dashboard/src/views/cost.ts
@@ -100,7 +100,8 @@ export function renderCostPage(args: RenderCostPageArgs): string {
   const hourlyRate = costs.hourlyEngRate ?? 50;
   const value = summary.timeSavedHours * hourlyRate;
 
-  const bodyInner = `<div class="summary-card">
+  const bodyInner = `${summary.truncated ? `<div class="warning-banner">⚠ Window exceeds 10,000 runs. Results truncated to the 10,000 most recent. Narrow your date range for complete totals.</div>` : ""}
+    <div class="summary-card">
       <p><strong>${fmtNumber(summary.prsMerged)} PRs merged</strong>
          &middot; <strong>${fmtHours(summary.timeSavedHours)}h saved</strong>
          &middot; <strong>${fmtNumber(summary.runs)} runs</strong></p>

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -87,6 +87,7 @@ export function layout(
     <a href="${bp}/tokens">Tokens</a>
     <a href="${bp}/errors">Errors</a>
     <a href="${bp}/audit">Audit</a>
+    <a href="${bp}/cost">Cost</a>
     <a href="${bp}/config">Config</a>
     <a href="${bp}/coordination">Coordination</a>
     ${signOut}


### PR DESCRIPTION
## Summary
- New `/cost` dashboard page: summary card + three breakdown tables (by team, repo, pipeline) + date-range picker + CSV export
- Per-run cost computed at read time from `stage_runs` tokens × configurable model-pricing table — no schema change on run tables
- Time saved = count(completed PRs) × `timeSavedPerPr` (default 4h, per-pipeline override)
- ROI = (timeSavedHours × hourlyEngRate) / dollars, $50/hr default, configurable
- New `cost_rollups_daily` table rebuilt nightly in PM tick; v1 dashboard still live-aggregates (rollup consumption in v2)
- Formula footer shows every rate used so operator can screenshot for CFO audit
- License-gated by `isFeatureLicensed(\"cost-roi\")`

Spec: docs/superpowers/specs/2026-04-15-cost-roi-dashboard-design.md
Plan: docs/superpowers/plans/2026-04-15-cost-roi-dashboard.md

## Test plan
- [x] pnpm build — clean
- [x] Core cost suite — 35 tests passing (rates, per-run, aggregate, rollup, csv, integration, license, pm step)
- [x] Dashboard suite — 149 tests passing
- [x] Holistic review — 3 high findings, all fixed inline: nullable team-id composite UNIQUE, day-boundary half-open interval, 10k row cap + truncated flag on aggregateAll
- [ ] Manual: seeded deployment, open /cost, verify totals
- [ ] Manual: CSV export downloads + opens in spreadsheet, formula injection neutralized

## Deferred
- Rollup-backed read path for preset windows (v2)
- Historical rollup backfill older than first PM tick
- Charts / sparklines / trendlines / multi-currency
- Per-issue breakdown (re-sort of run list, no aggregation value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)