### PR TITLE
feat: rbac / multi-user (enterprise 4.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,20 @@ It is a pnpm monorepo with 3 packages:
 - **10k run cap on `aggregateAll`**: when exceeded, results are truncated to the 10k most recent and `summary.truncated = true`; dashboard shows a warning banner
 - Preset windows (7d/30d/90d/365d) currently go through `aggregateAll` live; `readRollupWindow` exists but is deferred to v2 for rollup-backed reads
 
+### RBAC / multi-user (Enterprise feature 4.4)
+- Module: `packages/core/src/rbac/` — `matrix.ts` (PERMISSION_MATRIX + canAccess), `user-role-store.ts` (setUserRole, getUserRole, listUsers, applyBootstrapAdmins), `errors.ts` (SelfDemoteError, LastAdminError)
+- Schema: added `role TEXT NOT NULL DEFAULT 'viewer'` to `dashboard_users` via MIGRATION_COLUMNS
+- Three roles: `admin`, `operator`, `viewer`. Global-only in v1 — scoped roles (per team/repo) deferred to v2 via a new `user_scope_roles` table
+- Middleware: `packages/dashboard/src/middleware/rbac.ts` — `requirePermission(action)` decorates routes, returns 403 on insufficient role, no-op when feature unlicensed
+- **`getUserById` MUST include `role`** — the SSO middleware reads it from the returned `DashboardUser` and the RBAC middleware reads `user.role`. Dropping it silently makes every user 403
+- Bootstrap: `URATEAM_ADMIN_EMAILS` env var — comma-separated list, case-insensitive. Fire-and-forget from `/auth/callback` via `applyBootstrapAdmins`
+- Admin UI: `/users` dashboard page (admin-only) with role dropdown per user. CSRF via `HX-Request` header
+- CLI: `ura admin list/grant/revoke` — for emergency recovery and scripted management
+- Audit: four `dashboard.manual_action` subtypes — `grant_role`, `revoke_role`, `bootstrap_admin`, `retry_run`. No new `AuditEventTypeSchema` entries
+- Write actions in v1: only `POST /runs/:id/retry` (operator+admin, license-gated to 404 when unlicensed). Others (abort, approve, cancel) deferred
+- Guardrails: `setUserRole` wraps SELECT+COUNT+UPDATE in a transaction (SQLite `BEGIN IMMEDIATE`; Postgres `db.transaction()`) to prevent the TOCTOU race on last-admin demotion
+- Setup doc: `deploy/RBAC_SETUP.md`
+
 ### Coordination (`packages/core/src/pm/coordination.ts`)
 - DB-backed `active_work` table tracks files modified by in-flight pipeline runs
 - `upsertActiveWork` uses atomic `onConflictDoUpdate` (requires UNIQUE on `run_id`)

--- a/deploy/RBAC_SETUP.md
+++ b/deploy/RBAC_SETUP.md
@@ -1,0 +1,57 @@
+# RBAC setup (Enterprise)
+
+urateam supports three dashboard roles:
+- **admin** — full access, including /config and /users
+- **operator** — full read access, can retry failed runs
+- **viewer** — read-only access to /runs, /tokens, /errors
+
+RBAC is gated by the `rbac` feature flag and requires the SSO feature (4.1).
+
+## Prerequisites
+- Enterprise license with `rbac` feature enabled
+- SSO configured (see `deploy/SSO_SETUP.md`)
+
+## Bootstrapping the first admin
+
+Set `URATEAM_ADMIN_EMAILS` (comma-separated, case-insensitive) before starting urateam:
+```
+URATEAM_ADMIN_EMAILS=alice@acme.com,bob@acme.com
+```
+
+When alice or bob logs in via SSO, their role is automatically promoted to `admin`. All other users default to `viewer`.
+
+The env var can be safely removed after initial setup — existing admins keep their role.
+
+## Managing roles
+
+### Via dashboard
+Admins see a "Users" nav entry. Go to `/users` to list users and change roles via the dropdown.
+
+### Via CLI
+On the host:
+```
+ura admin list
+ura admin grant <email> --role operator
+ura admin revoke <email>
+```
+
+`revoke` sets the role to `viewer` — the minimum privilege, not deletion.
+
+## Emergency recovery
+
+If the dashboard UI is broken or the last admin is locked out, use the CLI:
+```
+ura admin grant recovery@acme.com --role admin
+```
+
+## Guardrails
+
+- Admins cannot demote themselves (self-lockout protection)
+- The last remaining admin cannot be demoted (last-admin protection)
+- Every role change writes a `dashboard.manual_action` audit event
+
+## Troubleshooting
+
+- **"RBAC is an Enterprise feature"** → your license does not include the `rbac` flag. Upgrade or contact sales.
+- **Admin promotion didn't happen on first login** → check `URATEAM_ADMIN_EMAILS` is set and the email matches exactly (case-insensitive). Check logs for audit events.
+- **"403 Forbidden" on a route you should have access to** → check your assigned role via `ura admin list`. If the role is wrong, an admin needs to update it.

--- a/docs/superpowers/plans/2026-04-15-rbac.md
+++ b/docs/superpowers/plans/2026-04-15-rbac.md
@@ -1,0 +1,2064 @@
+# RBAC / multi-user Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship enterprise feature 4.4 — global role model (admin/operator/viewer), permission matrix, dashboard `/users` admin UI, `ura admin` CLI, and a manual retry endpoint gated by the operator role — per `docs/superpowers/specs/2026-04-15-rbac-design.md`.
+
+**Architecture:** One new `role` column on the existing `dashboard_users` table (from SSO feature 4.1) via the `MIGRATION_COLUMNS` mechanism. New `packages/core/src/rbac/` module owns the permission matrix, role store, and bootstrap logic as pure functions. Dashboard middleware `requirePermission(action)` decorates existing routes and returns 403 when the role is insufficient. License-gated by `isFeatureLicensed("rbac")` — when off, the middleware is a no-op and all new surfaces 404.
+
+**Tech Stack:** TypeScript, Drizzle ORM, Hono+HTMX, Vitest, Zod, pino.
+
+---
+
+## File Structure
+
+### New files
+- `packages/core/src/rbac/index.ts` — barrel
+- `packages/core/src/rbac/types.ts` — `Role`, `PermissionKey` types
+- `packages/core/src/rbac/matrix.ts` — `PERMISSION_MATRIX` constant + `canAccess`
+- `packages/core/src/rbac/user-role-store.ts` — `setUserRole`, `getUserRole`, `listUsers`, `applyBootstrapAdmins`
+- `packages/core/src/rbac/errors.ts` — `SelfDemoteError`, `LastAdminError`
+- `packages/core/src/__tests__/rbac/matrix.test.ts`
+- `packages/core/src/__tests__/rbac/user-role-store.test.ts`
+- `packages/core/src/__tests__/rbac/bootstrap.test.ts`
+- `packages/core/src/__tests__/rbac-integration.test.ts`
+- `packages/dashboard/src/middleware/rbac.ts` — `requirePermission` factory
+- `packages/dashboard/src/routes/users.ts` — `GET /users`, `POST /users/:id/role`
+- `packages/dashboard/src/views/users.ts` — user list page
+- `packages/dashboard/src/views/forbidden.ts` — 403 page
+- `packages/dashboard/src/__tests__/rbac-middleware.test.ts`
+- `packages/dashboard/src/__tests__/users-routes.test.ts`
+- `packages/dashboard/src/__tests__/retry-route.test.ts`
+- `packages/cli/src/commands/admin.ts` — list / grant / revoke
+- `packages/cli/src/__tests__/admin-commands.test.ts`
+- `deploy/RBAC_SETUP.md`
+
+### Modified files
+- `packages/core/src/db/schema.ts` — add `role` column to `dashboardUsers`
+- `packages/core/src/db/client.ts` — add `role` entry to `MIGRATION_COLUMNS`, extend `getCreateTablesDDL()`
+- `packages/core/src/license.ts` — add `"rbac"` to Enterprise feature set
+- `packages/core/src/index.ts` — re-export `./rbac/index.js`
+- `packages/core/src/audit/events.ts` — add `dashboardGrantRoleEvent`, `dashboardRevokeRoleEvent`, `dashboardBootstrapAdminEvent`, `dashboardRetryRunEvent` builders
+- `packages/core/src/auth/user-store.ts` (from SSO) — `upsertUser` respects existing role on update (doesn't reset to default)
+- `packages/dashboard/src/routes/auth.ts` — call `applyBootstrapAdmins` after `upsertUser` in the callback
+- `packages/dashboard/src/routes/runs.ts` — new `POST /runs/:id/retry` route, mount with middleware
+- `packages/dashboard/src/views/run-detail.ts` — show Retry button when licensed + role permits + run status permits
+- `packages/dashboard/src/views/layout.ts` — show "Users" nav entry when user is admin
+- `packages/dashboard/src/server.ts` — decorate existing route mounts with `requirePermission`
+- `packages/cli/src/index.ts` — register the `admin` command
+- `CLAUDE.md` — new "RBAC / multi-user" section
+
+---
+
+## Task 1: Schema — `role` column on `dashboard_users`
+
+**Files:**
+- Modify: `packages/core/src/db/schema.ts`
+- Modify: `packages/core/src/db/client.ts` (`MIGRATION_COLUMNS` + `getCreateTablesDDL`)
+- Test: `packages/core/src/__tests__/db-rbac-schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { dashboardUsers } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("dashboard_users.role column", () => {
+  it("includes role in the table schema with default 'viewer'", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const cols = (db as any).all(sql`PRAGMA table_info(dashboard_users)`) as Array<{name: string}>;
+    expect(cols.map(c => c.name).sort()).toContain("role");
+  });
+
+  it("defaults new rows to 'viewer'", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_1", email: "a@b.com", name: "A B", workosUserId: "wu_1",
+    });
+    const rows = await (db as any).select().from(dashboardUsers);
+    expect(rows[0].role).toBe("viewer");
+  });
+
+  it("accepts explicit role values", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_admin", email: "admin@b.com", name: null, workosUserId: null, role: "admin",
+    });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_op", email: "op@b.com", name: null, workosUserId: null, role: "operator",
+    });
+    const rows = await (db as any).select().from(dashboardUsers);
+    const roles = rows.map((r: any) => r.role).sort();
+    expect(roles).toEqual(["admin", "operator"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-rbac-schema.test.ts
+```
+Expected: FAIL with "role column missing".
+
+- [ ] **Step 3: Add the column to `dashboardUsers` in `db/schema.ts`**
+
+Find the `dashboardUsers` declaration and add before the closing `});`:
+```ts
+  role: text("role").notNull().default("viewer"),
+```
+
+- [ ] **Step 4: Add a `MIGRATION_COLUMNS` entry in `db/client.ts`**
+
+Find `MIGRATION_COLUMNS` and append:
+```ts
+// Feature 4.4: RBAC
+{
+  table: "dashboard_users",
+  column: "role",
+  sqliteType: "TEXT NOT NULL DEFAULT 'viewer'",
+  pgType: "TEXT NOT NULL DEFAULT 'viewer'",
+},
+```
+
+- [ ] **Step 5: Extend `getCreateTablesDDL()` template**
+
+Find the `CREATE TABLE IF NOT EXISTS dashboard_users (...)` block in `getCreateTablesDDL()` and add before the closing `)`:
+```sql
+    role TEXT NOT NULL DEFAULT 'viewer',
+```
+
+(Place it on the last line inside the parens, after `last_login_at`. Match the existing comma placement style.)
+
+- [ ] **Step 6: Run the test, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/db-rbac-schema.test.ts
+```
+Expected: PASS (3/3).
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/core/src/db/schema.ts packages/core/src/db/client.ts packages/core/src/__tests__/db-rbac-schema.test.ts
+git commit -m "feat(rbac): add role column to dashboard_users"
+```
+
+---
+
+## Task 2: RBAC types and permission matrix
+
+**Files:**
+- Create: `packages/core/src/rbac/types.ts`
+- Create: `packages/core/src/rbac/matrix.ts`
+- Create: `packages/core/src/rbac/index.ts`
+- Test: `packages/core/src/__tests__/rbac/matrix.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { canAccess, PERMISSION_MATRIX } from "../../rbac/matrix.js";
+import type { PermissionKey } from "../../rbac/matrix.js";
+
+describe("PERMISSION_MATRIX", () => {
+  const cases: Array<[PermissionKey, "admin" | "operator" | "viewer", boolean]> = [
+    ["runs.view",         "admin",    true],
+    ["runs.view",         "operator", true],
+    ["runs.view",         "viewer",   true],
+    ["runs.retry",        "admin",    true],
+    ["runs.retry",        "operator", true],
+    ["runs.retry",        "viewer",   false],
+    ["tokens.view",       "admin",    true],
+    ["tokens.view",       "operator", true],
+    ["tokens.view",       "viewer",   true],
+    ["audit.view",        "admin",    true],
+    ["audit.view",        "operator", true],
+    ["audit.view",        "viewer",   false],
+    ["audit.export",      "viewer",   false],
+    ["cost.view",         "admin",    true],
+    ["cost.view",         "viewer",   false],
+    ["cost.export",       "admin",    true],
+    ["cost.export",       "viewer",   false],
+    ["errors.view",       "viewer",   true],
+    ["coordination.view", "operator", true],
+    ["coordination.view", "viewer",   false],
+    ["config.view",       "admin",    true],
+    ["config.view",       "operator", false],
+    ["config.view",       "viewer",   false],
+    ["users.view",        "admin",    true],
+    ["users.view",        "operator", false],
+    ["users.view",        "viewer",   false],
+    ["users.manage",      "admin",    true],
+    ["users.manage",      "operator", false],
+  ];
+
+  it.each(cases)("canAccess(%s, %s) === %s", (action, role, expected) => {
+    expect(canAccess(role, action)).toBe(expected);
+  });
+
+  it("admin has at least as many permissions as operator", () => {
+    const keys = Object.keys(PERMISSION_MATRIX) as PermissionKey[];
+    for (const k of keys) {
+      if (canAccess("operator", k)) expect(canAccess("admin", k)).toBe(true);
+    }
+  });
+
+  it("operator has at least as many permissions as viewer", () => {
+    const keys = Object.keys(PERMISSION_MATRIX) as PermissionKey[];
+    for (const k of keys) {
+      if (canAccess("viewer", k)) expect(canAccess("operator", k)).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/rbac/matrix.test.ts
+```
+
+- [ ] **Step 3: Create `rbac/types.ts`**
+
+```ts
+export type Role = "admin" | "operator" | "viewer";
+```
+
+- [ ] **Step 4: Create `rbac/matrix.ts`**
+
+```ts
+import type { Role } from "./types.js";
+
+export const PERMISSION_MATRIX = {
+  "runs.view":         ["admin", "operator", "viewer"],
+  "runs.retry":        ["admin", "operator"],
+  "tokens.view":       ["admin", "operator", "viewer"],
+  "audit.view":        ["admin", "operator"],
+  "audit.export":      ["admin", "operator"],
+  "cost.view":         ["admin", "operator"],
+  "cost.export":       ["admin", "operator"],
+  "errors.view":       ["admin", "operator", "viewer"],
+  "coordination.view": ["admin", "operator"],
+  "config.view":       ["admin"],
+  "users.view":        ["admin"],
+  "users.manage":      ["admin"],
+} as const satisfies Record<string, readonly Role[]>;
+
+export type PermissionKey = keyof typeof PERMISSION_MATRIX;
+
+export function canAccess(role: Role, action: PermissionKey): boolean {
+  return (PERMISSION_MATRIX[action] as readonly Role[]).includes(role);
+}
+```
+
+- [ ] **Step 5: Create `rbac/index.ts`**
+
+```ts
+export * from "./types.js";
+export * from "./matrix.js";
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/core/src/rbac packages/core/src/__tests__/rbac/matrix.test.ts
+git commit -m "feat(rbac): permission matrix and canAccess helper"
+```
+
+---
+
+## Task 3: User role store + errors
+
+**Files:**
+- Create: `packages/core/src/rbac/errors.ts`
+- Create: `packages/core/src/rbac/user-role-store.ts`
+- Modify: `packages/core/src/rbac/index.ts`
+- Test: `packages/core/src/__tests__/rbac/user-role-store.test.ts`
+
+**Note:** This task introduces audit event writes. The builder functions (`dashboardGrantRoleEvent` etc.) are added in Task 5; for now, the store's calls to `logAuditEvent` use inline event literals and will be cleaned up in Task 5. Alternatively, do Task 5 first and then Task 3 — pick based on reviewer preference. This plan does Task 3 first with inline literals, then Task 5 swaps them for builders.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { dashboardUsers, auditEvents } from "../../db/schema.js";
+import { setUserRole, getUserRole, listUsers } from "../../rbac/user-role-store.js";
+import { SelfDemoteError, LastAdminError } from "../../rbac/errors.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+  // Seed three users
+  await db.insert(dashboardUsers).values([
+    { id: "u_admin", email: "admin@b.com", name: "Admin", workosUserId: null, role: "admin" },
+    { id: "u_op",    email: "op@b.com",    name: "Op",    workosUserId: null, role: "operator" },
+    { id: "u_view",  email: "view@b.com",  name: "View",  workosUserId: null, role: "viewer" },
+  ]);
+});
+
+afterEach(async () => { await restoreLicense(); });
+
+describe("setUserRole", () => {
+  it("updates role and writes audit event", async () => {
+    await setUserRole(db, { userId: "u_view", newRole: "operator", actorUserId: "u_admin" });
+    expect(await getUserRole(db, "u_view")).toBe("operator");
+    const events = await db.select().from(auditEvents);
+    const grant = events.find((e: any) => e.eventType === "dashboard.manual_action");
+    expect(grant).toBeDefined();
+    const payload = JSON.parse(grant.payload);
+    expect(payload.action).toBe("grant_role");
+    expect(payload.targetUserId).toBe("u_view");
+    expect(payload.oldRole).toBe("viewer");
+    expect(payload.newRole).toBe("operator");
+  });
+
+  it("is idempotent — same role is a no-op, no audit event", async () => {
+    await setUserRole(db, { userId: "u_view", newRole: "viewer", actorUserId: "u_admin" });
+    const events = await db.select().from(auditEvents);
+    expect(events).toHaveLength(0);
+  });
+
+  it("prevents self-demote", async () => {
+    await expect(
+      setUserRole(db, { userId: "u_admin", newRole: "viewer", actorUserId: "u_admin" }),
+    ).rejects.toBeInstanceOf(SelfDemoteError);
+  });
+
+  it("prevents demoting the last admin", async () => {
+    await expect(
+      setUserRole(db, { userId: "u_admin", newRole: "viewer", actorUserId: "u_op" }),
+    ).rejects.toBeInstanceOf(LastAdminError);
+  });
+
+  it("allows demoting an admin when another admin exists", async () => {
+    await db.insert(dashboardUsers).values({
+      id: "u_admin2", email: "admin2@b.com", name: null, workosUserId: null, role: "admin",
+    });
+    await setUserRole(db, { userId: "u_admin", newRole: "viewer", actorUserId: "u_admin2" });
+    expect(await getUserRole(db, "u_admin")).toBe("viewer");
+  });
+
+  it("emits 'revoke_role' action for demotions to viewer", async () => {
+    await setUserRole(db, { userId: "u_op", newRole: "viewer", actorUserId: "u_admin" });
+    const events = await db.select().from(auditEvents);
+    const event = events.find((e: any) => e.eventType === "dashboard.manual_action");
+    const payload = JSON.parse(event.payload);
+    expect(payload.action).toBe("revoke_role");
+  });
+});
+
+describe("getUserRole", () => {
+  it("returns the role for a known user", async () => {
+    expect(await getUserRole(db, "u_op")).toBe("operator");
+  });
+
+  it("returns null for an unknown user", async () => {
+    expect(await getUserRole(db, "u_nope")).toBeNull();
+  });
+});
+
+describe("listUsers", () => {
+  it("returns all users sorted by email", async () => {
+    const users = await listUsers(db);
+    expect(users).toHaveLength(3);
+    expect(users.map(u => u.email)).toEqual(["admin@b.com", "op@b.com", "view@b.com"]);
+  });
+});
+```
+
+(Note: add `afterEach` import from vitest.)
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/core && npx vitest run src/__tests__/rbac/user-role-store.test.ts
+```
+
+- [ ] **Step 3: Create `rbac/errors.ts`**
+
+```ts
+export class SelfDemoteError extends Error {
+  constructor() { super("An admin cannot demote themselves"); this.name = "SelfDemoteError"; }
+}
+
+export class LastAdminError extends Error {
+  constructor() { super("Cannot demote the last remaining admin"); this.name = "LastAdminError"; }
+}
+```
+
+- [ ] **Step 4: Create `rbac/user-role-store.ts`**
+
+```ts
+import { and, eq, ne, count } from "drizzle-orm";
+import type { AnyDb } from "../db/client.js";
+import { dashboardUsers } from "../db/schema.js";
+import { logAuditEvent } from "../audit/index.js";
+import { randomUUID } from "node:crypto";
+import type { Role } from "./types.js";
+import { SelfDemoteError, LastAdminError } from "./errors.js";
+
+export interface SetUserRoleArgs {
+  userId: string;
+  newRole: Role;
+  actorUserId: string;
+  reason?: string;
+}
+
+export async function setUserRole(db: AnyDb, args: SetUserRoleArgs): Promise<void> {
+  const currentRows = await db.select().from(dashboardUsers).where(eq(dashboardUsers.id, args.userId));
+  if (currentRows.length === 0) throw new Error(`user not found: ${args.userId}`);
+  const current = currentRows[0] as { id: string; email: string; role: Role };
+  const oldRole = current.role;
+
+  // Idempotent no-op
+  if (oldRole === args.newRole) return;
+
+  // Self-lockout
+  if (args.userId === args.actorUserId && args.newRole !== "admin") {
+    throw new SelfDemoteError();
+  }
+
+  // Last-admin guard: if target is currently admin and we're demoting, count other admins
+  if (oldRole === "admin" && args.newRole !== "admin") {
+    const [row] = await db.select({ n: count() })
+      .from(dashboardUsers)
+      .where(and(eq(dashboardUsers.role, "admin"), ne(dashboardUsers.id, args.userId)));
+    const otherAdmins = Number((row as any)?.n ?? 0);
+    if (otherAdmins === 0) throw new LastAdminError();
+  }
+
+  await db.update(dashboardUsers)
+    .set({ role: args.newRole })
+    .where(eq(dashboardUsers.id, args.userId));
+
+  const isRevoke = args.newRole === "viewer";
+  void logAuditEvent(db, {
+    id: `evt_${randomUUID()}`,
+    timestamp: new Date(),
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorUserId}`,
+    actorType: "dashboard-user",
+    scope: null,
+    runId: null,
+    issueId: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    payload: {
+      action: isRevoke ? "revoke_role" : "grant_role",
+      targetUserId: args.userId,
+      targetEmail: current.email,
+      oldRole,
+      newRole: args.newRole,
+      actorUserId: args.actorUserId,
+      reason: args.reason,
+    },
+  });
+}
+
+export async function getUserRole(db: AnyDb, userId: string): Promise<Role | null> {
+  const rows = await db.select().from(dashboardUsers).where(eq(dashboardUsers.id, userId));
+  if (rows.length === 0) return null;
+  return (rows[0] as any).role as Role;
+}
+
+export async function listUsers(db: AnyDb): Promise<Array<{
+  id: string; email: string; name: string | null; role: Role; lastLoginAt: Date | null;
+}>> {
+  const rows = await db.select().from(dashboardUsers);
+  const mapped = rows.map((r: any) => ({
+    id: r.id, email: r.email, name: r.name ?? null,
+    role: r.role as Role, lastLoginAt: r.lastLoginAt ?? null,
+  }));
+  return mapped.sort((a, b) => a.email.localeCompare(b.email));
+}
+```
+
+- [ ] **Step 5: Update `rbac/index.ts`**
+
+```ts
+export * from "./types.js";
+export * from "./matrix.js";
+export * from "./errors.js";
+export * from "./user-role-store.js";
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/core/src/rbac/errors.ts packages/core/src/rbac/user-role-store.ts packages/core/src/rbac/index.ts packages/core/src/__tests__/rbac/user-role-store.test.ts
+git commit -m "feat(rbac): user role store with self-lockout and last-admin guards"
+```
+
+---
+
+## Task 4: Bootstrap admins from env var
+
+**Files:**
+- Modify: `packages/core/src/rbac/user-role-store.ts`
+- Test: `packages/core/src/__tests__/rbac/bootstrap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { dashboardUsers, auditEvents } from "../../db/schema.js";
+import { applyBootstrapAdmins, getUserRole } from "../../rbac/user-role-store.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values({
+    id: "u_1", email: "alice@acme.com", name: "Alice", workosUserId: null, role: "viewer",
+  });
+});
+
+afterEach(async () => { await restoreLicense(); });
+
+describe("applyBootstrapAdmins", () => {
+  it("promotes matching email to admin", async () => {
+    const changed = await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "alice@acme.com,bob@acme.com");
+    expect(changed).toBe(true);
+    expect(await getUserRole(db, "u_1")).toBe("admin");
+  });
+
+  it("is case-insensitive", async () => {
+    const changed = await applyBootstrapAdmins(db, "ALICE@ACME.COM", "u_1", "Alice@Acme.com");
+    expect(changed).toBe(true);
+    expect(await getUserRole(db, "u_1")).toBe("admin");
+  });
+
+  it("handles whitespace and empty entries in env list", async () => {
+    const changed = await applyBootstrapAdmins(db, "alice@acme.com", "u_1", " ,alice@acme.com , ");
+    expect(changed).toBe(true);
+  });
+
+  it("returns false when no list is configured", async () => {
+    expect(await applyBootstrapAdmins(db, "alice@acme.com", "u_1", undefined)).toBe(false);
+    expect(await getUserRole(db, "u_1")).toBe("viewer");
+  });
+
+  it("returns false when email does not match", async () => {
+    expect(await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "bob@acme.com")).toBe(false);
+    expect(await getUserRole(db, "u_1")).toBe("viewer");
+  });
+
+  it("is idempotent — already-admin is not re-promoted", async () => {
+    await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "alice@acme.com");
+    const before = (await db.select().from(auditEvents)).length;
+    const result = await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "alice@acme.com");
+    expect(result).toBe(false);
+    const after = (await db.select().from(auditEvents)).length;
+    expect(after).toBe(before);
+  });
+
+  it("writes a dashboard.manual_action event with action=bootstrap_admin", async () => {
+    await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "alice@acme.com");
+    const events = await db.select().from(auditEvents);
+    const bootstrap = events.find((e: any) => {
+      const p = JSON.parse(e.payload);
+      return e.eventType === "dashboard.manual_action" && p.action === "bootstrap_admin";
+    });
+    expect(bootstrap).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Add `applyBootstrapAdmins` to `rbac/user-role-store.ts`**
+
+Append to the file:
+```ts
+/**
+ * If the user's email matches `envAdminList` (comma-separated, case-insensitive),
+ * promote them to admin. Idempotent — already-admin users are not re-promoted
+ * and no audit event is written. Emits a `dashboard.manual_action` event with
+ * `action: "bootstrap_admin"` on successful promotion.
+ *
+ * Returns true if the role was changed.
+ */
+export async function applyBootstrapAdmins(
+  db: AnyDb,
+  email: string,
+  userId: string,
+  envAdminList: string | undefined,
+): Promise<boolean> {
+  if (!envAdminList || envAdminList.trim() === "") return false;
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const adminSet = new Set(
+    envAdminList
+      .split(",")
+      .map(s => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  if (!adminSet.has(normalizedEmail)) return false;
+
+  // Already admin? No-op.
+  const currentRole = await getUserRole(db, userId);
+  if (currentRole === "admin") return false;
+
+  // Promote. Bypass setUserRole because the actor is "system", not a user, and
+  // the self-demote guard doesn't apply.
+  await db.update(dashboardUsers)
+    .set({ role: "admin" as Role })
+    .where(eq(dashboardUsers.id, userId));
+
+  void logAuditEvent(db, {
+    id: `evt_${randomUUID()}`,
+    timestamp: new Date(),
+    eventType: "dashboard.manual_action",
+    actor: "system",
+    actorType: "system",
+    scope: null,
+    runId: null,
+    issueId: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    payload: {
+      action: "bootstrap_admin",
+      targetUserId: userId,
+      targetEmail: normalizedEmail,
+      envVarMatched: true,
+    },
+  });
+  return true;
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/core/src/rbac/user-role-store.ts packages/core/src/__tests__/rbac/bootstrap.test.ts
+git commit -m "feat(rbac): applyBootstrapAdmins for env-var admin list"
+```
+
+---
+
+## Task 5: Audit event builders for RBAC actions
+
+**Files:**
+- Modify: `packages/core/src/audit/events.ts`
+- Modify: `packages/core/src/rbac/user-role-store.ts` (use the new builders)
+- Test: `packages/core/src/__tests__/audit/rbac-events.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  dashboardGrantRoleEvent, dashboardRevokeRoleEvent,
+  dashboardBootstrapAdminEvent, dashboardRetryRunEvent,
+} from "../../audit/events.js";
+import { AuditEventSchema } from "../../types.js";
+
+describe("rbac audit event builders", () => {
+  it("dashboardGrantRoleEvent", () => {
+    const evt = dashboardGrantRoleEvent({
+      targetUserId: "u_1", targetEmail: "a@b.com",
+      oldRole: "viewer", newRole: "operator",
+      actorUserId: "u_admin", actorEmail: "admin@b.com",
+    });
+    const p = AuditEventSchema.parse(evt);
+    expect(p.eventType).toBe("dashboard.manual_action");
+    expect(p.actor).toBe("dashboard:admin@b.com");
+    expect(p.payload.action).toBe("grant_role");
+    expect(p.payload.oldRole).toBe("viewer");
+    expect(p.payload.newRole).toBe("operator");
+  });
+
+  it("dashboardRevokeRoleEvent", () => {
+    const evt = dashboardRevokeRoleEvent({
+      targetUserId: "u_1", targetEmail: "a@b.com",
+      oldRole: "operator", newRole: "viewer",
+      actorUserId: "u_admin", actorEmail: "admin@b.com",
+    });
+    expect(evt.payload.action).toBe("revoke_role");
+  });
+
+  it("dashboardBootstrapAdminEvent", () => {
+    const evt = dashboardBootstrapAdminEvent({
+      targetUserId: "u_1", targetEmail: "alice@acme.com",
+    });
+    expect(evt.eventType).toBe("dashboard.manual_action");
+    expect(evt.actor).toBe("system");
+    expect(evt.actorType).toBe("system");
+    expect(evt.payload.action).toBe("bootstrap_admin");
+  });
+
+  it("dashboardRetryRunEvent", () => {
+    const evt = dashboardRetryRunEvent({
+      runId: "run_1", issueId: "BEC-42",
+      previousStatus: "failed",
+      actorUserId: "u_op", actorEmail: "op@b.com",
+    });
+    expect(evt.payload.action).toBe("retry_run");
+    expect(evt.runId).toBe("run_1");
+    expect(evt.issueId).toBe("BEC-42");
+    expect(evt.actor).toBe("dashboard:op@b.com");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Append builders to `audit/events.ts`**
+
+```ts
+export function dashboardGrantRoleEvent(args: {
+  targetUserId: string; targetEmail: string;
+  oldRole: string; newRole: string;
+  actorUserId: string; actorEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorEmail}`,
+    actorType: "dashboard-user",
+    payload: {
+      action: "grant_role",
+      targetUserId: args.targetUserId,
+      targetEmail: args.targetEmail,
+      oldRole: args.oldRole,
+      newRole: args.newRole,
+      actorUserId: args.actorUserId,
+    },
+  });
+}
+
+export function dashboardRevokeRoleEvent(args: {
+  targetUserId: string; targetEmail: string;
+  oldRole: string; newRole: string;
+  actorUserId: string; actorEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorEmail}`,
+    actorType: "dashboard-user",
+    payload: {
+      action: "revoke_role",
+      targetUserId: args.targetUserId,
+      targetEmail: args.targetEmail,
+      oldRole: args.oldRole,
+      newRole: args.newRole,
+      actorUserId: args.actorUserId,
+    },
+  });
+}
+
+export function dashboardBootstrapAdminEvent(args: {
+  targetUserId: string; targetEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: "system",
+    actorType: "system",
+    payload: {
+      action: "bootstrap_admin",
+      targetUserId: args.targetUserId,
+      targetEmail: args.targetEmail,
+      envVarMatched: true,
+    },
+  });
+}
+
+export function dashboardRetryRunEvent(args: {
+  runId: string; issueId: string;
+  previousStatus: string;
+  actorUserId: string; actorEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorEmail}`,
+    actorType: "dashboard-user",
+    runId: args.runId,
+    issueId: args.issueId,
+    payload: {
+      action: "retry_run",
+      previousStatus: args.previousStatus,
+      actorUserId: args.actorUserId,
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Update `setUserRole` and `applyBootstrapAdmins` to use the new builders**
+
+In `packages/core/src/rbac/user-role-store.ts`:
+- Replace the inline `logAuditEvent(...)` call in `setUserRole` with:
+```ts
+import { logAuditEvent, dashboardGrantRoleEvent, dashboardRevokeRoleEvent } from "../audit/index.js";
+// ...
+const actorEmailRows = await db.select().from(dashboardUsers).where(eq(dashboardUsers.id, args.actorUserId));
+const actorEmail = (actorEmailRows[0] as any)?.email ?? "unknown";
+const builder = isRevoke ? dashboardRevokeRoleEvent : dashboardGrantRoleEvent;
+void logAuditEvent(db, builder({
+  targetUserId: args.userId,
+  targetEmail: current.email,
+  oldRole,
+  newRole: args.newRole,
+  actorUserId: args.actorUserId,
+  actorEmail,
+}));
+```
+- Replace the inline event literal in `applyBootstrapAdmins` with `dashboardBootstrapAdminEvent({...})`
+
+- [ ] **Step 5: Run all rbac + audit tests, verify pass**
+
+```
+cd packages/core && npx vitest run src/__tests__/rbac src/__tests__/audit/rbac-events.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/audit/events.ts packages/core/src/rbac/user-role-store.ts packages/core/src/__tests__/audit/rbac-events.test.ts
+git commit -m "feat(rbac): audit event builders for role and retry actions"
+```
+
+---
+
+## Task 6: License flag + core barrel re-export
+
+**Files:**
+- Modify: `packages/core/src/license.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/src/__tests__/rbac-license.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import { _resetLicenseCache, isFeatureLicensed } from "../license.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+afterEach(async () => { _resetLicenseCache(); await restoreLicense(); });
+
+describe("rbac feature flag", () => {
+  it("licensed at enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    expect(isFeatureLicensed("rbac")).toBe(true);
+  });
+
+  it("not licensed at pro tier", async () => {
+    await installTestProLicense("pro");
+    expect(isFeatureLicensed("rbac")).toBe(false);
+  });
+
+  it("not licensed without a license", async () => {
+    expect(isFeatureLicensed("rbac")).toBe(false);
+  });
+
+  it("rbac module is re-exported from @urateam/core", async () => {
+    const mod = await import("../index.js");
+    expect(typeof (mod as any).canAccess).toBe("function");
+    expect(typeof (mod as any).setUserRole).toBe("function");
+    expect(typeof (mod as any).applyBootstrapAdmins).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Add `"rbac"` to Enterprise feature set**
+
+In `packages/core/src/license.ts`, find `ENTERPRISE_FEATURES` and add `"rbac"` alongside the existing entries.
+
+- [ ] **Step 4: Re-export from core barrel**
+
+In `packages/core/src/index.ts` add:
+```ts
+export * from "./rbac/index.js";
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/core/src/license.ts packages/core/src/index.ts packages/core/src/__tests__/rbac-license.test.ts
+git commit -m "feat(rbac): add rbac to enterprise feature set"
+```
+
+---
+
+## Task 7: Dashboard `requirePermission` middleware
+
+**Files:**
+- Create: `packages/dashboard/src/middleware/rbac.ts`
+- Create: `packages/dashboard/src/views/forbidden.ts`
+- Test: `packages/dashboard/src/__tests__/rbac-middleware.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { requirePermission } from "../middleware/rbac.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+afterEach(async () => { await restoreLicense(); });
+
+function appWithRoute(permission: string, role: string | undefined) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (role) c.set("user" as never, { id: "u_1", role, email: "u@b.com" } as any);
+    await next();
+  });
+  app.get("/test", requirePermission(permission as any), (c) => c.text("ok"));
+  return app;
+}
+
+describe("requirePermission", () => {
+  it("unlicensed → no-op, all roles pass", async () => {
+    let app = appWithRoute("config.view", "viewer");
+    expect((await app.request("/test")).status).toBe(200);
+  });
+
+  describe("licensed", () => {
+    beforeEach(async () => { await installTestProLicense("enterprise"); });
+
+    it("admin passes runs.view", async () => {
+      const res = await appWithRoute("runs.view", "admin").request("/test");
+      expect(res.status).toBe(200);
+    });
+
+    it("viewer passes runs.view", async () => {
+      const res = await appWithRoute("runs.view", "viewer").request("/test");
+      expect(res.status).toBe(200);
+    });
+
+    it("viewer gets 403 on audit.view", async () => {
+      const res = await appWithRoute("audit.view", "viewer").request("/test");
+      expect(res.status).toBe(403);
+    });
+
+    it("operator gets 403 on config.view", async () => {
+      const res = await appWithRoute("config.view", "operator").request("/test");
+      expect(res.status).toBe(403);
+    });
+
+    it("admin passes config.view", async () => {
+      const res = await appWithRoute("config.view", "admin").request("/test");
+      expect(res.status).toBe(200);
+    });
+
+    it("no session → 401", async () => {
+      const res = await appWithRoute("runs.view", undefined).request("/test");
+      expect(res.status).toBe(401);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```
+cd packages/dashboard && npx vitest run src/__tests__/rbac-middleware.test.ts
+```
+
+- [ ] **Step 3: Create `views/forbidden.ts`**
+
+```ts
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+export function renderForbidden(args: {
+  email: string;
+  role: string;
+  action: string;
+  basePath: string;
+}): string {
+  return `<!DOCTYPE html>
+<html><head><title>Forbidden</title></head><body>
+  <h1>403 — Access denied</h1>
+  <p>Your account (<strong>${escapeHtml(args.email)}</strong>, role <strong>${escapeHtml(args.role)}</strong>) does not have permission to access this page (requires <code>${escapeHtml(args.action)}</code>).</p>
+  <p>Contact your administrator.</p>
+  <p><a href="${escapeHtml(args.basePath)}/auth/logout">Sign out</a></p>
+</body></html>`;
+}
+```
+
+- [ ] **Step 4: Create `middleware/rbac.ts`**
+
+```ts
+import type { MiddlewareHandler } from "hono";
+import { isFeatureLicensed, canAccess, type PermissionKey, type Role } from "@urateam/core";
+import { renderForbidden } from "../views/forbidden.js";
+
+export function requirePermission(action: PermissionKey): MiddlewareHandler {
+  return async (c, next) => {
+    if (!isFeatureLicensed("rbac")) return next();
+
+    const user = c.get("user" as never) as { id: string; email: string; role: Role } | undefined;
+    if (!user) return c.text("Unauthorized", 401);
+
+    if (!canAccess(user.role, action)) {
+      return c.html(
+        renderForbidden({
+          email: user.email,
+          role: user.role,
+          action,
+          basePath: "",
+        }),
+        403,
+      );
+    }
+    return next();
+  };
+}
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/dashboard/src/middleware/rbac.ts packages/dashboard/src/views/forbidden.ts packages/dashboard/src/__tests__/rbac-middleware.test.ts
+git commit -m "feat(rbac): requirePermission middleware and forbidden view"
+```
+
+---
+
+## Task 8: Wire bootstrap into SSO callback
+
+**Files:**
+- Modify: `packages/dashboard/src/routes/auth.ts`
+- Test: `packages/dashboard/src/__tests__/bootstrap-integration.test.ts`
+
+- [ ] **Step 1: Read existing `/auth/callback` handler**
+
+Look for the line `const userId = await upsertUser(deps.db, ...)` in `packages/dashboard/src/routes/auth.ts`. The bootstrap call goes immediately after it, before `createSession`.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createDb, auditEvents, dashboardUsers } from "@urateam/core";
+import { signState } from "@urateam/core";
+import { Hono } from "hono";
+import { createAuthRouter } from "../routes/auth.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test",
+  workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  allowedDomain: undefined as string | undefined,
+  sessionDurationHours: 24,
+  cookieName: "urateam_session",
+  cookieSecure: false,
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+const stubWorkos = {
+  async getAuthorizationUrl() { return "https://workos.example/auth"; },
+  async authenticateWithCode() {
+    return { user: { id: "wu_1", email: "alice@acme.com", firstName: "Alice", lastName: "X" } };
+  },
+} as any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+});
+afterEach(async () => { await restoreLicense(); vi.unstubAllEnvs(); });
+
+describe("SSO callback bootstrap admin integration", () => {
+  it("promotes alice@acme.com when URATEAM_ADMIN_EMAILS matches", async () => {
+    vi.stubEnv("URATEAM_ADMIN_EMAILS", "alice@acme.com");
+    const app = new Hono();
+    app.route("/", createAuthRouter({ db, sso: ssoConfig, workos: stubWorkos }));
+    const state = signState({ next: "/", nonce: "n" }, ssoConfig.stateSigningSecret);
+    const res = await app.request(`/auth/callback?code=abc&state=${encodeURIComponent(state)}`);
+    expect(res.status).toBe(302);
+    const users = await db.select().from(dashboardUsers);
+    expect(users[0].role).toBe("admin");
+  });
+
+  it("leaves role as viewer when email does not match", async () => {
+    vi.stubEnv("URATEAM_ADMIN_EMAILS", "bob@acme.com");
+    const app = new Hono();
+    app.route("/", createAuthRouter({ db, sso: ssoConfig, workos: stubWorkos }));
+    const state = signState({ next: "/", nonce: "n" }, ssoConfig.stateSigningSecret);
+    await app.request(`/auth/callback?code=abc&state=${encodeURIComponent(state)}`);
+    const users = await db.select().from(dashboardUsers);
+    expect(users[0].role).toBe("viewer");
+  });
+
+  it("does not promote when URATEAM_ADMIN_EMAILS is unset", async () => {
+    vi.stubEnv("URATEAM_ADMIN_EMAILS", "");
+    const app = new Hono();
+    app.route("/", createAuthRouter({ db, sso: ssoConfig, workos: stubWorkos }));
+    const state = signState({ next: "/", nonce: "n" }, ssoConfig.stateSigningSecret);
+    await app.request(`/auth/callback?code=abc&state=${encodeURIComponent(state)}`);
+    const users = await db.select().from(dashboardUsers);
+    expect(users[0].role).toBe("viewer");
+  });
+});
+```
+
+- [ ] **Step 3: Run, confirm failure**
+
+- [ ] **Step 4: Modify `routes/auth.ts` to call `applyBootstrapAdmins`**
+
+In the `/auth/callback` handler, immediately after `const userId = await upsertUser(...)`:
+
+```ts
+import { applyBootstrapAdmins, isFeatureLicensed } from "@urateam/core";
+
+// ... inside the callback handler, after upsertUser returns userId:
+if (isFeatureLicensed("rbac")) {
+  try {
+    await applyBootstrapAdmins(deps.db, email, userId, process.env.URATEAM_ADMIN_EMAILS);
+  } catch (err) {
+    // bootstrap must never block login
+    // log via pino if available; otherwise swallow
+  }
+}
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/dashboard/src/routes/auth.ts packages/dashboard/src/__tests__/bootstrap-integration.test.ts
+git commit -m "feat(rbac): apply bootstrap admins on sso callback"
+```
+
+---
+
+## Task 9: Retry endpoint
+
+**Files:**
+- Modify: `packages/dashboard/src/routes/runs.ts`
+- Modify: `packages/dashboard/src/views/run-detail.ts`
+- Test: `packages/dashboard/src/__tests__/retry-route.test.ts`
+
+- [ ] **Step 1: Read the existing runs router**
+
+Look at `packages/dashboard/src/routes/runs.ts` to see the router factory shape and how `deps.runner` is passed.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import { createDb, auditEvents } from "@urateam/core";
+import { pipelineRuns } from "@urateam/core/dist/db/schema.js";
+import { createRunsRouter } from "../routes/runs.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+import { requirePermission } from "../middleware/rbac.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(pipelineRuns).values({
+    id: "run_1", issueId: "BEC-42", issueTitle: "fix bug", pipelineKey: "auto-implement",
+    repoUrl: "https://github.com/acme/api", status: "failed",
+    startedAt: new Date(), completedAt: new Date(),
+    errorMessage: "boom",
+  });
+});
+afterEach(async () => { await restoreLicense(); });
+
+function appWith(role: string | undefined, runner: any = { resume: vi.fn(), start: vi.fn() }) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (role) c.set("user" as never, { id: "u_1", email: "u@b.com", role } as any);
+    await next();
+  });
+  app.route("/", createRunsRouter({ db, runner, basePath: "" }));
+  return app;
+}
+
+describe("POST /runs/:id/retry", () => {
+  it("unlicensed → middleware is no-op but endpoint still exists — 200 for any role", async () => {
+    const app = appWith("viewer");
+    const res = await app.request("/runs/run_1/retry", { method: "POST" });
+    // Feature-off means role middleware is a no-op. The retry endpoint should
+    // still gate on run status (failed=ok). Expected: 302 redirect to /runs/run_1.
+    expect([200, 302]).toContain(res.status);
+  });
+
+  describe("licensed", () => {
+    beforeEach(async () => { await installTestProLicense("enterprise"); });
+
+    it("viewer → 403", async () => {
+      const res = await appWith("viewer").request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(403);
+    });
+
+    it("operator → 302 redirect, runner.resume called, audit event written", async () => {
+      const runner = { resume: vi.fn().mockResolvedValue(undefined), start: vi.fn() };
+      const app = appWith("operator", runner);
+      const res = await app.request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(302);
+      expect(runner.resume).toHaveBeenCalledWith("run_1");
+      const events = await db.select().from(auditEvents);
+      const retry = events.find((e: any) => {
+        const p = JSON.parse(e.payload);
+        return e.eventType === "dashboard.manual_action" && p.action === "retry_run";
+      });
+      expect(retry).toBeDefined();
+    });
+
+    it("admin → 302, runner.resume called", async () => {
+      const runner = { resume: vi.fn().mockResolvedValue(undefined), start: vi.fn() };
+      const app = appWith("admin", runner);
+      const res = await app.request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(302);
+      expect(runner.resume).toHaveBeenCalled();
+    });
+
+    it("operator retrying a completed run → 409", async () => {
+      await db.update(pipelineRuns)
+        .set({ status: "completed" })
+        .where((require("drizzle-orm") as any).eq(pipelineRuns.id, "run_1"));
+      const res = await appWith("operator").request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(409);
+    });
+
+    it("operator retrying a non-existent run → 404", async () => {
+      const res = await appWith("operator").request("/runs/nope/retry", { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+  });
+});
+```
+
+(Note: the require-drizzle-orm import in the completed-run test is inline to avoid a top-level import pollution. Match the existing test style — if other tests use a top-level `import { eq } from "drizzle-orm"`, do the same here.)
+
+- [ ] **Step 3: Run, confirm failure**
+
+- [ ] **Step 4: Add the retry route to `routes/runs.ts`**
+
+```ts
+import { eq } from "drizzle-orm";
+import { pipelineRuns } from "@urateam/core/dist/db/schema.js";
+import { logAuditEvent, dashboardRetryRunEvent } from "@urateam/core";
+import { requirePermission } from "../middleware/rbac.js";
+
+// Inside createRunsRouter, add:
+app.post("/runs/:id/retry", requirePermission("runs.retry"), async (c) => {
+  const id = c.req.param("id");
+  const rows = await deps.db.select().from(pipelineRuns).where(eq(pipelineRuns.id, id));
+  if (rows.length === 0) return c.text("Run not found", 404);
+  const run = rows[0] as any;
+  if (run.status !== "failed" && run.status !== "retriable") {
+    return c.text(`Cannot retry a run in status ${run.status}`, 409);
+  }
+
+  try {
+    if (run.resumePayload) {
+      await deps.runner.resume(id);
+    } else {
+      await deps.runner.start({ issueId: run.issueId, issueTitle: run.issueTitle, repoUrl: run.repoUrl });
+    }
+  } catch (err) {
+    return c.text(`Retry failed: ${(err as Error).message}`, 500);
+  }
+
+  const user = c.get("user" as never) as { id: string; email: string } | undefined;
+  if (user) {
+    void logAuditEvent(deps.db, dashboardRetryRunEvent({
+      runId: id,
+      issueId: run.issueId,
+      previousStatus: run.status,
+      actorUserId: user.id,
+      actorEmail: user.email,
+    }));
+  }
+  return c.redirect(`${deps.basePath}/runs/${id}`, 302);
+});
+```
+
+- [ ] **Step 5: Add the Retry button to `views/run-detail.ts`**
+
+Find where run-detail renders its action area. Add (thread `user` through the view's props):
+```ts
+${run.status === "failed" || run.status === "retriable" ? `
+  <form method="post" action="${basePath}/runs/${run.id}/retry" hx-post="${basePath}/runs/${run.id}/retry" hx-headers='{"HX-Request":"true"}'>
+    <button type="submit" class="button-primary">Retry</button>
+  </form>
+` : ""}
+```
+
+Visibility gate: only render the form when `user` is undefined (unlicensed, RBAC off) OR `canAccess(user.role, "runs.retry")`. For consistency, the button is always shown when RBAC is off — the endpoint itself enforces the status check.
+
+- [ ] **Step 6: Run tests, verify pass**
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/dashboard/src/routes/runs.ts packages/dashboard/src/views/run-detail.ts packages/dashboard/src/__tests__/retry-route.test.ts
+git commit -m "feat(rbac): manual retry endpoint gated by runs.retry permission"
+```
+
+---
+
+## Task 10: `/users` admin UI
+
+**Files:**
+- Create: `packages/dashboard/src/routes/users.ts`
+- Create: `packages/dashboard/src/views/users.ts`
+- Modify: `packages/dashboard/src/server.ts` (mount route)
+- Modify: `packages/dashboard/src/views/layout.ts` (add "Users" nav for admins)
+- Test: `packages/dashboard/src/__tests__/users-routes.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createDb, auditEvents } from "@urateam/core";
+import { dashboardUsers } from "@urateam/core/dist/db/schema.js";
+import { createUsersRouter } from "../routes/users.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values([
+    { id: "u_admin", email: "admin@b.com", name: "Admin", workosUserId: null, role: "admin" },
+    { id: "u_op",    email: "op@b.com",    name: "Op",    workosUserId: null, role: "operator" },
+    { id: "u_view",  email: "view@b.com",  name: "View",  workosUserId: null, role: "viewer" },
+  ]);
+});
+afterEach(async () => { await restoreLicense(); });
+
+function appWith(role: string | undefined, userId = "u_admin") {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (role) c.set("user" as never, { id: userId, email: `${role}@b.com`, role } as any);
+    await next();
+  });
+  app.route("/", createUsersRouter({ db, basePath: "" }));
+  return app;
+}
+
+describe("/users routes (licensed)", () => {
+  beforeEach(async () => { await installTestProLicense("enterprise"); });
+
+  it("GET /users as admin → 200 with user list", async () => {
+    const res = await appWith("admin").request("/users");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("admin@b.com");
+    expect(body).toContain("op@b.com");
+    expect(body).toContain("view@b.com");
+  });
+
+  it("GET /users as operator → 403", async () => {
+    const res = await appWith("operator").request("/users");
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /users as viewer → 403", async () => {
+    const res = await appWith("viewer").request("/users");
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /users/:id/role as admin → 302, role updated, audit event written", async () => {
+    const res = await appWith("admin").request("/users/u_view/role", {
+      method: "POST",
+      headers: { "HX-Request": "true", "content-type": "application/x-www-form-urlencoded" },
+      body: "role=operator",
+    });
+    expect(res.status).toBe(302);
+    const rows = await db.select().from(dashboardUsers);
+    expect(rows.find((u: any) => u.id === "u_view").role).toBe("operator");
+    const events = await db.select().from(auditEvents);
+    expect(events.some((e: any) => e.eventType === "dashboard.manual_action")).toBe(true);
+  });
+
+  it("POST /users/:id/role as operator → 403", async () => {
+    const res = await appWith("operator").request("/users/u_view/role", {
+      method: "POST",
+      headers: { "HX-Request": "true", "content-type": "application/x-www-form-urlencoded" },
+      body: "role=admin",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("POST with invalid role → 400", async () => {
+    const res = await appWith("admin").request("/users/u_view/role", {
+      method: "POST",
+      headers: { "HX-Request": "true", "content-type": "application/x-www-form-urlencoded" },
+      body: "role=god",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST to demote self → 400", async () => {
+    const res = await appWith("admin", "u_admin").request("/users/u_admin/role", {
+      method: "POST",
+      headers: { "HX-Request": "true", "content-type": "application/x-www-form-urlencoded" },
+      body: "role=viewer",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST to demote last admin → 400", async () => {
+    // u_admin is the only admin; try to demote as operator context would fail, but
+    // this test ensures the server-side guard fires even from admin context.
+    // Add a second admin first to test the inverse works.
+    await db.insert(dashboardUsers).values({
+      id: "u_admin2", email: "admin2@b.com", name: null, workosUserId: null, role: "admin",
+    });
+    // Now remove u_admin2, then try to demote u_admin — should fail because u_admin is last.
+    await db.delete(dashboardUsers).where((require("drizzle-orm") as any).eq(dashboardUsers.id, "u_admin2"));
+    // Call as u_admin2 (already deleted) would be weird; call as a hypothetical other admin
+    // instead. Simpler: test setUserRole directly in user-role-store.test.ts (Task 3).
+    // This test just verifies the route returns 400 when the store throws LastAdminError.
+    // Skip here or use a simpler scenario.
+  });
+});
+
+describe("/users routes (unlicensed)", () => {
+  it("GET /users → 404", async () => {
+    const res = await appWith("admin").request("/users");
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+(Note: the "POST to demote last admin" test is brittle as written. Remove it — Task 3's unit test on `setUserRole` already covers the `LastAdminError` path. Keep the unit test, drop this integration duplicate.)
+
+- [ ] **Step 2: Run, confirm failure**
+
+- [ ] **Step 3: Create `views/users.ts`**
+
+```ts
+import type { Role } from "@urateam/core";
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+interface UserRow {
+  id: string;
+  email: string;
+  name: string | null;
+  role: Role;
+  lastLoginAt: Date | null;
+}
+
+export function renderUsersPage(args: {
+  users: UserRow[];
+  currentUserId: string;
+  basePath: string;
+}): string {
+  const rows = args.users.map(u => {
+    const isSelf = u.id === args.currentUserId;
+    const lastLogin = u.lastLoginAt ? u.lastLoginAt.toISOString() : "(never)";
+    return `
+      <tr>
+        <td>${escapeHtml(u.email)}${isSelf ? " <em>(you)</em>" : ""}</td>
+        <td>${escapeHtml(u.name ?? "")}</td>
+        <td>${escapeHtml(u.role)}</td>
+        <td>${escapeHtml(lastLogin)}</td>
+        <td>
+          <form method="post" action="${args.basePath}/users/${escapeHtml(u.id)}/role" hx-post="${args.basePath}/users/${escapeHtml(u.id)}/role" hx-headers='{"HX-Request":"true"}'>
+            <select name="role" ${isSelf ? "disabled" : ""}>
+              <option value="admin" ${u.role === "admin" ? "selected" : ""}>admin</option>
+              <option value="operator" ${u.role === "operator" ? "selected" : ""}>operator</option>
+              <option value="viewer" ${u.role === "viewer" ? "selected" : ""}>viewer</option>
+            </select>
+            <button type="submit" ${isSelf ? "disabled" : ""}>Update</button>
+          </form>
+        </td>
+      </tr>`;
+  }).join("");
+
+  return `<!DOCTYPE html>
+<html><head><title>Users</title></head><body>
+  <h1>Users</h1>
+  <table>
+    <thead><tr>
+      <th>Email</th><th>Name</th><th>Role</th><th>Last login</th><th></th>
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</body></html>`;
+}
+```
+
+- [ ] **Step 4: Create `routes/users.ts`**
+
+```ts
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  listUsers, setUserRole, SelfDemoteError, LastAdminError,
+} from "@urateam/core";
+import { requirePermission } from "../middleware/rbac.js";
+import { renderUsersPage } from "../views/users.js";
+
+const roleSchema = z.enum(["admin", "operator", "viewer"]);
+
+export function createUsersRouter(deps: { db: any; basePath: string }): Hono {
+  const app = new Hono();
+
+  app.get("/users", requirePermission("users.view"), async (c) => {
+    const user = c.get("user" as never) as { id: string } | undefined;
+    const users = await listUsers(deps.db);
+    return c.html(renderUsersPage({
+      users,
+      currentUserId: user?.id ?? "",
+      basePath: deps.basePath,
+    }));
+  });
+
+  app.post("/users/:id/role", requirePermission("users.manage"), async (c) => {
+    const targetId = c.req.param("id");
+    const form = await c.req.parseBody();
+    const parse = roleSchema.safeParse(form.role);
+    if (!parse.success) return c.text("Invalid role", 400);
+
+    const user = c.get("user" as never) as { id: string } | undefined;
+    if (!user) return c.text("Unauthorized", 401);
+
+    try {
+      await setUserRole(deps.db, {
+        userId: targetId,
+        newRole: parse.data,
+        actorUserId: user.id,
+      });
+    } catch (err) {
+      if (err instanceof SelfDemoteError) return c.text("Cannot demote yourself", 400);
+      if (err instanceof LastAdminError) return c.text("Cannot demote the last remaining admin", 400);
+      return c.text(`Role update failed: ${(err as Error).message}`, 500);
+    }
+
+    return c.redirect(`${deps.basePath}/users`, 302);
+  });
+
+  return app;
+}
+```
+
+- [ ] **Step 5: Mount the route in `server.ts`**
+
+Find where other routers are mounted (e.g. `createAuditRouter`) and add:
+```ts
+import { createUsersRouter } from "./routes/users.js";
+// ...
+app.route("/", createUsersRouter({ db: config.db, basePath }));
+```
+
+- [ ] **Step 6: Add "Users" nav entry to `views/layout.ts`**
+
+Thread `user` into the layout's `LayoutContext`. When `ctx?.userRole === "admin"`, render `<a href="${bp}/users">Users</a>` in the nav. Otherwise omit.
+
+- [ ] **Step 7: Run tests, verify pass**
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/dashboard/src/routes/users.ts packages/dashboard/src/views/users.ts packages/dashboard/src/views/layout.ts packages/dashboard/src/server.ts packages/dashboard/src/__tests__/users-routes.test.ts
+git commit -m "feat(rbac): /users admin page with role management"
+```
+
+---
+
+## Task 11: Decorate existing dashboard routes with `requirePermission`
+
+**Files:**
+- Modify: `packages/dashboard/src/routes/runs.ts` — add `requirePermission("runs.view")` to `/runs`, `/runs/:id`
+- Modify: `packages/dashboard/src/routes/tokens.ts` — `requirePermission("tokens.view")`
+- Modify: `packages/dashboard/src/routes/audit.ts` — `requirePermission("audit.view")` on `/audit`, `/audit/page`; `requirePermission("audit.export")` on `/audit/export.csv`
+- Modify: `packages/dashboard/src/routes/cost.ts` — `requirePermission("cost.view")` on `/cost`, `/cost/page`; `requirePermission("cost.export")` on `/cost/export.csv`
+- Modify: `packages/dashboard/src/routes/errors.ts` — `requirePermission("errors.view")`
+- Modify: `packages/dashboard/src/routes/coordination.ts` — `requirePermission("coordination.view")`
+- Modify: `packages/dashboard/src/routes/config.ts` — `requirePermission("config.view")`
+
+- [ ] **Step 1: Check existing tests still pass**
+
+After wiring `requirePermission` on all the above routes, run the full dashboard test suite:
+```
+cd packages/dashboard && npx vitest run
+```
+
+Existing tests do not install an enterprise license for rbac, so the middleware is a no-op and all tests continue to pass. Verify this is true — if any test installs enterprise license and doesn't set a `user` in the context, it will fail because `requirePermission` returns 401 for missing user.
+
+If existing tests break, check which test and add one of:
+- `await installTestProLicense("pro")` in a `beforeEach` (disables rbac middleware)
+- Set a user in `c.set("user", ...)` at the start of the test
+- Use `await restoreLicense()` in `afterEach` to prevent license leaking
+
+- [ ] **Step 2: Add one-line decorations to each route file**
+
+Example for `routes/audit.ts`:
+```ts
+import { requirePermission } from "../middleware/rbac.js";
+
+app.get("/audit", requirePermission("audit.view"), existingAuditGetHandler);
+app.get("/audit/page", requirePermission("audit.view"), existingAuditPageHandler);
+app.get("/audit/export.csv", requirePermission("audit.export"), existingAuditExportHandler);
+```
+
+Same pattern for each of the 7 route files listed above. Each file is a 3–6 line diff.
+
+- [ ] **Step 3: Run full dashboard test suite**
+
+```
+cd packages/dashboard && npx vitest run
+```
+Expected: all pass. If not, investigate which test failed and whether the failure is a real regression or a test that needs a license reset.
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/dashboard/src/routes
+git commit -m "feat(rbac): decorate dashboard routes with requirePermission"
+```
+
+---
+
+## Task 12: `ura admin` CLI commands
+
+**Files:**
+- Create: `packages/cli/src/commands/admin.ts`
+- Modify: `packages/cli/src/index.ts` (register the command)
+- Test: `packages/cli/src/__tests__/admin-commands.test.ts`
+
+- [ ] **Step 1: Read `packages/cli/src/commands/license.ts` for the CLI command pattern**
+
+This gives you the command-registration idiom (probably commander-based) and the DB-bootstrap pattern for commands that don't need the runner.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { runAdminList, runAdminGrant, runAdminRevoke } from "../commands/admin.js";
+import { createDb } from "@urateam/core";
+import { dashboardUsers } from "@urateam/core/dist/db/schema.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+let logs: string[];
+const log = (s: string) => { logs.push(s); };
+
+beforeEach(async () => {
+  logs = [];
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values([
+    { id: "u_admin", email: "admin@b.com", name: "Admin", workosUserId: null, role: "admin" },
+    { id: "u_op",    email: "op@b.com",    name: "Op",    workosUserId: null, role: "operator" },
+  ]);
+});
+afterEach(async () => { await restoreLicense(); });
+
+describe("ura admin commands", () => {
+  it("list prints all users", async () => {
+    await runAdminList({ db, log });
+    expect(logs.some(l => l.includes("admin@b.com"))).toBe(true);
+    expect(logs.some(l => l.includes("op@b.com"))).toBe(true);
+  });
+
+  it("grant promotes by email", async () => {
+    await runAdminGrant({ db, email: "op@b.com", newRole: "admin", log });
+    const rows = await db.select().from(dashboardUsers);
+    expect(rows.find((u: any) => u.id === "u_op").role).toBe("admin");
+  });
+
+  it("grant with unknown email errors clearly", async () => {
+    await expect(
+      runAdminGrant({ db, email: "ghost@nowhere.com", newRole: "admin", log }),
+    ).rejects.toThrow(/user not found/i);
+  });
+
+  it("revoke sets role to viewer", async () => {
+    await runAdminRevoke({ db, email: "op@b.com", log });
+    const rows = await db.select().from(dashboardUsers);
+    expect(rows.find((u: any) => u.id === "u_op").role).toBe("viewer");
+  });
+
+  it("refuses when feature is unlicensed", async () => {
+    await restoreLicense();
+    await expect(runAdminList({ db, log })).rejects.toThrow(/enterprise/i);
+  });
+});
+```
+
+- [ ] **Step 3: Run, confirm failure**
+
+- [ ] **Step 4: Create `commands/admin.ts`**
+
+```ts
+import { eq } from "drizzle-orm";
+import { isFeatureLicensed, listUsers, setUserRole, type Role } from "@urateam/core";
+import { dashboardUsers } from "@urateam/core/dist/db/schema.js";
+import * as os from "node:os";
+
+interface Deps {
+  db: any;
+  log: (msg: string) => void;
+}
+
+function requireLicensed(): void {
+  if (!isFeatureLicensed("rbac")) {
+    throw new Error("RBAC is an Enterprise feature. Upgrade your license to use 'ura admin' commands.");
+  }
+}
+
+export async function runAdminList(deps: Deps): Promise<void> {
+  requireLicensed();
+  const users = await listUsers(deps.db);
+  deps.log("EMAIL                            ROLE       LAST_LOGIN");
+  for (const u of users) {
+    const email = u.email.padEnd(32).slice(0, 32);
+    const role = u.role.padEnd(10).slice(0, 10);
+    const ll = u.lastLoginAt ? u.lastLoginAt.toISOString() : "(never)";
+    deps.log(`${email} ${role} ${ll}`);
+  }
+}
+
+export async function runAdminGrant(args: Deps & { email: string; newRole: Role }): Promise<void> {
+  requireLicensed();
+  const rows = await args.db.select().from(dashboardUsers)
+    .where(eq(dashboardUsers.email, args.email.trim().toLowerCase()));
+  if (rows.length === 0) throw new Error(`user not found: ${args.email}`);
+  const target = rows[0];
+
+  await setUserRole(args.db, {
+    userId: target.id,
+    newRole: args.newRole,
+    actorUserId: `cli:${os.userInfo().username}`,
+  });
+  args.log(`Updated ${target.email} → ${args.newRole}`);
+}
+
+export async function runAdminRevoke(args: Deps & { email: string }): Promise<void> {
+  await runAdminGrant({ ...args, newRole: "viewer" });
+}
+```
+
+- [ ] **Step 5: Register the `admin` command in `packages/cli/src/index.ts`**
+
+Find where other commands (like `license`) are registered, and add an analogous `admin` command with three subcommands (`list`, `grant`, `revoke`). Each subcommand constructs a `Db` via `createDb({ connectionString: env.DATABASE_URL })`, calls the appropriate `runAdmin*` function, and prints via `console.log`.
+
+Example wiring (commander-style):
+```ts
+program
+  .command("admin")
+  .description("Manage dashboard user roles")
+  .command("list")
+  .action(async () => {
+    const db = await createDb({ connectionString: process.env.DATABASE_URL! });
+    try {
+      await runAdminList({ db, log: (s) => console.log(s) });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("admin grant <email>")
+  .option("--role <role>", "admin|operator|viewer", "operator")
+  .action(async (email, opts) => {
+    const db = await createDb({ connectionString: process.env.DATABASE_URL! });
+    try {
+      await runAdminGrant({ db, email, newRole: opts.role, log: (s) => console.log(s) });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("admin revoke <email>")
+  .action(async (email) => { /* same shape */ });
+```
+
+Adapt the exact API to whatever commander-ish framework the CLI actually uses. Look at the `license` command for the closest pattern.
+
+- [ ] **Step 6: Run tests, verify pass**
+
+```
+cd packages/cli && npx vitest run src/__tests__/admin-commands.test.ts
+```
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/cli/src/commands/admin.ts packages/cli/src/index.ts packages/cli/src/__tests__/admin-commands.test.ts
+git commit -m "feat(rbac): ura admin list/grant/revoke cli commands"
+```
+
+---
+
+## Task 13: Operator setup guide + end-to-end integration test
+
+**Files:**
+- Create: `deploy/RBAC_SETUP.md`
+- Create: `packages/core/src/__tests__/rbac-integration.test.ts`
+
+- [ ] **Step 1: Write the end-to-end integration test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createDb } from "../db/client.js";
+import { dashboardUsers, auditEvents, pipelineRuns } from "../db/schema.js";
+import {
+  setUserRole, applyBootstrapAdmins, canAccess, listUsers,
+} from "../rbac/index.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+});
+afterEach(async () => { await restoreLicense(); });
+
+describe("rbac end-to-end flow", () => {
+  it("bootstrap → promote → permission chain", async () => {
+    // 1. First user logs in, bootstrap promotes to admin
+    await db.insert(dashboardUsers).values({
+      id: "u_alice", email: "alice@acme.com", name: "Alice", workosUserId: null,
+    });
+    const promoted = await applyBootstrapAdmins(db, "alice@acme.com", "u_alice", "alice@acme.com");
+    expect(promoted).toBe(true);
+
+    // 2. Alice logs in, role is admin, she can view config
+    const users = await listUsers(db);
+    const alice = users.find(u => u.id === "u_alice")!;
+    expect(alice.role).toBe("admin");
+    expect(canAccess(alice.role, "config.view")).toBe(true);
+
+    // 3. Second user joins (viewer by default), alice promotes to operator
+    await db.insert(dashboardUsers).values({
+      id: "u_bob", email: "bob@acme.com", name: "Bob", workosUserId: null, role: "viewer",
+    });
+    await setUserRole(db, {
+      userId: "u_bob", newRole: "operator", actorUserId: "u_alice",
+    });
+
+    // 4. Bob can now retry but can't manage users or view config
+    const updated = await listUsers(db);
+    const bob = updated.find(u => u.id === "u_bob")!;
+    expect(bob.role).toBe("operator");
+    expect(canAccess(bob.role, "runs.retry")).toBe(true);
+    expect(canAccess(bob.role, "users.manage")).toBe(false);
+    expect(canAccess(bob.role, "config.view")).toBe(false);
+
+    // 5. Audit trail contains bootstrap + grant events
+    const events = await db.select().from(auditEvents);
+    const bootstrap = events.find((e: any) => JSON.parse(e.payload).action === "bootstrap_admin");
+    const grant = events.find((e: any) => JSON.parse(e.payload).action === "grant_role");
+    expect(bootstrap).toBeDefined();
+    expect(grant).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify pass**
+
+- [ ] **Step 3: Create `deploy/RBAC_SETUP.md`**
+
+```markdown
+# RBAC setup (Enterprise)
+
+urateam supports three dashboard roles:
+- **admin** — full access, including /config and /users
+- **operator** — full read access, can retry failed runs
+- **viewer** — read-only access to /runs, /tokens, /errors
+
+RBAC is gated by the `rbac` feature flag and requires the SSO feature (4.1).
+
+## Prerequisites
+- Enterprise license with `rbac` feature enabled
+- SSO configured (see `deploy/SSO_SETUP.md`)
+
+## Bootstrapping the first admin
+
+Set `URATEAM_ADMIN_EMAILS` (comma-separated, case-insensitive) before starting urateam:
+```
+URATEAM_ADMIN_EMAILS=alice@acme.com,bob@acme.com
+```
+
+When alice or bob logs in via SSO, their role is automatically promoted to `admin`. All other users default to `viewer`.
+
+The env var can be safely removed after initial setup — existing admins keep their role.
+
+## Managing roles
+
+### Via dashboard
+Admins see a "Users" nav entry. Go to `/users` to list users and change roles via the dropdown.
+
+### Via CLI
+On the host:
+```
+ura admin list
+ura admin grant <email> --role operator
+ura admin revoke <email>
+```
+
+`revoke` sets the role to `viewer` — the minimum privilege, not deletion.
+
+## Emergency recovery
+
+If the dashboard UI is broken or the last admin is locked out, use the CLI:
+```
+ura admin grant recovery@acme.com --role admin
+```
+
+## Guardrails
+
+- Admins cannot demote themselves (self-lockout protection)
+- The last remaining admin cannot be demoted (last-admin protection)
+- Every role change writes a `dashboard.manual_action` audit event
+
+## Troubleshooting
+
+- **"RBAC is an Enterprise feature"** → your license does not include the `rbac` flag. Upgrade or contact sales.
+- **Admin promotion didn't happen on first login** → check `URATEAM_ADMIN_EMAILS` is set and the email matches exactly (case-insensitive). Check logs for audit events.
+- **"403 Forbidden" on a route you should have access to** → check your assigned role via `ura admin list`. If the role is wrong, an admin needs to update it.
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/core/src/__tests__/rbac-integration.test.ts deploy/RBAC_SETUP.md
+git commit -m "test(rbac): end-to-end integration test and operator setup guide"
+```
+
+---
+
+## Task 14: Full build + test sweep + holistic review + CLAUDE.md + PR
+
+- [ ] **Step 1: Build**
+
+```
+cd /private/tmp/urateam/.worktrees/rbac && pnpm build
+```
+Expected: clean.
+
+- [ ] **Step 2: Full test suite**
+
+```
+pnpm test
+```
+Expected: all pass. Known-flaky `@urateam/cli` `run.test.ts` under turbo parallel load — verify standalone.
+
+- [ ] **Step 3: Integration tests**
+
+```
+pnpm test:integration
+```
+
+- [ ] **Step 4: Holistic external review**
+
+Dispatch `feature-dev:code-reviewer` with:
+- Spec: `docs/superpowers/specs/2026-04-15-rbac-design.md`
+- Plan: `docs/superpowers/plans/2026-04-15-rbac.md`
+- Diff: `git diff main...HEAD`
+
+Ask specifically about:
+- Self-lockout and last-admin guard under concurrent requests (TOCTOU window)
+- XSS on `/users` page (every user-controlled field escaped)
+- CSRF on `POST /users/:id/role` and `POST /runs/:id/retry` (do they go through the `HX-Request` middleware properly?)
+- License gate consistency (unlicensed → 404 / no-op, never silent grants)
+- Postgres parity for the `role` column migration
+- Missing guard: what if a user with `role: "viewer"` is promoted to admin while in the middle of a request? Does the middleware read a stale role?
+- Audit event coverage: every role change produces exactly one event
+- Regression on existing dashboard tests from Task 11's middleware decorations
+- Is `applyBootstrapAdmins` safe to call inside the `/auth/callback` handler without blocking login on failure?
+
+Address all high-confidence findings.
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+Append under "Key Patterns":
+```
+### RBAC / multi-user (Enterprise feature 4.4)
+- Module: `packages/core/src/rbac/` — `matrix.ts` (PERMISSION_MATRIX + canAccess), `user-role-store.ts` (setUserRole, getUserRole, listUsers, applyBootstrapAdmins), `errors.ts` (SelfDemoteError, LastAdminError)
+- Schema: added `role TEXT NOT NULL DEFAULT 'viewer'` to `dashboard_users` via MIGRATION_COLUMNS
+- Three roles: `admin`, `operator`, `viewer`. Global-only in v1 — scoped roles (per team/repo) deferred to v2 via a new `user_scope_roles` table
+- Middleware: `packages/dashboard/src/middleware/rbac.ts` — `requirePermission(action)` decorates routes, returns 403 on insufficient role, no-op when feature unlicensed
+- Bootstrap: `URATEAM_ADMIN_EMAILS` env var — comma-separated list, case-insensitive. Fire-and-forget from `/auth/callback` via `applyBootstrapAdmins`
+- Admin UI: `/users` dashboard page (admin-only) with role dropdown per user. CSRF via `HX-Request` header
+- CLI: `ura admin list/grant/revoke` — for emergency recovery and scripted management
+- Audit: four new `dashboard.manual_action` subtypes — `grant_role`, `revoke_role`, `bootstrap_admin`, `retry_run`. No new `AuditEventTypeSchema` entries
+- Write actions in v1: only `POST /runs/:id/retry` (operator+admin). Others (abort, approve, cancel) deferred to follow-up PRs reusing the same middleware
+- Guardrails: `setUserRole` rejects self-demote and last-admin-demote at the store level — every caller inherits the guards
+- Setup doc: `deploy/RBAC_SETUP.md`
+```
+
+- [ ] **Step 6: Commit CLAUDE.md, push, open PR**
+
+```
+git add CLAUDE.md
+git commit -m "docs(claude.md): rbac feature notes"
+git push -u origin feat/rbac
+gh pr create --title "feat: rbac / multi-user (enterprise 4.4)" --body "$(cat <<'EOF'
+## Summary
+- Three-role model (admin/operator/viewer) on the SSO `dashboard_users` foundation
+- Static permission matrix gates every dashboard route via `requirePermission(action)` middleware
+- Admin UI at `/users` and `ura admin list/grant/revoke` CLI for role management
+- `POST /runs/:id/retry` — the one v1 write action, gated by `runs.retry` (operator+admin)
+- `URATEAM_ADMIN_EMAILS` env var bootstraps first admins on SSO callback
+- Four new `dashboard.manual_action` audit subtypes: grant_role / revoke_role / bootstrap_admin / retry_run
+- Self-lockout and last-admin-demote guards enforced at the store level
+- Scoped roles (per team / per repo) deferred to v2 with extension-point schema documented
+
+Spec: docs/superpowers/specs/2026-04-15-rbac-design.md
+Plan: docs/superpowers/plans/2026-04-15-rbac.md
+
+## Test plan
+- [ ] pnpm test (unit)
+- [ ] pnpm test:integration
+- [ ] Manual: set URATEAM_ADMIN_EMAILS, log in, verify role=admin
+- [ ] Manual: promote second user via /users UI, log in as them, verify retry button works
+- [ ] Manual: ura admin list/grant/revoke CLI against a dev deployment
+
+## Deferred
+- Scoped roles per team/repo (v2)
+- Additional write actions (abort, approve, cancel, manual promote) — same middleware can gate them later
+- Role expiration / time-limited grants
+- Bulk role assignment / CSV import
+- "Service account" API tokens
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Every spec section is implemented by at least one task — §2 permission matrix (Task 2), §3 schema (Task 1), §4 module layout (Tasks 2–4), §5 middleware (Task 7), §6 bootstrap (Tasks 4, 8), §7 admin UI (Task 10), §8 retry endpoint (Task 9), §9 audit integration (Task 5), §10 license gate (Task 6), §11 testing (all tasks have tests), §12 migration (Task 1).
+- **Placeholders:** None. Task 3 has a deliberate ordering note about Task 5's builders — the plan first uses inline event literals and swaps them for builders in Task 5. Task 10's "POST to demote last admin" test is explicitly removed as brittle and noted as covered by Task 3's unit test.
+- **Type consistency:** `Role`, `PermissionKey`, `SetUserRoleArgs`, `PERMISSION_MATRIX` defined once in Task 2/3 and referenced consistently. Audit event builders match the event subtype strings. Middleware signature `requirePermission(action)` is stable across Tasks 7, 9, 10, 11.
+- **Known follow-up:** Task 11 decorates every existing dashboard route with `requirePermission`. If any existing test fails because it installs enterprise license but doesn't set a `user` in context, those tests need a one-line fix to add a user (the plan notes this explicitly in Step 1).

--- a/docs/superpowers/specs/2026-04-15-rbac-design.md
+++ b/docs/superpowers/specs/2026-04-15-rbac-design.md
@@ -1,0 +1,386 @@
+# Design: RBAC / multi-user (Enterprise feature 4.4)
+
+**Date**: 2026-04-15
+**Status**: Draft for review
+**Parent strategy**: `docs/superpowers/specs/2026-04-13-enterprise-tier-design.md` § 4.4
+**Scope**: Add a global role model (`admin` | `operator` | `viewer`) to the dashboard on top of feature 4.1's SSO foundation, gate every existing route by a static permission matrix, ship one new operator-gated write action (manual retry), and provide both a dashboard admin UI and a CLI for role management. License-gated by `isFeatureLicensed("rbac")`.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+- Build on feature 4.1's `dashboard_users` table with a single `role` column — no new tables in v1, schema ready to extend for scoped roles in v2
+- Define a permission matrix as **data, not code branches** — one source of truth that can be unit-tested per role × permission
+- Ship the permission model with **at least one real write action** (manual retry) so the `operator` role has concrete meaning at launch
+- Support both a `/users` admin dashboard page and a `ura admin` CLI so admins can manage roles without requiring shell access, and can recover without requiring dashboard access
+- Bootstrap the first admin deterministically via `URATEAM_ADMIN_EMAILS` env var, avoiding the chicken-and-egg problem of "nobody can promote anyone without being an admin"
+- Zero behavior change on deployments without the `rbac` license flag — the middleware is a no-op, the admin surface is 404, the CLI commands refuse
+
+### Non-goals
+- **Per-team or per-repo scoped role overrides.** Deferred to v2. The v1 schema is a single `role` column; v2 will add a `user_scope_roles` table without migrating the existing column
+- **Additional write actions** (abort, approve, cancel, manual promote). Retry is the only v1 write. The middleware can gate these later without architectural changes
+- **Bulk role assignment / CSV import.** Admins promote users one at a time
+- **Role expiration / time-limited grants.** No TTL on roles; admins must manually revoke
+- **Audit log filtered view** for role changes only. The existing audit feed with event-type filter is sufficient
+- **A "read-only dashboard" mode** for unlicensed deployments that still want to hide `/config`. Unlicensed = SSO-binary-gate only
+
+## 2. Roles and permission matrix
+
+Three roles, plus the implicit "unauthorized" state for users not yet in the `dashboard_users` table:
+
+| Route / Action | `admin` | `operator` | `viewer` |
+|---|---|---|---|
+| `GET /` redirect to `/runs` | ✓ | ✓ | ✓ |
+| `GET /runs` | ✓ | ✓ | ✓ |
+| `GET /runs/:id` | ✓ | ✓ | ✓ |
+| `GET /tokens` | ✓ | ✓ | ✓ |
+| `GET /errors` | ✓ | ✓ | ✓ |
+| `GET /audit` (feature 4.2) | ✓ | ✓ | — |
+| `GET /audit/export.csv` | ✓ | ✓ | — |
+| `GET /cost` (feature 4.5) | ✓ | ✓ | — |
+| `GET /cost/export.csv` | ✓ | ✓ | — |
+| `GET /coordination` | ✓ | ✓ | — |
+| `GET /config` | ✓ | — | — |
+| `POST /runs/:id/retry` (**new**) | ✓ | ✓ | — |
+| `GET /users` (**new**) | ✓ | — | — |
+| `POST /users/:id/role` (**new**) | ✓ | — | — |
+| `POST /auth/logout` | ✓ | ✓ | ✓ |
+
+Non-obvious reasoning:
+- **Audit, cost, coordination are operator-only.** Viewers get the run feed (day-to-day monitoring) but not the governance surface.
+- **Errors is viewer-visible** — it's an operational health view, weird to hide.
+- **Config is admin-only** because the view reveals secrets (Slack webhook, GitHub App IDs, WorkOS keys). Operators who need a config change ask an admin.
+- **Retry is operator+admin** — the whole reason the operator role exists.
+- **User management is admin-only.** Only admins assign roles.
+
+## 3. Data model
+
+### 3.1 Schema change
+
+Add one column to the existing `dashboard_users` table (from feature 4.1):
+
+```ts
+// packages/core/src/db/schema.ts
+export const dashboardUsers = sqliteTable("dashboard_users", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  workosUserId: text("workos_user_id"),
+  createdAt: crossTimestamp("created_at").notNull().$defaultFn(() => new Date()),
+  lastLoginAt: crossTimestamp("last_login_at"),
+  role: text("role").notNull().default("viewer"),   // NEW
+});
+```
+
+### 3.2 Migration
+
+Use the existing `MIGRATION_COLUMNS` pattern in `packages/core/src/db/client.ts` — add one entry that generates driver-specific ALTER TABLE statements for both SQLite and Postgres:
+
+```ts
+{
+  table: "dashboard_users",
+  column: "role",
+  sqliteType: "TEXT NOT NULL DEFAULT 'viewer'",
+  pgType: "TEXT NOT NULL DEFAULT 'viewer'",
+}
+```
+
+Also extend the `getCreateTablesDDL()` template so fresh installs get the column without depending on the ALTER path.
+
+No separate `008_rbac.sql` / `009_rbac.sql` migration file needed — the `MIGRATION_COLUMNS` mechanism covers it. (Unlike features 4.1, 4.2, 4.5 which added new tables and needed file-based migrations.)
+
+### 3.3 v2 extension point (documented, not implemented)
+
+When scoped roles arrive, a new table is added:
+```ts
+userScopeRoles = sqliteTable("user_scope_roles", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull().references(() => dashboardUsers.id),
+  scopeKind: text("scope_kind").notNull(),       // "team" | "repo"
+  scopeId: text("scope_id").notNull(),           // Linear team id or repo URL
+  role: text("role").notNull(),
+});
+```
+
+Effective-role computation becomes `max(user.role, scopeOverride)` where `max` respects the lattice `viewer < operator < admin`. The v1 `dashboard_users.role` column remains the base role — no breaking migration.
+
+## 4. Module layout
+
+New directory `packages/core/src/rbac/`:
+
+```
+rbac/
+  index.ts            — barrel
+  types.ts            — Role ("admin" | "operator" | "viewer"), PermissionKey, PermissionMatrix
+  matrix.ts           — PERMISSION_MATRIX constant + canAccess(role, action) pure function
+  user-role-store.ts  — setUserRole, getUserRole, listUsers, applyBootstrapAdmins
+```
+
+Each file has one responsibility. `matrix.ts` is pure data + one pure function. `user-role-store.ts` owns all DB writes to the `role` column.
+
+### 4.1 `matrix.ts`
+
+```ts
+import type { Role } from "./types.js";
+
+export const PERMISSION_MATRIX = {
+  "runs.view":         ["admin", "operator", "viewer"],
+  "runs.retry":        ["admin", "operator"],
+  "tokens.view":       ["admin", "operator", "viewer"],
+  "audit.view":        ["admin", "operator"],
+  "audit.export":      ["admin", "operator"],
+  "cost.view":         ["admin", "operator"],
+  "cost.export":       ["admin", "operator"],
+  "errors.view":       ["admin", "operator", "viewer"],
+  "coordination.view": ["admin", "operator"],
+  "config.view":       ["admin"],
+  "users.view":        ["admin"],
+  "users.manage":      ["admin"],
+} as const satisfies Record<string, readonly Role[]>;
+
+export type PermissionKey = keyof typeof PERMISSION_MATRIX;
+
+export function canAccess(role: Role, action: PermissionKey): boolean {
+  return (PERMISSION_MATRIX[action] as readonly Role[]).includes(role);
+}
+```
+
+One source of truth. Every middleware call, every test, every role assignment validation reads from the same table.
+
+### 4.2 `user-role-store.ts`
+
+```ts
+export async function setUserRole(
+  db: AnyDb,
+  args: { userId: string; newRole: Role; actorUserId: string; reason?: string },
+): Promise<void>;
+
+export async function getUserRole(db: AnyDb, userId: string): Promise<Role | null>;
+
+export async function listUsers(
+  db: AnyDb,
+): Promise<Array<{ id: string; email: string; role: Role; lastLoginAt: Date | null }>>;
+
+export async function applyBootstrapAdmins(
+  db: AnyDb,
+  email: string,
+  userId: string,
+  envAdminList: string | undefined,
+): Promise<boolean>;  // returns true if role was changed
+```
+
+**`setUserRole` guardrails (enforced inside the helper so every caller inherits them):**
+1. **Self-lockout prevention:** if `args.userId === args.actorUserId && args.newRole !== "admin"`, throw `SelfDemoteError`
+2. **Last-admin prevention:** if the target is currently `admin` and `args.newRole !== "admin"`, run a `SELECT COUNT(*) WHERE role = 'admin'` query in the same transaction. If the count would drop to zero, throw `LastAdminError`
+3. **Audit event:** after successful update, emit `dashboardGrantRoleEvent` (or `dashboardRevokeRoleEvent` if demoting to viewer) via `logAuditEvent`
+4. **Idempotent:** setting a role to its current value is a no-op (no audit event, no DB write)
+
+**`applyBootstrapAdmins` logic:**
+1. If `envAdminList` is absent or empty, return `false`
+2. Split on `,`, trim, lowercase each entry
+3. If the normalized `email` is in the list AND the current user's role is not already `admin`, call `setUserRole({userId, newRole: "admin", actorUserId: "system"})`
+4. Emit a distinct audit event subtype `action: "bootstrap_admin"` so the audit log shows "system granted admin to X via env var"
+
+Called from `/auth/callback` right after `upsertUser` succeeds. Fire-and-forget with try/catch (a bootstrap failure must not block login).
+
+## 5. Middleware
+
+New file `packages/dashboard/src/middleware/rbac.ts`:
+
+```ts
+import type { MiddlewareHandler } from "hono";
+import { canAccess, type PermissionKey } from "@urateam/core";
+import { isFeatureLicensed } from "@urateam/core";
+
+export function requirePermission(action: PermissionKey): MiddlewareHandler {
+  return async (c, next) => {
+    // Feature-off: no gating (Pro/OSS unchanged)
+    if (!isFeatureLicensed("rbac")) return next();
+
+    const user = c.get("user") as { id: string; role: string } | undefined;
+    if (!user) return c.text("Unauthorized", 401);  // SSO middleware should have caught this
+
+    if (!canAccess(user.role as any, action)) {
+      return c.html(renderForbidden(user.role, action), 403);
+    }
+    return next();
+  };
+}
+```
+
+Each existing dashboard route picks up a one-line decoration:
+```ts
+app.get("/audit", requirePermission("audit.view"), existingAuditHandler);
+app.get("/audit/export.csv", requirePermission("audit.export"), existingCsvHandler);
+app.get("/cost", requirePermission("cost.view"), existingCostHandler);
+app.get("/config", requirePermission("config.view"), existingConfigHandler);
+app.post("/runs/:id/retry", requirePermission("runs.retry"), retryHandler);
+```
+
+Routes that are viewer-accessible (`/runs`, `/tokens`, `/errors`) also get the decoration for consistency (`requirePermission("runs.view")` etc.) even though the matrix grants viewer access — this keeps all gating in one place.
+
+### 5.1 Forbidden page
+
+Minimal HTML: "Your account (`<email>`, role `<role>`) does not have permission to access this page. Contact your administrator." No link to `/` — the user might not have access to `/` either. `<a href="/auth/logout">Sign out</a>` always visible. All fields `escapeHtml`'d.
+
+## 6. Bootstrap
+
+### 6.1 Env var
+`URATEAM_ADMIN_EMAILS=alice@acme.com,bob@acme.com` (comma-separated, case-insensitive). Read once at boot and passed to each SSO callback via the config.
+
+### 6.2 CLI commands
+
+`packages/cli/src/commands/admin.ts` — three subcommands:
+
+```
+ura admin list
+ura admin grant <email> [--role admin|operator|viewer]    (default: operator)
+ura admin revoke <email>                                  (sets role to viewer)
+```
+
+All three:
+- Open the DB via `createDb({ connectionString: DATABASE_URL })`
+- Call `setUserRole()` from the core barrel
+- Write `dashboard.manual_action` audit events with `actor: "cli:<os_user>"`, `actorType: "cli"`
+- Refuse to run with a clear error when `!isFeatureLicensed("rbac")`
+- Exit non-zero on validation errors
+
+The `revoke` command sets the target's role to `viewer` rather than deleting the row — the row is still referenced from the session table, and viewer is the minimum privilege, not absence of privilege.
+
+## 7. `/users` admin UI
+
+New route `packages/dashboard/src/routes/users.ts`:
+- `GET /users` — renders a `<table>` of `{email, role dropdown, last_login_at}` rows. Every field through `escapeHtml`. Gated by `requirePermission("users.view")`.
+- `POST /users/:id/role` — accepts form body `{role: "admin"|"operator"|"viewer"}`, validates against the three-role enum (zod), calls `setUserRole(db, {userId, newRole, actorUserId: session.user.id})`, redirects to `/users`. Gated by `requirePermission("users.manage")`. CSRF via the existing `HX-Request` header middleware (feature 4.1 BEC-103).
+
+New view `packages/dashboard/src/views/users.ts`:
+- Table rows: `<tr>` per user with HTMX-driven `<select hx-post="/users/{id}/role">`
+- Self-lockout guard: the current user's own row disables the dropdown (label "You" next to their email)
+- Last-admin guard: if the user is the only admin, their dropdown options exclude `operator` and `viewer` on the client side (server-side `setUserRole` also rejects)
+
+Navigation: add "Users" to `views/layout.ts` nav, visible only when `user.role === "admin"`.
+
+## 8. Retry endpoint
+
+New route `POST /runs/:id/retry` in `packages/dashboard/src/routes/runs.ts` (the runs router already exists):
+1. `requirePermission("runs.retry")` middleware
+2. Load the run by id
+3. If `status` is not `"failed"` or `"retriable"`, return 409 with `"cannot retry a run in status X"`
+4. Call `runner.resume(runId)` when the run has a `resumePayload`, else `runner.start(...)` with the stored issue context
+5. Emit `dashboardManualRetryEvent({runId, issueId, actorUserId, actorEmail})`
+6. Redirect back to `/runs/:id` with an HTMX success banner
+
+**UI surface:** new "Retry" button on the run detail page (`views/run-detail.ts`), rendered only when:
+- `runner.isFeatureLicensed("rbac") && canAccess(session.user.role, "runs.retry")`
+- `run.status in ("failed", "retriable")`
+
+The button uses `hx-post="/runs/{id}/retry"` and reloads the page on success.
+
+## 9. Audit integration
+
+**No new event types in `AuditEventTypeSchema`.** Feature 4.2 reserved `dashboard.manual_action` for this exact use case. The `payload.action` field distinguishes subtypes:
+
+| payload.action | Fired from | Payload shape |
+|---|---|---|
+| `"grant_role"` | `setUserRole` from dashboard or CLI | `{targetUserId, targetEmail, oldRole, newRole, actorUserId}` |
+| `"revoke_role"` | `setUserRole` when `newRole === "viewer"` | same as grant_role |
+| `"bootstrap_admin"` | `applyBootstrapAdmins` on SSO callback | `{targetUserId, targetEmail, envVarMatched: true}` |
+| `"retry_run"` | `/runs/:id/retry` handler | `{runId, issueId, previousStatus, actorUserId}` |
+
+New builder functions in `packages/core/src/audit/events.ts`:
+- `dashboardGrantRoleEvent(args)` — builds a `dashboard.manual_action` event
+- `dashboardRevokeRoleEvent(args)` — same, for demotions
+- `dashboardBootstrapAdminEvent(args)` — for the env-var path
+- `dashboardRetryRunEvent(args)` — for retry
+
+All flow through the existing license-gated `logAuditEvent`.
+
+## 10. License gate interaction
+
+- `isFeatureLicensed("rbac") === false`:
+  - `requirePermission` middleware short-circuits to `next()`, no gating
+  - `/users` route returns 404
+  - `POST /runs/:id/retry` returns 404
+  - CLI `ura admin` commands print "RBAC is an Enterprise feature" and exit 1
+  - `applyBootstrapAdmins` is a no-op (no silent admin grants)
+- `isFeatureLicensed("rbac") === true && !isFeatureLicensed("sso")`:
+  - Theoretically impossible in a valid license — both are Enterprise-tier
+  - Defensive behavior: log a pino warning at startup, treat RBAC as off (no sessions means no users means no roles to attach)
+- `isFeatureLicensed("rbac") === true && isFeatureLicensed("sso") === true`:
+  - Full feature active
+- OSS / Pro deployments: Basic Auth is unchanged, no user table, no role column read (the `dashboard_users` table is SSO-only so it simply doesn't exist in Basic Auth deployments)
+
+## 11. Testing strategy
+
+### 11.1 Unit (`packages/core/src/__tests__/rbac/`)
+- `matrix.test.ts` — every role × every permission combination asserted against the spec's matrix
+- `user-role-store.test.ts` — setUserRole happy path, self-lockout, last-admin guard, idempotent no-op, grant vs revoke audit event shape, listUsers ordering
+- `bootstrap.test.ts` — `applyBootstrapAdmins` with match / no-match / empty env / multiple emails / already-admin / case insensitive
+
+### 11.2 Middleware (`packages/dashboard/src/__tests__/rbac-middleware.test.ts`)
+- `requirePermission("runs.view")` — admin/operator/viewer all pass; no session → 401
+- `requirePermission("audit.view")` — admin/operator pass, viewer gets 403
+- `requirePermission("config.view")` — only admin passes
+- Feature unlicensed → all roles pass (no-op middleware)
+
+### 11.3 Routes (`packages/dashboard/src/__tests__/users-routes.test.ts`)
+- `GET /users` unlicensed → 404
+- `GET /users` as viewer/operator → 403
+- `GET /users` as admin → 200 with user list
+- `POST /users/:id/role` as non-admin → 403
+- `POST /users/:id/role` as admin, valid → 200 + audit event
+- `POST /users/:id/role` self-demote → 400
+- `POST /users/:id/role` last-admin demote → 400
+- `POST /users/:id/role` invalid role value → 400
+
+### 11.4 Retry endpoint (`packages/dashboard/src/__tests__/retry-route.test.ts`)
+- Unlicensed → 404
+- Viewer → 403
+- Operator on a failed run → 200 + audit event + runner.resume called
+- Operator on a completed run → 409
+- Operator on a non-existent run → 404
+
+### 11.5 CLI (`packages/cli/src/__tests__/admin-commands.test.ts`)
+- `ura admin list` happy path, unlicensed refusal, correct table format
+- `ura admin grant <email> --role operator` → DB row updated + audit event
+- `ura admin revoke <email>` → role is viewer
+- `ura admin grant <unknown-email>` → clear error, exit 1
+
+### 11.6 End-to-end (`packages/core/src/__tests__/rbac-integration.test.ts`)
+- SSO callback → `URATEAM_ADMIN_EMAILS` matches → user becomes admin → audit event
+- Admin promotes second user to operator → operator can retry a failed run → audit event chain is complete
+- Operator tries to access `/users` → 403
+
+## 12. Migration and rollout
+
+### 12.1 Schema
+- `MIGRATION_COLUMNS` entry adds `role TEXT NOT NULL DEFAULT 'viewer'` on both drivers
+- Fresh installs get the column via `getCreateTablesDDL()` template
+- Existing SSO deployments: all current users default to `viewer` on migration — the `URATEAM_ADMIN_EMAILS` env var promotes them on their next login
+
+### 12.2 Feature flag
+- `rbac` added to the Enterprise feature set in `license.ts`
+- OSS / Pro deployments unchanged (they don't use SSO, no dashboard_users table)
+
+### 12.3 Rollout sequence for an existing Enterprise customer
+1. Deploy the new binary with the migration — all current users default to `viewer`
+2. **Before the dashboard comes up**, the operator sets `URATEAM_ADMIN_EMAILS` in their env for the bootstrap admins
+3. Bootstrap admins log in → their role is auto-promoted to `admin`
+4. They promote operators via `/users` UI
+5. The remaining viewers stay viewers
+
+The `URATEAM_ADMIN_EMAILS` env var can be removed after initial setup — existing admins persist, and new users default to viewer.
+
+### 12.4 Operator setup guide
+Append to `deploy/SSO_SETUP.md` (or a new `deploy/RBAC_SETUP.md`) a short section explaining the three roles, the bootstrap env var, and the `/users` admin page.
+
+## 13. Open questions (deferred)
+
+- **Scoped roles** (per-team, per-repo) — deferred to v2 with the extension-point schema documented in § 3.3
+- **Additional write actions** (abort, approve, cancel, manual promote) — same middleware gates them; add in follow-up PRs
+- **Bulk role assignment / CSV import** — wait for a customer with >20 users to ask
+- **Role expiration / time-limited grants** — security feature for larger deployments; defer
+- **"Read-only dashboard" mode** for unlicensed deployments that want `/config` hidden — conflates RBAC with feature gating
+- **"Service account" roles** for machine-to-machine dashboard access (API tokens) — separate feature, no API exists yet
+- **Last-admin guard under concurrent demotions** — the `SELECT COUNT` + UPDATE pattern has a TOCTOU window. v1 uses a single transaction which SQLite and Postgres both serialize; a rare race is possible but the guard is best-effort and the CLI recovery path exists as a fallback

--- a/packages/cli/src/__tests__/admin-commands.test.ts
+++ b/packages/cli/src/__tests__/admin-commands.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "@urateam/core";
+import { dashboardUsers } from "@urateam/core/dist/db/schema.js";
+import {
+  runAdminList,
+  runAdminGrant,
+  runAdminRevoke,
+} from "../commands/admin.js";
+import {
+  installTestProLicense,
+  restoreLicense,
+} from "./helpers/license.js";
+
+let db: any;
+let logs: string[];
+const log = (s: string) => {
+  logs.push(s);
+};
+
+beforeEach(async () => {
+  logs = [];
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values([
+    {
+      id: "u_admin",
+      email: "admin@b.com",
+      name: "Admin",
+      workosUserId: null,
+      role: "admin",
+    },
+    {
+      id: "u_op",
+      email: "op@b.com",
+      name: "Op",
+      workosUserId: null,
+      role: "operator",
+    },
+  ]);
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+describe("ura admin commands", () => {
+  it("list prints all users", async () => {
+    await runAdminList({ db, log });
+    expect(logs.some((l) => l.includes("admin@b.com"))).toBe(true);
+    expect(logs.some((l) => l.includes("op@b.com"))).toBe(true);
+  });
+
+  it("grant promotes by email", async () => {
+    await runAdminGrant({ db, email: "op@b.com", newRole: "admin", log });
+    const rows = await db.select().from(dashboardUsers);
+    expect(rows.find((u: any) => u.id === "u_op").role).toBe("admin");
+  });
+
+  it("grant with unknown email errors clearly", async () => {
+    await expect(
+      runAdminGrant({
+        db,
+        email: "ghost@nowhere.com",
+        newRole: "admin",
+        log,
+      }),
+    ).rejects.toThrow(/user not found/i);
+  });
+
+  it("revoke sets role to viewer", async () => {
+    // First promote op to admin so a revoke → viewer is a real change
+    await runAdminGrant({ db, email: "op@b.com", newRole: "admin", log });
+    await runAdminRevoke({ db, email: "op@b.com", log });
+    const rows = await db.select().from(dashboardUsers);
+    expect(rows.find((u: any) => u.id === "u_op").role).toBe("viewer");
+  });
+
+  it("refuses when feature is unlicensed", async () => {
+    await restoreLicense();
+    await expect(runAdminList({ db, log })).rejects.toThrow(/enterprise/i);
+  });
+});

--- a/packages/cli/src/__tests__/helpers/license.ts
+++ b/packages/cli/src/__tests__/helpers/license.ts
@@ -1,0 +1,75 @@
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { _resetLicenseCache } from "@urateam/core/dist/license.js";
+
+function b64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(privateKey: KeyObject, payload: object): string {
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const headerB64 = b64url(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = b64url(Buffer.from(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = sign(null, Buffer.from(signingInput), privateKey);
+  return `${signingInput}.${b64url(sig)}`;
+}
+
+let savedPublicKey: string | undefined;
+let savedEnv: string | undefined;
+
+export async function installTestProLicense(
+  tier: "pro" | "enterprise" = "enterprise",
+): Promise<void> {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyB64 = Buffer.from(
+    publicKey.export({ format: "der", type: "spki" }),
+  ).toString("base64");
+
+  const mod = await import("@urateam/core/dist/license-public-key.js");
+  if (savedPublicKey === undefined) {
+    savedPublicKey = (mod as { LICENSE_PUBLIC_KEY_DER_B64: string })
+      .LICENSE_PUBLIC_KEY_DER_B64;
+  }
+  Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+    value: publicKeyB64,
+    writable: true,
+    configurable: true,
+  });
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = makeJwt(privateKey, {
+    iss: "urateam.dev",
+    sub: "cust_test",
+    tier,
+    seats: 25,
+    iat: now,
+    exp: now + 86_400,
+  });
+
+  if (savedEnv === undefined) savedEnv = process.env.URATEAM_LICENSE_KEY;
+  process.env.URATEAM_LICENSE_KEY = jwt;
+  _resetLicenseCache();
+}
+
+export async function restoreLicense(): Promise<void> {
+  if (savedPublicKey !== undefined) {
+    const mod = await import("@urateam/core/dist/license-public-key.js");
+    Object.defineProperty(mod, "LICENSE_PUBLIC_KEY_DER_B64", {
+      value: savedPublicKey,
+      writable: true,
+      configurable: true,
+    });
+    savedPublicKey = undefined;
+  }
+  if (savedEnv === undefined) {
+    delete process.env.URATEAM_LICENSE_KEY;
+  } else {
+    process.env.URATEAM_LICENSE_KEY = savedEnv;
+    savedEnv = undefined;
+  }
+  _resetLicenseCache();
+}

--- a/packages/cli/src/commands/admin.ts
+++ b/packages/cli/src/commands/admin.ts
@@ -1,0 +1,146 @@
+import { Command } from "commander";
+import * as os from "node:os";
+import {
+  createDb,
+  isFeatureLicensed,
+  listUsers,
+  setUserRole,
+  type Role,
+} from "@urateam/core";
+
+export interface AdminDeps {
+  db: any;
+  log: (msg: string) => void;
+}
+
+function requireLicensed(): void {
+  if (!isFeatureLicensed("rbac")) {
+    throw new Error(
+      "RBAC is an Enterprise feature. Upgrade your license to use 'ura admin' commands.",
+    );
+  }
+}
+
+function actorId(): string {
+  try {
+    return `cli:${os.userInfo().username}`;
+  } catch {
+    return "cli:unknown";
+  }
+}
+
+export async function runAdminList(deps: AdminDeps): Promise<void> {
+  requireLicensed();
+  const users = await listUsers(deps.db);
+  deps.log("EMAIL                            ROLE       LAST_LOGIN");
+  for (const u of users) {
+    const email = u.email.padEnd(32).slice(0, 32);
+    const role = u.role.padEnd(10).slice(0, 10);
+    const ll = u.lastLoginAt ? u.lastLoginAt.toISOString() : "(never)";
+    deps.log(`${email} ${role} ${ll}`);
+  }
+}
+
+export async function runAdminGrant(
+  args: AdminDeps & { email: string; newRole: Role },
+): Promise<void> {
+  requireLicensed();
+  const normalized = args.email.trim().toLowerCase();
+  const users = await listUsers(args.db);
+  const target = users.find((u) => u.email.toLowerCase() === normalized);
+  if (!target) {
+    throw new Error(`user not found: ${args.email}`);
+  }
+
+  await setUserRole(args.db, {
+    userId: target.id,
+    newRole: args.newRole,
+    actorUserId: actorId(),
+  });
+  args.log(`Updated ${target.email} → ${args.newRole}`);
+}
+
+export async function runAdminRevoke(
+  args: AdminDeps & { email: string },
+): Promise<void> {
+  await runAdminGrant({ ...args, newRole: "viewer" });
+}
+
+// ---------------- commander wiring ----------------
+
+async function openDb(): Promise<any> {
+  const conn = process.env.DATABASE_URL;
+  if (!conn) {
+    throw new Error(
+      "DATABASE_URL is not set. Set it to your urateam database (e.g. postgres://... or file:./ura.db).",
+    );
+  }
+  return createDb({ connectionString: conn });
+}
+
+function fail(err: unknown): never {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
+export const adminCommand = new Command("admin")
+  .description("Manage dashboard user roles (Enterprise)")
+  .addCommand(
+    new Command("list")
+      .description("List all dashboard users and their roles")
+      .action(async () => {
+        try {
+          const db = await openDb();
+          await runAdminList({ db, log: (s) => console.log(s) });
+        } catch (err) {
+          fail(err);
+        }
+      }),
+  )
+  .addCommand(
+    new Command("grant")
+      .description("Grant a role to a user (by email)")
+      .argument("<email>", "Target user email")
+      .option(
+        "--role <role>",
+        "New role: admin | operator | viewer",
+        "operator",
+      )
+      .action(async (email: string, opts: { role: string }) => {
+        if (
+          opts.role !== "admin" &&
+          opts.role !== "operator" &&
+          opts.role !== "viewer"
+        ) {
+          fail(new Error(`invalid --role: '${opts.role}'`));
+        }
+        try {
+          const db = await openDb();
+          await runAdminGrant({
+            db,
+            email,
+            newRole: opts.role as Role,
+            log: (s) => console.log(s),
+          });
+        } catch (err) {
+          fail(err);
+        }
+      }),
+  )
+  .addCommand(
+    new Command("revoke")
+      .description("Revoke privileges — sets role to viewer")
+      .argument("<email>", "Target user email")
+      .action(async (email: string) => {
+        try {
+          const db = await openDb();
+          await runAdminRevoke({
+            db,
+            email,
+            log: (s) => console.log(s),
+          });
+        } catch (err) {
+          fail(err);
+        }
+      }),
+  );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import { startCommand } from "./commands/start.js";
 import { migrateCommand } from "./commands/migrate.js";
 import { getPackageVersion } from "./version.js";
 import { licenseCommand } from "./commands/license.js";
+import { adminCommand } from "./commands/admin.js";
 
 const program = new Command();
 
@@ -41,5 +42,6 @@ program.addCommand(configCommand);
 program.addCommand(startCommand);
 program.addCommand(migrateCommand);
 program.addCommand(licenseCommand, { hidden: true });
+program.addCommand(adminCommand);
 
 program.parse();

--- a/packages/core/src/__tests__/audit/rbac-events.test.ts
+++ b/packages/core/src/__tests__/audit/rbac-events.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  dashboardGrantRoleEvent,
+  dashboardRevokeRoleEvent,
+  dashboardBootstrapAdminEvent,
+  dashboardRetryRunEvent,
+} from "../../audit/events.js";
+import { AuditEventSchema } from "../../types.js";
+
+describe("rbac audit event builders", () => {
+  it("dashboardGrantRoleEvent", () => {
+    const evt = dashboardGrantRoleEvent({
+      targetUserId: "u_1",
+      targetEmail: "a@b.com",
+      oldRole: "viewer",
+      newRole: "operator",
+      actorUserId: "u_admin",
+      actorEmail: "admin@b.com",
+    });
+    const p = AuditEventSchema.parse(evt);
+    expect(p.eventType).toBe("dashboard.manual_action");
+    expect(p.actor).toBe("dashboard:admin@b.com");
+    expect((p.payload as any).action).toBe("grant_role");
+    expect((p.payload as any).oldRole).toBe("viewer");
+    expect((p.payload as any).newRole).toBe("operator");
+  });
+
+  it("dashboardRevokeRoleEvent", () => {
+    const evt = dashboardRevokeRoleEvent({
+      targetUserId: "u_1",
+      targetEmail: "a@b.com",
+      oldRole: "operator",
+      newRole: "viewer",
+      actorUserId: "u_admin",
+      actorEmail: "admin@b.com",
+    });
+    expect((evt.payload as any).action).toBe("revoke_role");
+  });
+
+  it("dashboardBootstrapAdminEvent", () => {
+    const evt = dashboardBootstrapAdminEvent({
+      targetUserId: "u_1",
+      targetEmail: "alice@acme.com",
+    });
+    expect(evt.eventType).toBe("dashboard.manual_action");
+    expect(evt.actor).toBe("system");
+    expect(evt.actorType).toBe("system");
+    expect((evt.payload as any).action).toBe("bootstrap_admin");
+  });
+
+  it("dashboardRetryRunEvent", () => {
+    const evt = dashboardRetryRunEvent({
+      runId: "run_1",
+      issueId: "BEC-42",
+      previousStatus: "failed",
+      actorUserId: "u_op",
+      actorEmail: "op@b.com",
+    });
+    expect((evt.payload as any).action).toBe("retry_run");
+    expect(evt.runId).toBe("run_1");
+    expect(evt.issueId).toBe("BEC-42");
+    expect(evt.actor).toBe("dashboard:op@b.com");
+  });
+});

--- a/packages/core/src/__tests__/auth/user-role-round-trip.test.ts
+++ b/packages/core/src/__tests__/auth/user-role-round-trip.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../../db/client.js";
+import { dashboardUsers } from "../../db/schema.js";
+import { getUserById } from "../../auth/user-store.js";
+
+describe("getUserById role round-trip", () => {
+  it("returns role when admin", async () => {
+    const db = (await createDb({ connectionString: ":memory:" })) as any;
+    await db.insert(dashboardUsers).values({
+      id: "u_1",
+      email: "a@b.com",
+      name: null,
+      workosUserId: null,
+      role: "admin",
+    });
+    const user = await getUserById(db, "u_1");
+    expect(user?.role).toBe("admin");
+  });
+
+  it("defaults to viewer when role is missing", async () => {
+    const db = (await createDb({ connectionString: ":memory:" })) as any;
+    await db.insert(dashboardUsers).values({
+      id: "u_1",
+      email: "a@b.com",
+      name: null,
+      workosUserId: null,
+    });
+    const user = await getUserById(db, "u_1");
+    expect(user?.role).toBe("viewer");
+  });
+});

--- a/packages/core/src/__tests__/db-rbac-schema.test.ts
+++ b/packages/core/src/__tests__/db-rbac-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { createDb } from "../db/client.js";
+import { dashboardUsers } from "../db/schema.js";
+import { sql } from "drizzle-orm";
+
+describe("dashboard_users.role column", () => {
+  it("includes role in the table schema with default 'viewer'", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    const cols = (db as any).all(sql`PRAGMA table_info(dashboard_users)`) as Array<{name: string}>;
+    expect(cols.map(c => c.name).sort()).toContain("role");
+  });
+
+  it("defaults new rows to 'viewer'", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_1", email: "a@b.com", name: "A B", workosUserId: "wu_1",
+    });
+    const rows = await (db as any).select().from(dashboardUsers);
+    expect(rows[0].role).toBe("viewer");
+  });
+
+  it("accepts explicit role values", async () => {
+    const db = await createDb({ connectionString: ":memory:" });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_admin", email: "admin@b.com", name: null, workosUserId: null, role: "admin",
+    });
+    await (db as any).insert(dashboardUsers).values({
+      id: "u_op", email: "op@b.com", name: null, workosUserId: null, role: "operator",
+    });
+    const rows = await (db as any).select().from(dashboardUsers);
+    const roles = rows.map((r: any) => r.role).sort();
+    expect(roles).toEqual(["admin", "operator"]);
+  });
+});

--- a/packages/core/src/__tests__/db-sso-schema.test.ts
+++ b/packages/core/src/__tests__/db-sso-schema.test.ts
@@ -15,6 +15,7 @@ describe("sso schema", () => {
       "id",
       "last_login_at",
       "name",
+      "role",
       "workos_user_id",
     ]);
     const sessionCols = (db as any).all(

--- a/packages/core/src/__tests__/rbac-integration.test.ts
+++ b/packages/core/src/__tests__/rbac-integration.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../db/client.js";
+import { dashboardUsers, auditEvents } from "../db/schema.js";
+import {
+  setUserRole,
+  applyBootstrapAdmins,
+  canAccess,
+  listUsers,
+} from "../rbac/index.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+describe("rbac end-to-end flow", () => {
+  it("bootstrap → promote → permission chain", async () => {
+    // 1. First user logs in, bootstrap promotes to admin
+    await db.insert(dashboardUsers).values({
+      id: "u_alice",
+      email: "alice@acme.com",
+      name: "Alice",
+      workosUserId: null,
+    });
+    const promoted = await applyBootstrapAdmins(
+      db,
+      "alice@acme.com",
+      "u_alice",
+      "alice@acme.com",
+    );
+    expect(promoted).toBe(true);
+
+    // 2. Alice logs in, role is admin, she can view config
+    const users = await listUsers(db);
+    const alice = users.find((u) => u.id === "u_alice")!;
+    expect(alice.role).toBe("admin");
+    expect(canAccess(alice.role, "config.view")).toBe(true);
+
+    // 3. Second user joins (viewer by default), alice promotes to operator
+    await db.insert(dashboardUsers).values({
+      id: "u_bob",
+      email: "bob@acme.com",
+      name: "Bob",
+      workosUserId: null,
+      role: "viewer",
+    });
+    await setUserRole(db, {
+      userId: "u_bob",
+      newRole: "operator",
+      actorUserId: "u_alice",
+    });
+
+    // 4. Bob can now retry but can't manage users or view config
+    const updated = await listUsers(db);
+    const bob = updated.find((u) => u.id === "u_bob")!;
+    expect(bob.role).toBe("operator");
+    expect(canAccess(bob.role, "runs.retry")).toBe(true);
+    expect(canAccess(bob.role, "users.manage")).toBe(false);
+    expect(canAccess(bob.role, "config.view")).toBe(false);
+
+    // 5. Audit trail contains bootstrap + grant events
+    const events = await db.select().from(auditEvents);
+    const bootstrap = events.find(
+      (e: any) => JSON.parse(e.payload).action === "bootstrap_admin",
+    );
+    const grant = events.find(
+      (e: any) => JSON.parse(e.payload).action === "grant_role",
+    );
+    expect(bootstrap).toBeDefined();
+    expect(grant).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/rbac-license.test.ts
+++ b/packages/core/src/__tests__/rbac-license.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { _resetLicenseCache, isFeatureLicensed } from "../license.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+afterEach(async () => {
+  _resetLicenseCache();
+  await restoreLicense();
+});
+
+describe("rbac feature flag", () => {
+  it("licensed at enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    expect(isFeatureLicensed("rbac")).toBe(true);
+  });
+
+  it("not licensed at pro tier", async () => {
+    await installTestProLicense("pro");
+    expect(isFeatureLicensed("rbac")).toBe(false);
+  });
+
+  it("not licensed without a license", async () => {
+    expect(isFeatureLicensed("rbac")).toBe(false);
+  });
+
+  it("rbac module is re-exported from @urateam/core", async () => {
+    const mod = await import("../index.js");
+    expect(typeof (mod as any).canAccess).toBe("function");
+    expect(typeof (mod as any).setUserRole).toBe("function");
+    expect(typeof (mod as any).applyBootstrapAdmins).toBe("function");
+  });
+});

--- a/packages/core/src/__tests__/rbac/bootstrap.test.ts
+++ b/packages/core/src/__tests__/rbac/bootstrap.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { dashboardUsers, auditEvents } from "../../db/schema.js";
+import {
+  applyBootstrapAdmins,
+  getUserRole,
+} from "../../rbac/user-role-store.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values({
+    id: "u_1",
+    email: "alice@acme.com",
+    name: "Alice",
+    workosUserId: null,
+    role: "viewer",
+  });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+describe("applyBootstrapAdmins", () => {
+  it("promotes matching email to admin", async () => {
+    const changed = await applyBootstrapAdmins(
+      db,
+      "alice@acme.com",
+      "u_1",
+      "alice@acme.com,bob@acme.com",
+    );
+    expect(changed).toBe(true);
+    expect(await getUserRole(db, "u_1")).toBe("admin");
+  });
+
+  it("is case-insensitive", async () => {
+    const changed = await applyBootstrapAdmins(
+      db,
+      "ALICE@ACME.COM",
+      "u_1",
+      "Alice@Acme.com",
+    );
+    expect(changed).toBe(true);
+    expect(await getUserRole(db, "u_1")).toBe("admin");
+  });
+
+  it("handles whitespace and empty entries in env list", async () => {
+    const changed = await applyBootstrapAdmins(
+      db,
+      "alice@acme.com",
+      "u_1",
+      " ,alice@acme.com , ",
+    );
+    expect(changed).toBe(true);
+  });
+
+  it("returns false when no list is configured", async () => {
+    expect(
+      await applyBootstrapAdmins(db, "alice@acme.com", "u_1", undefined),
+    ).toBe(false);
+    expect(await getUserRole(db, "u_1")).toBe("viewer");
+  });
+
+  it("returns false when email does not match", async () => {
+    expect(
+      await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "bob@acme.com"),
+    ).toBe(false);
+    expect(await getUserRole(db, "u_1")).toBe("viewer");
+  });
+
+  it("is idempotent — already-admin is not re-promoted", async () => {
+    await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "alice@acme.com");
+    const before = (await db.select().from(auditEvents)).length;
+    const result = await applyBootstrapAdmins(
+      db,
+      "alice@acme.com",
+      "u_1",
+      "alice@acme.com",
+    );
+    expect(result).toBe(false);
+    const after = (await db.select().from(auditEvents)).length;
+    expect(after).toBe(before);
+  });
+
+  it("writes a dashboard.manual_action event with action=bootstrap_admin", async () => {
+    await applyBootstrapAdmins(db, "alice@acme.com", "u_1", "alice@acme.com");
+    const events = await db.select().from(auditEvents);
+    const bootstrap = events.find((e: any) => {
+      const p = JSON.parse(e.payload);
+      return e.eventType === "dashboard.manual_action" && p.action === "bootstrap_admin";
+    });
+    expect(bootstrap).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/rbac/matrix.test.ts
+++ b/packages/core/src/__tests__/rbac/matrix.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { canAccess, PERMISSION_MATRIX } from "../../rbac/matrix.js";
+import type { PermissionKey } from "../../rbac/matrix.js";
+
+describe("PERMISSION_MATRIX", () => {
+  const cases: Array<[PermissionKey, "admin" | "operator" | "viewer", boolean]> = [
+    ["runs.view",         "admin",    true],
+    ["runs.view",         "operator", true],
+    ["runs.view",         "viewer",   true],
+    ["runs.retry",        "admin",    true],
+    ["runs.retry",        "operator", true],
+    ["runs.retry",        "viewer",   false],
+    ["tokens.view",       "admin",    true],
+    ["tokens.view",       "operator", true],
+    ["tokens.view",       "viewer",   true],
+    ["audit.view",        "admin",    true],
+    ["audit.view",        "operator", true],
+    ["audit.view",        "viewer",   false],
+    ["audit.export",      "viewer",   false],
+    ["cost.view",         "admin",    true],
+    ["cost.view",         "viewer",   false],
+    ["cost.export",       "admin",    true],
+    ["cost.export",       "viewer",   false],
+    ["errors.view",       "viewer",   true],
+    ["coordination.view", "operator", true],
+    ["coordination.view", "viewer",   false],
+    ["config.view",       "admin",    true],
+    ["config.view",       "operator", false],
+    ["config.view",       "viewer",   false],
+    ["users.view",        "admin",    true],
+    ["users.view",        "operator", false],
+    ["users.view",        "viewer",   false],
+    ["users.manage",      "admin",    true],
+    ["users.manage",      "operator", false],
+  ];
+
+  it.each(cases)("canAccess(%s, %s) === %s", (action, role, expected) => {
+    expect(canAccess(role, action)).toBe(expected);
+  });
+
+  it("admin has at least as many permissions as operator", () => {
+    const keys = Object.keys(PERMISSION_MATRIX) as PermissionKey[];
+    for (const k of keys) {
+      if (canAccess("operator", k)) expect(canAccess("admin", k)).toBe(true);
+    }
+  });
+
+  it("operator has at least as many permissions as viewer", () => {
+    const keys = Object.keys(PERMISSION_MATRIX) as PermissionKey[];
+    for (const k of keys) {
+      if (canAccess("viewer", k)) expect(canAccess("operator", k)).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/__tests__/rbac/user-role-store.test.ts
+++ b/packages/core/src/__tests__/rbac/user-role-store.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../../db/client.js";
+import { dashboardUsers, auditEvents } from "../../db/schema.js";
+import {
+  setUserRole,
+  getUserRole,
+  listUsers,
+} from "../../rbac/user-role-store.js";
+import { SelfDemoteError, LastAdminError } from "../../rbac/errors.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values([
+    { id: "u_admin", email: "admin@b.com", name: "Admin", workosUserId: null, role: "admin" },
+    { id: "u_op",    email: "op@b.com",    name: "Op",    workosUserId: null, role: "operator" },
+    { id: "u_view",  email: "view@b.com",  name: "View",  workosUserId: null, role: "viewer" },
+  ]);
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+describe("setUserRole", () => {
+  it("updates role and writes audit event", async () => {
+    await setUserRole(db, { userId: "u_view", newRole: "operator", actorUserId: "u_admin" });
+    expect(await getUserRole(db, "u_view")).toBe("operator");
+    const events = await db.select().from(auditEvents);
+    const grant = events.find((e: any) => e.eventType === "dashboard.manual_action");
+    expect(grant).toBeDefined();
+    const payload = JSON.parse(grant.payload);
+    expect(payload.action).toBe("grant_role");
+    expect(payload.targetUserId).toBe("u_view");
+    expect(payload.oldRole).toBe("viewer");
+    expect(payload.newRole).toBe("operator");
+  });
+
+  it("is idempotent — same role is a no-op, no audit event", async () => {
+    await setUserRole(db, { userId: "u_view", newRole: "viewer", actorUserId: "u_admin" });
+    const events = await db.select().from(auditEvents);
+    expect(events).toHaveLength(0);
+  });
+
+  it("prevents self-demote", async () => {
+    await expect(
+      setUserRole(db, { userId: "u_admin", newRole: "viewer", actorUserId: "u_admin" }),
+    ).rejects.toBeInstanceOf(SelfDemoteError);
+  });
+
+  it("prevents demoting the last admin", async () => {
+    await expect(
+      setUserRole(db, { userId: "u_admin", newRole: "viewer", actorUserId: "u_op" }),
+    ).rejects.toBeInstanceOf(LastAdminError);
+  });
+
+  it("allows demoting an admin when another admin exists", async () => {
+    await db.insert(dashboardUsers).values({
+      id: "u_admin2", email: "admin2@b.com", name: null, workosUserId: null, role: "admin",
+    });
+    await setUserRole(db, { userId: "u_admin", newRole: "viewer", actorUserId: "u_admin2" });
+    expect(await getUserRole(db, "u_admin")).toBe("viewer");
+  });
+
+  it("emits 'revoke_role' action for demotions to viewer", async () => {
+    await setUserRole(db, { userId: "u_op", newRole: "viewer", actorUserId: "u_admin" });
+    const events = await db.select().from(auditEvents);
+    const event = events.find((e: any) => e.eventType === "dashboard.manual_action");
+    const payload = JSON.parse(event.payload);
+    expect(payload.action).toBe("revoke_role");
+  });
+});
+
+describe("getUserRole", () => {
+  it("returns the role for a known user", async () => {
+    expect(await getUserRole(db, "u_op")).toBe("operator");
+  });
+
+  it("returns null for an unknown user", async () => {
+    expect(await getUserRole(db, "u_nope")).toBeNull();
+  });
+});
+
+describe("listUsers", () => {
+  it("returns all users sorted by email", async () => {
+    const users = await listUsers(db);
+    expect(users).toHaveLength(3);
+    expect(users.map((u) => u.email)).toEqual([
+      "admin@b.com",
+      "op@b.com",
+      "view@b.com",
+    ]);
+  });
+});

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -164,6 +164,90 @@ export function dashboardLoginDeniedEvent(args: {
   });
 }
 
+export function dashboardGrantRoleEvent(args: {
+  targetUserId: string;
+  targetEmail: string;
+  oldRole: string;
+  newRole: string;
+  actorUserId: string;
+  actorEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorEmail}`,
+    actorType: "dashboard-user",
+    payload: {
+      action: "grant_role",
+      targetUserId: args.targetUserId,
+      targetEmail: args.targetEmail,
+      oldRole: args.oldRole,
+      newRole: args.newRole,
+      actorUserId: args.actorUserId,
+    },
+  });
+}
+
+export function dashboardRevokeRoleEvent(args: {
+  targetUserId: string;
+  targetEmail: string;
+  oldRole: string;
+  newRole: string;
+  actorUserId: string;
+  actorEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorEmail}`,
+    actorType: "dashboard-user",
+    payload: {
+      action: "revoke_role",
+      targetUserId: args.targetUserId,
+      targetEmail: args.targetEmail,
+      oldRole: args.oldRole,
+      newRole: args.newRole,
+      actorUserId: args.actorUserId,
+    },
+  });
+}
+
+export function dashboardBootstrapAdminEvent(args: {
+  targetUserId: string;
+  targetEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: "system",
+    actorType: "system",
+    payload: {
+      action: "bootstrap_admin",
+      targetUserId: args.targetUserId,
+      targetEmail: args.targetEmail,
+      envVarMatched: true,
+    },
+  });
+}
+
+export function dashboardRetryRunEvent(args: {
+  runId: string;
+  issueId: string;
+  previousStatus: string;
+  actorUserId: string;
+  actorEmail: string;
+}): AuditEvent {
+  return base({
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorEmail}`,
+    actorType: "dashboard-user",
+    runId: args.runId,
+    issueId: args.issueId,
+    payload: {
+      action: "retry_run",
+      previousStatus: args.previousStatus,
+      actorUserId: args.actorUserId,
+    },
+  });
+}
+
 export function configLoadedEvent(args: {
   path: string;
   sha256: string;

--- a/packages/core/src/auth/user-store.ts
+++ b/packages/core/src/auth/user-store.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { dashboardUsers } from "../db/schema.js";
+import type { Role } from "../rbac/types.js";
 
 export interface DashboardUser {
   id: string;
@@ -10,6 +11,7 @@ export interface DashboardUser {
   workosUserId: string | null;
   createdAt: Date;
   lastLoginAt: Date | null;
+  role: Role;
 }
 
 export interface UpsertUserInput {
@@ -91,5 +93,6 @@ export async function getUserById(
     workosUserId: row.workosUserId ?? null,
     createdAt: row.createdAt,
     lastLoginAt: row.lastLoginAt ?? null,
+    role: ((row as { role?: string | null }).role ?? "viewer") as Role,
   };
 }

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -56,6 +56,13 @@ const MIGRATION_COLUMNS: MigrationColumn[] = [
   // BEC-94: auto-commit quality metric
   { table: "pipeline_runs", column: "auto_committed", sqliteType: "INTEGER", pgType: "BOOLEAN" },
   { table: "pipeline_runs", column: "linear_team_id", sqliteType: "TEXT", pgType: "TEXT" },
+  // Feature 4.4: RBAC
+  {
+    table: "dashboard_users",
+    column: "role",
+    sqliteType: "TEXT NOT NULL DEFAULT 'viewer'",
+    pgType: "TEXT NOT NULL DEFAULT 'viewer'",
+  },
 ];
 
 /**
@@ -190,7 +197,8 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
     name TEXT,
     workos_user_id TEXT,
     created_at ${ts} NOT NULL,
-    last_login_at ${ts}
+    last_login_at ${ts},
+    role TEXT NOT NULL DEFAULT 'viewer'
   );
 
   CREATE TABLE IF NOT EXISTS dashboard_sessions (

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -188,6 +188,7 @@ export const dashboardUsers = sqliteTable("dashboard_users", {
     .notNull()
     .$defaultFn(() => new Date()),
   lastLoginAt: crossTimestamp("last_login_at"),
+  role: text("role").notNull().default("viewer"),
 });
 
 export const dashboardSessions = sqliteTable("dashboard_sessions", {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./audit/index.js";
 export * from "./auth/index.js";
 export * from "./policy/index.js";
 export * from "./cost/index.js";
+export * from "./rbac/index.js";
 export { computeConfigFingerprint } from "./audit/config-fingerprint.js";
 export { rootLogger, createLogger, addLogStream } from "./logger.js";
 export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db } from "./db/index.js";

--- a/packages/core/src/rbac/errors.ts
+++ b/packages/core/src/rbac/errors.ts
@@ -1,0 +1,13 @@
+export class SelfDemoteError extends Error {
+  constructor() {
+    super("An admin cannot demote themselves");
+    this.name = "SelfDemoteError";
+  }
+}
+
+export class LastAdminError extends Error {
+  constructor() {
+    super("Cannot demote the last remaining admin");
+    this.name = "LastAdminError";
+  }
+}

--- a/packages/core/src/rbac/index.ts
+++ b/packages/core/src/rbac/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./matrix.js";

--- a/packages/core/src/rbac/index.ts
+++ b/packages/core/src/rbac/index.ts
@@ -1,2 +1,4 @@
 export * from "./types.js";
 export * from "./matrix.js";
+export * from "./errors.js";
+export * from "./user-role-store.js";

--- a/packages/core/src/rbac/matrix.ts
+++ b/packages/core/src/rbac/matrix.ts
@@ -1,0 +1,22 @@
+import type { Role } from "./types.js";
+
+export const PERMISSION_MATRIX = {
+  "runs.view":         ["admin", "operator", "viewer"],
+  "runs.retry":        ["admin", "operator"],
+  "tokens.view":       ["admin", "operator", "viewer"],
+  "audit.view":        ["admin", "operator"],
+  "audit.export":      ["admin", "operator"],
+  "cost.view":         ["admin", "operator"],
+  "cost.export":       ["admin", "operator"],
+  "errors.view":       ["admin", "operator", "viewer"],
+  "coordination.view": ["admin", "operator"],
+  "config.view":       ["admin"],
+  "users.view":        ["admin"],
+  "users.manage":      ["admin"],
+} as const satisfies Record<string, readonly Role[]>;
+
+export type PermissionKey = keyof typeof PERMISSION_MATRIX;
+
+export function canAccess(role: Role, action: PermissionKey): boolean {
+  return (PERMISSION_MATRIX[action] as readonly Role[]).includes(role);
+}

--- a/packages/core/src/rbac/types.ts
+++ b/packages/core/src/rbac/types.ts
@@ -1,0 +1,1 @@
+export type Role = "admin" | "operator" | "viewer";

--- a/packages/core/src/rbac/user-role-store.ts
+++ b/packages/core/src/rbac/user-role-store.ts
@@ -78,6 +78,63 @@ export async function getUserRole(db: AnyDb, userId: string): Promise<Role | nul
   return (rows[0] as any).role as Role;
 }
 
+/**
+ * If the user's email matches `envAdminList` (comma-separated, case-insensitive),
+ * promote them to admin. Idempotent — already-admin users are not re-promoted
+ * and no audit event is written. Emits a `dashboard.manual_action` event with
+ * `action: "bootstrap_admin"` on successful promotion.
+ *
+ * Returns true if the role was changed.
+ */
+export async function applyBootstrapAdmins(
+  db: AnyDb,
+  email: string,
+  userId: string,
+  envAdminList: string | undefined,
+): Promise<boolean> {
+  if (!envAdminList || envAdminList.trim() === "") return false;
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const adminSet = new Set(
+    envAdminList
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  if (!adminSet.has(normalizedEmail)) return false;
+
+  // Already admin? No-op.
+  const currentRole = await getUserRole(db, userId);
+  if (currentRole === "admin") return false;
+
+  // Promote. Bypass setUserRole because the actor is "system", not a user, and
+  // the self-demote/last-admin guards don't apply.
+  await (db as any)
+    .update(dashboardUsers)
+    .set({ role: "admin" as Role })
+    .where(eq(dashboardUsers.id, userId));
+
+  await logAuditEvent(db, {
+    id: `evt_${randomUUID()}`,
+    timestamp: new Date(),
+    eventType: "dashboard.manual_action",
+    actor: "system",
+    actorType: "system",
+    scope: null,
+    runId: null,
+    issueId: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    payload: {
+      action: "bootstrap_admin",
+      targetUserId: userId,
+      targetEmail: normalizedEmail,
+      envVarMatched: true,
+    },
+  });
+  return true;
+}
+
 export async function listUsers(db: AnyDb): Promise<
   Array<{
     id: string;

--- a/packages/core/src/rbac/user-role-store.ts
+++ b/packages/core/src/rbac/user-role-store.ts
@@ -1,5 +1,6 @@
-import { and, eq, ne, count } from "drizzle-orm";
+import { and, eq, ne, count, sql } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
+import { isPostgres } from "../db/client.js";
 import { dashboardUsers } from "../db/schema.js";
 import {
   logAuditEvent,
@@ -18,50 +19,95 @@ export interface SetUserRoleArgs {
 }
 
 export async function setUserRole(db: AnyDb, args: SetUserRoleArgs): Promise<void> {
-  const currentRows = await (db as any)
-    .select()
-    .from(dashboardUsers)
-    .where(eq(dashboardUsers.id, args.userId));
-  if (currentRows.length === 0) throw new Error(`user not found: ${args.userId}`);
-  const current = currentRows[0] as { id: string; email: string; role: Role };
-  const oldRole = current.role;
+  // The SELECT current / SELECT COUNT / UPDATE sequence MUST share a
+  // transaction to close the TOCTOU race on the last-admin guard. Two
+  // concurrent demotions must not both see `otherAdmins > 0`.
+  //
+  // Driver note: drizzle's `db.transaction(async ...)` is NOT supported on
+  // better-sqlite3 (it throws "Transaction function cannot return a
+  // promise"). For SQLite we issue `BEGIN IMMEDIATE` / `COMMIT` manually,
+  // which acquires a RESERVED lock and serializes concurrent writers.
+  // For Postgres we use the native drizzle transaction API.
+  // `logAuditEvent` is fire-and-forget and runs outside the transaction.
+  let oldRole: Role;
+  let actorEmail = "unknown";
+  let targetEmail: string;
 
-  // Idempotent no-op
-  if (oldRole === args.newRole) return;
-
-  // Self-lockout
-  if (args.userId === args.actorUserId && args.newRole !== "admin") {
-    throw new SelfDemoteError();
-  }
-
-  // Last-admin guard: if target is currently admin and we're demoting, count other admins
-  if (oldRole === "admin" && args.newRole !== "admin") {
-    const [row] = await (db as any)
-      .select({ n: count() })
+  const body = async (handle: any): Promise<void> => {
+    const currentRows = await handle
+      .select()
       .from(dashboardUsers)
-      .where(and(eq(dashboardUsers.role, "admin"), ne(dashboardUsers.id, args.userId)));
-    const otherAdmins = Number((row as any)?.n ?? 0);
-    if (otherAdmins === 0) throw new LastAdminError();
+      .where(eq(dashboardUsers.id, args.userId));
+    if (currentRows.length === 0)
+      throw new Error(`user not found: ${args.userId}`);
+    const current = currentRows[0] as { id: string; email: string; role: Role };
+    oldRole = current.role;
+    targetEmail = current.email;
+
+    // Idempotent no-op
+    if (oldRole === args.newRole) return;
+
+    // Self-lockout
+    if (args.userId === args.actorUserId && args.newRole !== "admin") {
+      throw new SelfDemoteError();
+    }
+
+    // Last-admin guard: if target is currently admin and we're demoting, count other admins
+    if (oldRole === "admin" && args.newRole !== "admin") {
+      const [row] = await handle
+        .select({ n: count() })
+        .from(dashboardUsers)
+        .where(
+          and(eq(dashboardUsers.role, "admin"), ne(dashboardUsers.id, args.userId)),
+        );
+      const otherAdmins = Number((row as any)?.n ?? 0);
+      if (otherAdmins === 0) throw new LastAdminError();
+    }
+
+    await handle
+      .update(dashboardUsers)
+      .set({ role: args.newRole })
+      .where(eq(dashboardUsers.id, args.userId));
+
+    const actorRows = await handle
+      .select()
+      .from(dashboardUsers)
+      .where(eq(dashboardUsers.id, args.actorUserId));
+    actorEmail = (actorRows[0] as any)?.email ?? "unknown";
+  };
+
+  if (isPostgres(db as any)) {
+    await (db as any).transaction(async (tx: any) => {
+      await body(tx);
+    });
+  } else {
+    // SQLite path — manual transaction. Use BEGIN IMMEDIATE to grab the
+    // RESERVED lock up front, avoiding SQLITE_BUSY under contention.
+    await (db as any).run(sql`BEGIN IMMEDIATE`);
+    try {
+      await body(db);
+      await (db as any).run(sql`COMMIT`);
+    } catch (err) {
+      try {
+        await (db as any).run(sql`ROLLBACK`);
+      } catch {
+        // ignore rollback errors
+      }
+      throw err;
+    }
   }
 
-  await (db as any)
-    .update(dashboardUsers)
-    .set({ role: args.newRole })
-    .where(eq(dashboardUsers.id, args.userId));
+  // Early-exit idempotent no-op: skip audit write.
+  if (oldRole! === args.newRole) return;
 
   const isRevoke = args.newRole === "viewer";
-  const actorRows = await (db as any)
-    .select()
-    .from(dashboardUsers)
-    .where(eq(dashboardUsers.id, args.actorUserId));
-  const actorEmail = (actorRows[0] as any)?.email ?? "unknown";
   const builder = isRevoke ? dashboardRevokeRoleEvent : dashboardGrantRoleEvent;
   await logAuditEvent(
     db,
     builder({
       targetUserId: args.userId,
-      targetEmail: current.email,
-      oldRole,
+      targetEmail: targetEmail!,
+      oldRole: oldRole!,
       newRole: args.newRole,
       actorUserId: args.actorUserId,
       actorEmail,

--- a/packages/core/src/rbac/user-role-store.ts
+++ b/packages/core/src/rbac/user-role-store.ts
@@ -1,0 +1,101 @@
+import { and, eq, ne, count } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import type { AnyDb } from "../db/client.js";
+import { dashboardUsers } from "../db/schema.js";
+import { logAuditEvent } from "../audit/index.js";
+import type { Role } from "./types.js";
+import { SelfDemoteError, LastAdminError } from "./errors.js";
+
+export interface SetUserRoleArgs {
+  userId: string;
+  newRole: Role;
+  actorUserId: string;
+  reason?: string;
+}
+
+export async function setUserRole(db: AnyDb, args: SetUserRoleArgs): Promise<void> {
+  const currentRows = await (db as any)
+    .select()
+    .from(dashboardUsers)
+    .where(eq(dashboardUsers.id, args.userId));
+  if (currentRows.length === 0) throw new Error(`user not found: ${args.userId}`);
+  const current = currentRows[0] as { id: string; email: string; role: Role };
+  const oldRole = current.role;
+
+  // Idempotent no-op
+  if (oldRole === args.newRole) return;
+
+  // Self-lockout
+  if (args.userId === args.actorUserId && args.newRole !== "admin") {
+    throw new SelfDemoteError();
+  }
+
+  // Last-admin guard: if target is currently admin and we're demoting, count other admins
+  if (oldRole === "admin" && args.newRole !== "admin") {
+    const [row] = await (db as any)
+      .select({ n: count() })
+      .from(dashboardUsers)
+      .where(and(eq(dashboardUsers.role, "admin"), ne(dashboardUsers.id, args.userId)));
+    const otherAdmins = Number((row as any)?.n ?? 0);
+    if (otherAdmins === 0) throw new LastAdminError();
+  }
+
+  await (db as any)
+    .update(dashboardUsers)
+    .set({ role: args.newRole })
+    .where(eq(dashboardUsers.id, args.userId));
+
+  const isRevoke = args.newRole === "viewer";
+  await logAuditEvent(db, {
+    id: `evt_${randomUUID()}`,
+    timestamp: new Date(),
+    eventType: "dashboard.manual_action",
+    actor: `dashboard:${args.actorUserId}`,
+    actorType: "dashboard-user",
+    scope: null,
+    runId: null,
+    issueId: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    payload: {
+      action: isRevoke ? "revoke_role" : "grant_role",
+      targetUserId: args.userId,
+      targetEmail: current.email,
+      oldRole,
+      newRole: args.newRole,
+      actorUserId: args.actorUserId,
+      reason: args.reason,
+    },
+  });
+}
+
+export async function getUserRole(db: AnyDb, userId: string): Promise<Role | null> {
+  const rows = await (db as any)
+    .select()
+    .from(dashboardUsers)
+    .where(eq(dashboardUsers.id, userId));
+  if (rows.length === 0) return null;
+  return (rows[0] as any).role as Role;
+}
+
+export async function listUsers(db: AnyDb): Promise<
+  Array<{
+    id: string;
+    email: string;
+    name: string | null;
+    role: Role;
+    lastLoginAt: Date | null;
+  }>
+> {
+  const rows = await (db as any).select().from(dashboardUsers);
+  const mapped = rows.map((r: any) => ({
+    id: r.id,
+    email: r.email,
+    name: r.name ?? null,
+    role: r.role as Role,
+    lastLoginAt: r.lastLoginAt ?? null,
+  }));
+  return mapped.sort((a: { email: string }, b: { email: string }) =>
+    a.email.localeCompare(b.email),
+  );
+}

--- a/packages/core/src/rbac/user-role-store.ts
+++ b/packages/core/src/rbac/user-role-store.ts
@@ -1,8 +1,12 @@
 import { and, eq, ne, count } from "drizzle-orm";
-import { randomUUID } from "node:crypto";
 import type { AnyDb } from "../db/client.js";
 import { dashboardUsers } from "../db/schema.js";
-import { logAuditEvent } from "../audit/index.js";
+import {
+  logAuditEvent,
+  dashboardGrantRoleEvent,
+  dashboardRevokeRoleEvent,
+  dashboardBootstrapAdminEvent,
+} from "../audit/index.js";
 import type { Role } from "./types.js";
 import { SelfDemoteError, LastAdminError } from "./errors.js";
 
@@ -46,27 +50,23 @@ export async function setUserRole(db: AnyDb, args: SetUserRoleArgs): Promise<voi
     .where(eq(dashboardUsers.id, args.userId));
 
   const isRevoke = args.newRole === "viewer";
-  await logAuditEvent(db, {
-    id: `evt_${randomUUID()}`,
-    timestamp: new Date(),
-    eventType: "dashboard.manual_action",
-    actor: `dashboard:${args.actorUserId}`,
-    actorType: "dashboard-user",
-    scope: null,
-    runId: null,
-    issueId: null,
-    inputTokens: 0,
-    outputTokens: 0,
-    payload: {
-      action: isRevoke ? "revoke_role" : "grant_role",
+  const actorRows = await (db as any)
+    .select()
+    .from(dashboardUsers)
+    .where(eq(dashboardUsers.id, args.actorUserId));
+  const actorEmail = (actorRows[0] as any)?.email ?? "unknown";
+  const builder = isRevoke ? dashboardRevokeRoleEvent : dashboardGrantRoleEvent;
+  await logAuditEvent(
+    db,
+    builder({
       targetUserId: args.userId,
       targetEmail: current.email,
       oldRole,
       newRole: args.newRole,
       actorUserId: args.actorUserId,
-      reason: args.reason,
-    },
-  });
+      actorEmail,
+    }),
+  );
 }
 
 export async function getUserRole(db: AnyDb, userId: string): Promise<Role | null> {
@@ -114,24 +114,13 @@ export async function applyBootstrapAdmins(
     .set({ role: "admin" as Role })
     .where(eq(dashboardUsers.id, userId));
 
-  await logAuditEvent(db, {
-    id: `evt_${randomUUID()}`,
-    timestamp: new Date(),
-    eventType: "dashboard.manual_action",
-    actor: "system",
-    actorType: "system",
-    scope: null,
-    runId: null,
-    issueId: null,
-    inputTokens: 0,
-    outputTokens: 0,
-    payload: {
-      action: "bootstrap_admin",
+  await logAuditEvent(
+    db,
+    dashboardBootstrapAdminEvent({
       targetUserId: userId,
       targetEmail: normalizedEmail,
-      envVarMatched: true,
-    },
-  });
+    }),
+  );
   return true;
 }
 

--- a/packages/dashboard/src/__tests__/audit.test.ts
+++ b/packages/dashboard/src/__tests__/audit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { Hono } from "hono";
 import { createDashboard } from "../server.js";
 import { createDb } from "@urateam/core";
 import type { Db } from "@urateam/core";
@@ -141,16 +142,35 @@ describe("audit route — licensed (enterprise)", () => {
     await restoreLicense();
   });
 
+  // Enterprise tier enables `rbac`, so `requirePermission("audit.view")`
+  // requires a `user` in context. Wrap the dashboard in an outer Hono and
+  // inject a stub admin user so tests that run in enterprise mode pass.
+  function wrapWithAdminUser(inner: Hono): Hono {
+    const outer = new Hono();
+    outer.use("*", async (c, next) => {
+      c.set("user" as never, {
+        id: "u_admin",
+        email: "admin@b.com",
+        role: "admin",
+      } as any);
+      await next();
+    });
+    outer.route("/", inner);
+    return outer;
+  }
+
   it("GET /audit returns 200 and renders a seeded event", async () => {
     const db = await createDb({ connectionString: ":memory:" });
     await seedAuditEvent(db);
 
-    const app = createDashboard({
-      db,
-      pipelineConfigs: {},
-      repoConfigs: {},
-      auth: { username: "admin", password: "secret" },
-    });
+    const app = wrapWithAdminUser(
+      createDashboard({
+        db,
+        pipelineConfigs: {},
+        repoConfigs: {},
+        auth: { username: "admin", password: "secret" },
+      }),
+    );
 
     const res = await app.request("/audit", { headers: AUTH });
     expect(res.status).toBe(200);
@@ -163,12 +183,14 @@ describe("audit route — licensed (enterprise)", () => {
     const db = await createDb({ connectionString: ":memory:" });
     await seedAuditEvent(db);
 
-    const app = createDashboard({
-      db,
-      pipelineConfigs: {},
-      repoConfigs: {},
-      auth: { username: "admin", password: "secret" },
-    });
+    const app = wrapWithAdminUser(
+      createDashboard({
+        db,
+        pipelineConfigs: {},
+        repoConfigs: {},
+        auth: { username: "admin", password: "secret" },
+      }),
+    );
 
     const res = await app.request("/audit/export.csv", { headers: AUTH });
     expect(res.status).toBe(200);

--- a/packages/dashboard/src/__tests__/bootstrap-integration.test.ts
+++ b/packages/dashboard/src/__tests__/bootstrap-integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createDb, signState } from "@urateam/core";
+import { dashboardUsers } from "@urateam/core/dist/db/schema.js";
+import { Hono } from "hono";
+import { createAuthRouter } from "../routes/auth.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+const ssoConfig = {
+  enabled: true,
+  workosApiKey: "sk_test",
+  workosClientId: "client_test",
+  redirectUri: "https://x/auth/callback",
+  allowedDomain: undefined as string | undefined,
+  sessionDurationHours: 24,
+  cookieName: "urateam_session",
+  cookieSecure: false,
+  stateSigningSecret: "0123456789abcdef0123456789abcdef",
+};
+
+const stubWorkos = {
+  async getAuthorizationUrl() {
+    return "https://workos.example/auth";
+  },
+  async authenticateWithCode() {
+    return {
+      user: {
+        id: "wu_1",
+        email: "alice@acme.com",
+        firstName: "Alice",
+        lastName: "X",
+      },
+    };
+  },
+} as any;
+
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+  vi.unstubAllEnvs();
+});
+
+describe("SSO callback bootstrap admin integration", () => {
+  it("promotes alice@acme.com when URATEAM_ADMIN_EMAILS matches", async () => {
+    vi.stubEnv("URATEAM_ADMIN_EMAILS", "alice@acme.com");
+    const app = new Hono();
+    app.route(
+      "/",
+      createAuthRouter({ db, sso: ssoConfig as any, workos: stubWorkos }),
+    );
+    const state = signState(
+      { next: "/", nonce: "n" },
+      ssoConfig.stateSigningSecret,
+    );
+    const res = await app.request(
+      `/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    expect(res.status).toBe(302);
+    const users = await db.select().from(dashboardUsers);
+    expect(users).toHaveLength(1);
+    expect(users[0].role).toBe("admin");
+  });
+
+  it("leaves role as viewer when email does not match", async () => {
+    vi.stubEnv("URATEAM_ADMIN_EMAILS", "bob@acme.com");
+    const app = new Hono();
+    app.route(
+      "/",
+      createAuthRouter({ db, sso: ssoConfig as any, workos: stubWorkos }),
+    );
+    const state = signState(
+      { next: "/", nonce: "n" },
+      ssoConfig.stateSigningSecret,
+    );
+    const res = await app.request(
+      `/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    expect(res.status).toBe(302);
+    const users = await db.select().from(dashboardUsers);
+    expect(users[0].role).toBe("viewer");
+  });
+
+  it("does not promote when URATEAM_ADMIN_EMAILS is unset", async () => {
+    vi.stubEnv("URATEAM_ADMIN_EMAILS", "");
+    const app = new Hono();
+    app.route(
+      "/",
+      createAuthRouter({ db, sso: ssoConfig as any, workos: stubWorkos }),
+    );
+    const state = signState(
+      { next: "/", nonce: "n" },
+      ssoConfig.stateSigningSecret,
+    );
+    const res = await app.request(
+      `/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    expect(res.status).toBe(302);
+    const users = await db.select().from(dashboardUsers);
+    expect(users[0].role).toBe("viewer");
+  });
+});

--- a/packages/dashboard/src/__tests__/rbac-middleware.test.ts
+++ b/packages/dashboard/src/__tests__/rbac-middleware.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { requirePermission } from "../middleware/rbac.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+function appWithRoute(permission: string, role: string | undefined) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (role)
+      c.set("user" as never, {
+        id: "u_1",
+        role,
+        email: "u@b.com",
+      } as never);
+    await next();
+  });
+  app.get(
+    "/test",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    requirePermission(permission as any),
+    (c) => c.text("ok"),
+  );
+  return app;
+}
+
+describe("requirePermission", () => {
+  it("unlicensed → no-op, all roles pass", async () => {
+    const app = appWithRoute("config.view", "viewer");
+    expect((await app.request("/test")).status).toBe(200);
+  });
+
+  describe("licensed", () => {
+    beforeEach(async () => {
+      await installTestProLicense("enterprise");
+    });
+
+    it("admin passes runs.view", async () => {
+      const res = await appWithRoute("runs.view", "admin").request("/test");
+      expect(res.status).toBe(200);
+    });
+
+    it("viewer passes runs.view", async () => {
+      const res = await appWithRoute("runs.view", "viewer").request("/test");
+      expect(res.status).toBe(200);
+    });
+
+    it("viewer gets 403 on audit.view", async () => {
+      const res = await appWithRoute("audit.view", "viewer").request("/test");
+      expect(res.status).toBe(403);
+    });
+
+    it("operator gets 403 on config.view", async () => {
+      const res = await appWithRoute("config.view", "operator").request(
+        "/test",
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("admin passes config.view", async () => {
+      const res = await appWithRoute("config.view", "admin").request("/test");
+      expect(res.status).toBe(200);
+    });
+
+    it("no session → 401", async () => {
+      const res = await appWithRoute("runs.view", undefined).request("/test");
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/packages/dashboard/src/__tests__/retry-route.test.ts
+++ b/packages/dashboard/src/__tests__/retry-route.test.ts
@@ -47,10 +47,13 @@ function appWith(
 }
 
 describe("POST /runs/:id/retry", () => {
-  it("unlicensed → middleware is no-op and endpoint redirects", async () => {
-    const app = appWith("viewer");
+  it("unlicensed → 404 even for valid retry requests", async () => {
+    // Do NOT install enterprise license
+    const runner = { resume: vi.fn(), start: vi.fn() };
+    const app = appWith("operator", runner); // operator role set but feature off
     const res = await app.request("/runs/run_1/retry", { method: "POST" });
-    expect([200, 302]).toContain(res.status);
+    expect(res.status).toBe(404);
+    expect(runner.resume).not.toHaveBeenCalled();
   });
 
   describe("licensed", () => {

--- a/packages/dashboard/src/__tests__/retry-route.test.ts
+++ b/packages/dashboard/src/__tests__/retry-route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { createDb } from "@urateam/core";
+import { pipelineRuns, auditEvents } from "@urateam/core/dist/db/schema.js";
+import { createRunsRouter } from "../routes/runs.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(pipelineRuns).values({
+    id: "run_1",
+    issueId: "BEC-42",
+    issueTitle: "fix bug",
+    pipelineKey: "auto-implement",
+    repoUrl: "https://github.com/acme/api",
+    status: "failed",
+    startedAt: new Date(),
+    completedAt: new Date(),
+    errorMessage: "boom",
+  });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+function appWith(
+  role: string | undefined,
+  runner: any = { resume: vi.fn(), start: vi.fn() },
+) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (role) {
+      c.set("user" as never, {
+        id: "u_1",
+        email: "u@b.com",
+        role,
+      } as any);
+    }
+    await next();
+  });
+  app.route("/", createRunsRouter({ db, runner, basePath: "" }));
+  return app;
+}
+
+describe("POST /runs/:id/retry", () => {
+  it("unlicensed → middleware is no-op and endpoint redirects", async () => {
+    const app = appWith("viewer");
+    const res = await app.request("/runs/run_1/retry", { method: "POST" });
+    expect([200, 302]).toContain(res.status);
+  });
+
+  describe("licensed", () => {
+    beforeEach(async () => {
+      await installTestProLicense("enterprise");
+    });
+
+    it("viewer → 403", async () => {
+      const res = await appWith("viewer").request("/runs/run_1/retry", {
+        method: "POST",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("operator → 302 redirect, runner.resume called, audit event written", async () => {
+      // Give the run a resumePayload so runner.resume is called (not start).
+      await db
+        .update(pipelineRuns)
+        .set({ resumePayload: JSON.stringify({ stageIndex: 1 }) })
+        .where(eq(pipelineRuns.id, "run_1"));
+      const runner = {
+        resume: vi.fn().mockResolvedValue(undefined),
+        start: vi.fn(),
+      };
+      const app = appWith("operator", runner);
+      const res = await app.request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(302);
+      expect(runner.resume).toHaveBeenCalledWith("run_1");
+      // Give fire-and-forget logAuditEvent a chance to flush
+      await new Promise((r) => setTimeout(r, 50));
+      const events = await db.select().from(auditEvents);
+      const retry = events.find((e: any) => {
+        const p =
+          typeof e.payload === "string" ? JSON.parse(e.payload) : e.payload;
+        return (
+          e.eventType === "dashboard.manual_action" && p.action === "retry_run"
+        );
+      });
+      expect(retry).toBeDefined();
+    });
+
+    it("admin → 302, runner.resume called (with resumePayload)", async () => {
+      await db
+        .update(pipelineRuns)
+        .set({ resumePayload: JSON.stringify({ stageIndex: 1 }) })
+        .where(eq(pipelineRuns.id, "run_1"));
+      const runner = {
+        resume: vi.fn().mockResolvedValue(undefined),
+        start: vi.fn(),
+      };
+      const app = appWith("admin", runner);
+      const res = await app.request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(302);
+      expect(runner.resume).toHaveBeenCalled();
+    });
+
+    it("operator retrying a completed run → 409", async () => {
+      await db
+        .update(pipelineRuns)
+        .set({ status: "completed" })
+        .where(eq(pipelineRuns.id, "run_1"));
+      const res = await appWith("operator").request("/runs/run_1/retry", {
+        method: "POST",
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("operator retrying a non-existent run → 404", async () => {
+      const res = await appWith("operator").request("/runs/nope/retry", {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/dashboard/src/__tests__/users-routes.test.ts
+++ b/packages/dashboard/src/__tests__/users-routes.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createDb } from "@urateam/core";
+import {
+  dashboardUsers,
+  auditEvents,
+} from "@urateam/core/dist/db/schema.js";
+import { createUsersRouter } from "../routes/users.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(dashboardUsers).values([
+    {
+      id: "u_admin",
+      email: "admin@b.com",
+      name: "Admin",
+      workosUserId: null,
+      role: "admin",
+    },
+    {
+      id: "u_op",
+      email: "op@b.com",
+      name: "Op",
+      workosUserId: null,
+      role: "operator",
+    },
+    {
+      id: "u_view",
+      email: "view@b.com",
+      name: "View",
+      workosUserId: null,
+      role: "viewer",
+    },
+  ]);
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+function appWith(role: string | undefined, userId = "u_admin") {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (role) {
+      c.set("user" as never, {
+        id: userId,
+        email: `${role}@b.com`,
+        role,
+      } as any);
+    }
+    await next();
+  });
+  app.route("/", createUsersRouter({ db, basePath: "" }));
+  return app;
+}
+
+describe("/users routes (licensed)", () => {
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+
+  it("GET /users as admin → 200 with user list", async () => {
+    const res = await appWith("admin").request("/users");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("admin@b.com");
+    expect(body).toContain("op@b.com");
+    expect(body).toContain("view@b.com");
+  });
+
+  it("GET /users as operator → 403", async () => {
+    const res = await appWith("operator", "u_op").request("/users");
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /users as viewer → 403", async () => {
+    const res = await appWith("viewer", "u_view").request("/users");
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /users/:id/role as admin → 302, role updated, audit event written", async () => {
+    const res = await appWith("admin").request("/users/u_view/role", {
+      method: "POST",
+      headers: {
+        "HX-Request": "true",
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "role=operator",
+    });
+    expect(res.status).toBe(302);
+    const rows = await db.select().from(dashboardUsers);
+    expect(rows.find((u: any) => u.id === "u_view").role).toBe("operator");
+    const events = await db.select().from(auditEvents);
+    expect(
+      events.some((e: any) => e.eventType === "dashboard.manual_action"),
+    ).toBe(true);
+  });
+
+  it("POST /users/:id/role as operator → 403", async () => {
+    const res = await appWith("operator", "u_op").request(
+      "/users/u_view/role",
+      {
+        method: "POST",
+        headers: {
+          "HX-Request": "true",
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: "role=admin",
+      },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("POST with invalid role → 400", async () => {
+    const res = await appWith("admin").request("/users/u_view/role", {
+      method: "POST",
+      headers: {
+        "HX-Request": "true",
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "role=god",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST to demote self → 400", async () => {
+    const res = await appWith("admin", "u_admin").request(
+      "/users/u_admin/role",
+      {
+        method: "POST",
+        headers: {
+          "HX-Request": "true",
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: "role=viewer",
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("/users routes (unlicensed)", () => {
+  it("GET /users → 404", async () => {
+    const res = await appWith("admin").request("/users");
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/dashboard/src/middleware/rbac.ts
+++ b/packages/dashboard/src/middleware/rbac.ts
@@ -1,0 +1,32 @@
+import type { MiddlewareHandler } from "hono";
+import {
+  isFeatureLicensed,
+  canAccess,
+  type PermissionKey,
+  type Role,
+} from "@urateam/core";
+import { renderForbidden } from "../views/forbidden.js";
+
+export function requirePermission(action: PermissionKey): MiddlewareHandler {
+  return async (c, next) => {
+    if (!isFeatureLicensed("rbac")) return next();
+
+    const user = c.get("user" as never) as
+      | { id: string; email: string; role: Role }
+      | undefined;
+    if (!user) return c.text("Unauthorized", 401);
+
+    if (!canAccess(user.role, action)) {
+      return c.html(
+        renderForbidden({
+          email: user.email,
+          role: user.role,
+          action,
+          basePath: "",
+        }),
+        403,
+      );
+    }
+    return next();
+  };
+}

--- a/packages/dashboard/src/routes/audit.ts
+++ b/packages/dashboard/src/routes/audit.ts
@@ -7,6 +7,7 @@ import {
 } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { renderAuditPage, type AuditFilters } from "../views/audit.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 function parseFilters(query: Record<string, string | undefined>): AuditFilters & {
   cursor?: string;
@@ -71,7 +72,7 @@ export function createAuditRouter(db: Db, basePath = ""): Hono {
     await next();
   });
 
-  router.get("/audit", async (c) => {
+  router.get("/audit", requirePermission("audit.view"), async (c) => {
     const query = c.req.query();
     const filters = parseFilters(query);
     const readerFilters = buildReaderFilters(query);
@@ -85,7 +86,7 @@ export function createAuditRouter(db: Db, basePath = ""): Hono {
   });
 
   // HTMX partial used by the "Load more" link to append rows.
-  router.get("/audit/page", async (c) => {
+  router.get("/audit/page", requirePermission("audit.view"), async (c) => {
     const query = c.req.query();
     const filters = parseFilters(query);
     const readerFilters = buildReaderFilters(query);
@@ -93,7 +94,7 @@ export function createAuditRouter(db: Db, basePath = ""): Hono {
     return c.html(renderAuditPage({ events, nextCursor, filters, partial: true }));
   });
 
-  router.get("/audit/export.csv", async (c) => {
+  router.get("/audit/export.csv", requirePermission("audit.export"), async (c) => {
     const query = c.req.query();
     const readerFilters = buildReaderFilters(query);
     // Export ignores the paginated limit; streamAuditCsv walks its own cursor.

--- a/packages/dashboard/src/routes/auth.ts
+++ b/packages/dashboard/src/routes/auth.ts
@@ -6,6 +6,8 @@ import {
   verifyState,
   validateNextPath,
   upsertUser,
+  applyBootstrapAdmins,
+  isFeatureLicensed,
   createSession,
   deleteSession,
   getSession,
@@ -89,6 +91,21 @@ export function createAuthRouter(deps: AuthRouterDeps): Hono {
       name: fullName,
       workosUserId: result.user.id,
     });
+
+    if (isFeatureLicensed("rbac")) {
+      try {
+        await applyBootstrapAdmins(
+          deps.db,
+          email,
+          userId,
+          process.env.URATEAM_ADMIN_EMAILS,
+        );
+      } catch (err) {
+        // bootstrap must never block login
+        log.warn({ err }, "bootstrap admin failed");
+      }
+    }
+
     const sessionId = await createSession(deps.db, {
       userId,
       durationHours: deps.sso.sessionDurationHours,

--- a/packages/dashboard/src/routes/config.ts
+++ b/packages/dashboard/src/routes/config.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { PipelineConfig, RepoConfig } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { configView } from "../views/config.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 export function createConfigRouter(
   pipelineConfigs: Record<string, PipelineConfig>,
@@ -10,7 +11,7 @@ export function createConfigRouter(
 ): Hono {
   const router = new Hono();
 
-  router.get("/config", (c) => {
+  router.get("/config", requirePermission("config.view"), (c) => {
     const content = configView(pipelineConfigs, repoConfigs);
     return c.html(layout("Configuration", content, basePath));
   });

--- a/packages/dashboard/src/routes/coordination.ts
+++ b/packages/dashboard/src/routes/coordination.ts
@@ -3,11 +3,12 @@ import type { Db } from "@urateam/core";
 import { getActiveWork } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { coordinationView } from "../views/coordination.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 export function createCoordinationRouter(db: Db, basePath = ""): Hono {
   const router = new Hono();
 
-  router.get("/coordination", async (c) => {
+  router.get("/coordination", requirePermission("coordination.view"), async (c) => {
     const entries = await getActiveWork(db as any);
     const content = coordinationView(entries);
 
@@ -19,7 +20,7 @@ export function createCoordinationRouter(db: Db, basePath = ""): Hono {
   });
 
   // HTMX partial: active coordination feed (polled every 10s)
-  router.get("/coordination/feed", async (c) => {
+  router.get("/coordination/feed", requirePermission("coordination.view"), async (c) => {
     const entries = await getActiveWork(db as any);
     return c.html(coordinationView(entries));
   });

--- a/packages/dashboard/src/routes/errors.ts
+++ b/packages/dashboard/src/routes/errors.ts
@@ -4,6 +4,7 @@ import type { Db } from "@urateam/core";
 import { stageRuns } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { errorsView } from "../views/errors.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 type AnyDb = any;
 
@@ -11,7 +12,7 @@ export function createErrorsRouter(db: Db, basePath = ""): Hono {
   const router = new Hono();
   const d = db as AnyDb;
 
-  router.get("/errors", async (c) => {
+  router.get("/errors", requirePermission("errors.view"), async (c) => {
     const stageFailures = await d
       .select({
         stage: stageRuns.stage,

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -1,14 +1,51 @@
 import { Hono } from "hono";
 import { desc, eq, inArray, count } from "drizzle-orm";
 import type { Db } from "@urateam/core";
-import { pipelineRuns, stageRuns, agentLogs } from "@urateam/core";
+import {
+  pipelineRuns,
+  stageRuns,
+  agentLogs,
+  logAuditEvent,
+  dashboardRetryRunEvent,
+} from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { runFeedView, type RunRow } from "../views/run-feed.js";
 import { runDetailView, type RunInfo, type StageInfo, type LogEntry } from "../views/run-detail.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 type AnyDb = any;
 
-export function createRunsRouter(db: Db, basePath = ""): Hono {
+export interface RunsRouterDeps {
+  db: Db;
+  runner?: {
+    resume: (runOrIssueId: string) => Promise<void>;
+    start: (...args: any[]) => Promise<void>;
+  };
+  basePath?: string;
+}
+
+export function createRunsRouter(
+  dbOrDeps: Db | RunsRouterDeps,
+  basePath = "",
+): Hono {
+  // Backwards-compatible: accept either (db, basePath) or a deps object.
+  let db: Db;
+  let runner: RunsRouterDeps["runner"];
+  let effectiveBasePath: string;
+  if (
+    dbOrDeps &&
+    typeof dbOrDeps === "object" &&
+    "db" in (dbOrDeps as any)
+  ) {
+    const deps = dbOrDeps as RunsRouterDeps;
+    db = deps.db;
+    runner = deps.runner;
+    effectiveBasePath = deps.basePath ?? "";
+  } else {
+    db = dbOrDeps as Db;
+    effectiveBasePath = basePath;
+  }
+
   const router = new Hono();
   const d = db as AnyDb;
 
@@ -25,7 +62,7 @@ export function createRunsRouter(db: Db, basePath = ""): Hono {
       return c.html(content);
     }
 
-    return c.html(layout("Pipeline Runs", content, basePath));
+    return c.html(layout("Pipeline Runs", content, effectiveBasePath));
   });
 
   // HTMX partial: feed of latest pipeline runs (polled every 5s)
@@ -51,7 +88,7 @@ export function createRunsRouter(db: Db, basePath = ""): Hono {
       .limit(1) as (RunInfo | undefined)[];
 
     if (!run) {
-      return c.html(layout("Not Found", "<p>Run not found</p>", basePath), 404);
+      return c.html(layout("Not Found", "<p>Run not found</p>", effectiveBasePath), 404);
     }
 
     const stages = await d
@@ -84,8 +121,63 @@ export function createRunsRouter(db: Db, basePath = ""): Hono {
     }
 
     const content = runDetailView(run, stages, logs, page, totalLogs);
-    return c.html(layout(`Run ${id}`, content, basePath));
+    return c.html(layout(`Run ${id}`, content, effectiveBasePath));
   });
+
+  router.post(
+    "/runs/:id/retry",
+    requirePermission("runs.retry"),
+    async (c) => {
+      const id = c.req.param("id");
+      const rows = await d
+        .select()
+        .from(pipelineRuns)
+        .where(eq(pipelineRuns.id, id))
+        .limit(1);
+      if (rows.length === 0) {
+        return c.text("Run not found", 404);
+      }
+      const run = rows[0] as any;
+      if (run.status !== "failed" && run.status !== "retriable") {
+        return c.text(`Cannot retry a run in status ${run.status}`, 409);
+      }
+
+      if (!runner) {
+        return c.text("Runner not configured", 500);
+      }
+
+      try {
+        if (run.resumePayload) {
+          await runner.resume(id);
+        } else {
+          await runner.start({
+            issueId: run.issueId,
+            issueTitle: run.issueTitle,
+            repoUrl: run.repoUrl,
+          });
+        }
+      } catch (err) {
+        return c.text(`Retry failed: ${(err as Error).message}`, 500);
+      }
+
+      const user = c.get("user" as never) as
+        | { id: string; email: string }
+        | undefined;
+      if (user) {
+        void logAuditEvent(
+          db as any,
+          dashboardRetryRunEvent({
+            runId: id,
+            issueId: run.issueId,
+            previousStatus: run.status,
+            actorUserId: user.id,
+            actorEmail: user.email,
+          }),
+        );
+      }
+      return c.redirect(`${effectiveBasePath}/runs/${id}`, 302);
+    },
+  );
 
   return router;
 }

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -7,6 +7,9 @@ import {
   agentLogs,
   logAuditEvent,
   dashboardRetryRunEvent,
+  isFeatureLicensed,
+  canAccess,
+  type Role,
 } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { runFeedView, type RunRow } from "../views/run-feed.js";
@@ -120,12 +123,25 @@ export function createRunsRouter(
         .offset(offset) as LogEntry[];
     }
 
-    const content = runDetailView(run, stages, logs, page, totalLogs);
+    const user = c.get("user" as never) as
+      | { id: string; email: string; role?: Role }
+      | undefined;
+    const canRetry = isFeatureLicensed("rbac")
+      ? canAccess((user?.role ?? "viewer") as Role, "runs.retry")
+      : true;
+    const content = runDetailView(run, stages, logs, page, totalLogs, canRetry);
     return c.html(layout(`Run ${id}`, content, effectiveBasePath));
   });
 
   router.post(
     "/runs/:id/retry",
+    async (c, next) => {
+      // Per spec §10: retry endpoint returns 404 when RBAC is unlicensed.
+      // Without this gate the endpoint would be wide-open in unlicensed
+      // deployments because requirePermission is a no-op then.
+      if (!isFeatureLicensed("rbac")) return c.notFound();
+      return next();
+    },
     requirePermission("runs.retry"),
     async (c) => {
       const id = c.req.param("id");

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -49,7 +49,7 @@ export function createRunsRouter(
   const router = new Hono();
   const d = db as AnyDb;
 
-  router.get("/", async (c) => {
+  router.get("/", requirePermission("runs.view"), async (c) => {
     const runs = await d
       .select()
       .from(pipelineRuns)
@@ -66,7 +66,7 @@ export function createRunsRouter(
   });
 
   // HTMX partial: feed of latest pipeline runs (polled every 5s)
-  router.get("/runs/feed", async (c) => {
+  router.get("/runs/feed", requirePermission("runs.view"), async (c) => {
     const runs = await d
       .select()
       .from(pipelineRuns)
@@ -76,7 +76,7 @@ export function createRunsRouter(
     return c.html(runFeedView(runs));
   });
 
-  router.get("/runs/:id", async (c) => {
+  router.get("/runs/:id", requirePermission("runs.view"), async (c) => {
     const id = c.req.param("id");
     const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
     const logsPerPage = 50;

--- a/packages/dashboard/src/routes/tokens.ts
+++ b/packages/dashboard/src/routes/tokens.ts
@@ -4,6 +4,7 @@ import type { Db } from "@urateam/core";
 import { sqlDateGroup, sqlDaysAgoFilter, stageRuns, pipelineRuns } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { tokensView } from "../views/tokens.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 type AnyDb = any;
 
@@ -15,7 +16,7 @@ export function createTokensRouter(db: Db, basePath = ""): Hono {
   const dateExpr = sqlDateGroup(db, stageRuns.startedAt);
   const thirtyDaysAgo = sqlDaysAgoFilter(db, stageRuns.startedAt, 30);
 
-  router.get("/tokens", async (c) => {
+  router.get("/tokens", requirePermission("tokens.view"), async (c) => {
     const daily = await d
       .select({
         date: dateExpr.as("date"),

--- a/packages/dashboard/src/routes/users.ts
+++ b/packages/dashboard/src/routes/users.ts
@@ -1,0 +1,91 @@
+import { Hono } from "hono";
+import type { Db, Role } from "@urateam/core";
+import {
+  listUsers,
+  setUserRole,
+  SelfDemoteError,
+  LastAdminError,
+  isFeatureLicensed,
+} from "@urateam/core";
+import { requirePermission } from "../middleware/rbac.js";
+import { renderUsersPage } from "../views/users.js";
+
+const VALID_ROLES: readonly Role[] = ["admin", "operator", "viewer"] as const;
+function parseRole(v: unknown): Role | null {
+  return typeof v === "string" && (VALID_ROLES as readonly string[]).includes(v)
+    ? (v as Role)
+    : null;
+}
+
+export interface UsersRouterDeps {
+  db: Db;
+  basePath: string;
+}
+
+export function createUsersRouter(deps: UsersRouterDeps): Hono {
+  const app = new Hono();
+
+  // Feature gate — when RBAC is unlicensed, /users returns 404
+  app.use("/users", async (c, next) => {
+    if (!isFeatureLicensed("rbac")) return c.notFound();
+    await next();
+  });
+  app.use("/users/*", async (c, next) => {
+    if (!isFeatureLicensed("rbac")) return c.notFound();
+    await next();
+  });
+
+  app.get("/users", requirePermission("users.view"), async (c) => {
+    const user = c.get("user" as never) as
+      | { id: string; email: string }
+      | undefined;
+    const users = await listUsers(deps.db as any);
+    return c.html(
+      renderUsersPage({
+        users,
+        currentUserId: user?.id ?? "",
+        basePath: deps.basePath,
+        userEmail: user?.email,
+      }),
+    );
+  });
+
+  app.post(
+    "/users/:id/role",
+    requirePermission("users.manage"),
+    async (c) => {
+      const targetId = c.req.param("id");
+      const form = await c.req.parseBody();
+      const newRole = parseRole(form.role);
+      if (!newRole) return c.text("Invalid role", 400);
+
+      const user = c.get("user" as never) as
+        | { id: string; email: string }
+        | undefined;
+      if (!user) return c.text("Unauthorized", 401);
+
+      try {
+        await setUserRole(deps.db as any, {
+          userId: targetId,
+          newRole: newRole,
+          actorUserId: user.id,
+        });
+      } catch (err) {
+        if (err instanceof SelfDemoteError) {
+          return c.text("Cannot demote yourself", 400);
+        }
+        if (err instanceof LastAdminError) {
+          return c.text("Cannot demote the last remaining admin", 400);
+        }
+        return c.text(
+          `Role update failed: ${(err as Error).message}`,
+          500,
+        );
+      }
+
+      return c.redirect(`${deps.basePath}/users`, 302);
+    },
+  );
+
+  return app;
+}

--- a/packages/dashboard/src/routes/users.ts
+++ b/packages/dashboard/src/routes/users.ts
@@ -37,7 +37,7 @@ export function createUsersRouter(deps: UsersRouterDeps): Hono {
 
   app.get("/users", requirePermission("users.view"), async (c) => {
     const user = c.get("user" as never) as
-      | { id: string; email: string }
+      | { id: string; email: string; role?: string }
       | undefined;
     const users = await listUsers(deps.db as any);
     return c.html(
@@ -46,6 +46,7 @@ export function createUsersRouter(deps: UsersRouterDeps): Hono {
         currentUserId: user?.id ?? "",
         basePath: deps.basePath,
         userEmail: user?.email,
+        userRole: user?.role,
       }),
     );
   });

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -16,6 +16,7 @@ import { createErrorsRouter } from "./routes/errors.js";
 import { createConfigRouter } from "./routes/config.js";
 import { createCoordinationRouter } from "./routes/coordination.js";
 import { createAuditRouter } from "./routes/audit.js";
+import { createUsersRouter } from "./routes/users.js";
 import { createAuthRouter } from "./routes/auth.js";
 import { createSsoMiddleware } from "./middleware/sso.js";
 import { createCostRouter } from "./routes/cost.js";
@@ -229,6 +230,9 @@ export function createDashboard(config: DashboardConfig): Hono {
     basePath,
   });
   app.route("/", costRouter);
+
+  const usersRouter = createUsersRouter({ db: config.db, basePath });
+  app.route("/", usersRouter);
 
   return app;
 }

--- a/packages/dashboard/src/views/forbidden.ts
+++ b/packages/dashboard/src/views/forbidden.ts
@@ -1,0 +1,23 @@
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function renderForbidden(args: {
+  email: string;
+  role: string;
+  action: string;
+  basePath: string;
+}): string {
+  return `<!DOCTYPE html>
+<html><head><title>Forbidden</title></head><body>
+  <h1>403 — Access denied</h1>
+  <p>Your account (<strong>${escapeHtml(args.email)}</strong>, role <strong>${escapeHtml(args.role)}</strong>) does not have permission to access this page (requires <code>${escapeHtml(args.action)}</code>).</p>
+  <p>Contact your administrator.</p>
+  <p><a href="${escapeHtml(args.basePath)}/auth/logout">Sign out</a></p>
+</body></html>`;
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -45,6 +45,7 @@ function normalizeBasePath(basePath: string): string {
  */
 export interface LayoutContext {
   userEmail?: string;
+  userRole?: string;
 }
 
 export function layout(
@@ -90,6 +91,7 @@ export function layout(
     <a href="${bp}/cost">Cost</a>
     <a href="${bp}/config">Config</a>
     <a href="${bp}/coordination">Coordination</a>
+    ${ctx?.userRole === "admin" ? `<a href="${bp}/users">Users</a>` : ""}
     ${signOut}
   </nav>
   <main>

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -85,7 +85,8 @@ export function runDetailView(
   stages: StageInfo[],
   logs: LogEntry[],
   page: number,
-  totalLogs: number
+  totalLogs: number,
+  canRetry: boolean = false,
 ): string {
   const basePath = getBasePath();
   const logsPerPage = 50;
@@ -99,6 +100,13 @@ export function runDetailView(
       ${statusBadge(run.status)}
       <span class="duration-badge" title="Total run duration">⏱ ${duration}${isInFlight ? " (running)" : ""}</span>
       ${run.prUrl ? `<a href="${escapeHtml(run.prUrl)}" target="_blank" rel="noopener" style="font-size:0.875rem;">↗ Pull Request</a>` : ""}
+      ${
+        canRetry && (run.status === "failed" || run.status === "retriable")
+          ? `<form method="post" action="${basePath}/runs/${encodeURIComponent(run.id)}/retry" hx-post="${basePath}/runs/${encodeURIComponent(run.id)}/retry" hx-headers='{"HX-Request":"true"}' style="display:inline;margin:0;">
+          <button type="submit" class="button-primary">Retry</button>
+        </form>`
+          : ""
+      }
     </div>
     <dl class="meta">
       <div><dt>Issue</dt><dd>${escapeHtml(run.issueId)}: ${escapeHtml(run.issueTitle)}</dd></div>

--- a/packages/dashboard/src/views/users.ts
+++ b/packages/dashboard/src/views/users.ts
@@ -1,0 +1,60 @@
+import type { Role } from "@urateam/core";
+import { escapeHtml, layout } from "./layout.js";
+
+export interface UserRow {
+  id: string;
+  email: string;
+  name: string | null;
+  role: Role;
+  lastLoginAt: Date | null;
+}
+
+export function renderUsersPage(args: {
+  users: UserRow[];
+  currentUserId: string;
+  basePath: string;
+  userEmail?: string;
+}): string {
+  const bp = args.basePath;
+  const rows = args.users
+    .map((u) => {
+      const isSelf = u.id === args.currentUserId;
+      const lastLogin = u.lastLoginAt
+        ? u.lastLoginAt.toISOString()
+        : "(never)";
+      const disabled = isSelf ? "disabled" : "";
+      return `
+      <tr>
+        <td>${escapeHtml(u.email)}${isSelf ? " <em>(you)</em>" : ""}</td>
+        <td>${escapeHtml(u.name ?? "")}</td>
+        <td>${escapeHtml(u.role)}</td>
+        <td>${escapeHtml(lastLogin)}</td>
+        <td>
+          <form method="post" action="${bp}/users/${escapeHtml(u.id)}/role" hx-post="${bp}/users/${escapeHtml(u.id)}/role" hx-headers='{"HX-Request":"true"}'>
+            <select name="role" ${disabled}>
+              <option value="admin" ${u.role === "admin" ? "selected" : ""}>admin</option>
+              <option value="operator" ${u.role === "operator" ? "selected" : ""}>operator</option>
+              <option value="viewer" ${u.role === "viewer" ? "selected" : ""}>viewer</option>
+            </select>
+            <button type="submit" ${disabled}>Update</button>
+          </form>
+        </td>
+      </tr>`;
+    })
+    .join("");
+
+  const content = `
+  <table class="users-table">
+    <thead>
+      <tr>
+        <th>Email</th><th>Name</th><th>Role</th><th>Last login</th><th></th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+
+  return layout("Users", content, bp, {
+    userEmail: args.userEmail,
+    userRole: "admin",
+  });
+}

--- a/packages/dashboard/src/views/users.ts
+++ b/packages/dashboard/src/views/users.ts
@@ -14,6 +14,7 @@ export function renderUsersPage(args: {
   currentUserId: string;
   basePath: string;
   userEmail?: string;
+  userRole?: string;
 }): string {
   const bp = args.basePath;
   const rows = args.users
@@ -55,6 +56,6 @@ export function renderUsersPage(args: {
 
   return layout("Users", content, bp, {
     userEmail: args.userEmail,
-    userRole: "admin",
+    userRole: args.userRole,
   });
 }


### PR DESCRIPTION
## Summary
- Three-role model (admin/operator/viewer) layered on SSO's `dashboard_users` table
- Static permission matrix (`PERMISSION_MATRIX`) gates every dashboard route via `requirePermission(action)` middleware
- Admin UI at `/users` and `ura admin list/grant/revoke` CLI for role management
- `POST /runs/:id/retry` — the one v1 write action, gated by `runs.retry` (operator+admin), license-gated to 404 when unlicensed
- `URATEAM_ADMIN_EMAILS` env var bootstraps first admins on SSO callback
- Four `dashboard.manual_action` audit subtypes: grant_role, revoke_role, bootstrap_admin, retry_run
- Self-lockout and last-admin-demote guards enforced inside a transaction in `setUserRole`
- `getUserById` includes `role` field (caught by holistic review — omission would have made every user 403)
- Scoped roles (per team/repo) deferred to v2 with extension-point schema documented

Spec: docs/superpowers/specs/2026-04-15-rbac-design.md
Plan: docs/superpowers/plans/2026-04-15-rbac.md

## Test plan
- [x] pnpm build — clean
- [x] Core rbac suite — 90 tests passing (matrix, store, bootstrap, audit builders, license, integration)
- [x] Dashboard suite — 182 tests passing (middleware, users routes, retry, bootstrap integration, existing routes with permission decorations)
- [x] CLI admin-commands — 5 tests passing
- [x] Holistic review — 1 critical + 3 high + 2 medium findings; all fixed inline
- [ ] Manual: set URATEAM_ADMIN_EMAILS, log in, verify role=admin
- [ ] Manual: promote second user via /users UI, verify retry button on failed runs
- [ ] Manual: ura admin list/grant/revoke CLI

## Deferred
- Scoped roles per team/repo (v2 — `user_scope_roles` table)
- Additional write actions (abort, approve, cancel, manual promote)
- Role expiration / time-limited grants
- Bulk role assignment / CSV import
- Users nav link threading to all routes (currently visible on /users page only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)