### PR TITLE
fix: Phase 1 tier-1 follow-ups batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ It is a pnpm monorepo with 3 packages:
 - Reader merges native rows + projected rows by `(timestamp DESC, id DESC)` and supports cursor-based SQL filtering on all 4 sources to avoid pagination truncation
 - Dashboard route: `/audit` (filter bar, HTMX pagination), `/audit/page` (partial), `/audit/export.csv` (streamed). All return 404 unless `isFeatureLicensed("audit-log")`. View: `packages/dashboard/src/views/audit.ts` — all user-controlled fields go through `escapeHtml`
 - Retention sweep runs in PM tick after `digest`, default 365 days, configurable via `auditLog.retentionDays`. Tick step is gated on `isFeatureLicensed("audit-log")`
-- **`config.loaded` event currently only fires from `ura run`** — `ura dev` / `ura start` (production paths) build config from env vars and have no file path to fingerprint. Follow-up to wire those when needed.
+- **`config.loaded` event fires from all CLI paths** — `ura run` fingerprints the config file; `ura dev` / `ura start` emit with `path: "(env-vars)"` and a hash of pipeline config keys.
 - `/audit/event/:id` HTMX detail expansion route is in the spec but deferred — table shows truncated payload inline
 
 ### SSO via WorkOS (Enterprise feature 4.1)
@@ -171,7 +171,7 @@ It is a pnpm monorepo with 3 packages:
 - Audit events: `dashboard.login`, `dashboard.logout`, `dashboard.login_denied` flow through the existing license-gated `logAuditEvent`
 - Retention: PM tick calls `pruneExpiredSessions` after `pruneAuditLog`, gated on the SSO feature
 - Setup doc: `deploy/SSO_SETUP.md`
-- **Sign Out link is currently only on the Audit page**; threading user context through `runs`/`tokens`/`errors`/`config` views is a follow-up
+- **Sign Out link** renders on all dashboard pages when SSO is active (user context threaded through all route handlers)
 - **Session id MUST NOT be logged** — they're credentials. The `touchSessionLastSeen` warn logs only `idPrefix: id.slice(0,8) + "…"`
 
 ### Org policy / guardrails (Enterprise feature 4.6)

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -63,7 +63,7 @@ export const devCommand = new Command("dev")
       const { checkLicense, logAuditEvent, configLoadedEvent } = await import("@urateam/core");
       const { createHash } = await import("node:crypto");
       const status = checkLicense(db);
-      const sha = createHash("sha256").update(JSON.stringify(Object.keys(config.pipelineConfigs))).digest("hex");
+      const sha = createHash("sha256").update(JSON.stringify(config.pipelineConfigs, null, 0)).digest("hex");
       void logAuditEvent(db, configLoadedEvent({ path: "(env-vars)", sha256: sha, tier: status.tier }));
     } catch {
       // audit must never crash startup

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -58,6 +58,17 @@ export const devCommand = new Command("dev")
     const ssoBootstrap = await bootstrapSsoFromEnv();
 
     const { app, db } = await createApp(config);
+
+    try {
+      const { checkLicense, logAuditEvent, configLoadedEvent } = await import("@urateam/core");
+      const { createHash } = await import("node:crypto");
+      const status = checkLicense(db);
+      const sha = createHash("sha256").update(JSON.stringify(Object.keys(config.pipelineConfigs))).digest("hex");
+      void logAuditEvent(db, configLoadedEvent({ path: "(env-vars)", sha256: sha, tier: status.tier }));
+    } catch {
+      // audit must never crash startup
+    }
+
     const dashboardApp = createDashboard({
       db,
       pipelineConfigs: config.pipelineConfigs,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -162,7 +162,7 @@ export const startCommand = new Command("start")
       const { checkLicense, logAuditEvent, configLoadedEvent } = await import("@urateam/core");
       const { createHash } = await import("node:crypto");
       const status = checkLicense(db);
-      const sha = createHash("sha256").update(JSON.stringify(Object.keys(config.pipelineConfigs))).digest("hex");
+      const sha = createHash("sha256").update(JSON.stringify(config.pipelineConfigs, null, 0)).digest("hex");
       void logAuditEvent(db, configLoadedEvent({ path: "(env-vars)", sha256: sha, tier: status.tier }));
     } catch {
       // audit must never crash startup

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -158,6 +158,16 @@ export const startCommand = new Command("start")
     // --- Start servers ---
     const { app, runner, db } = await createApp(config);
 
+    try {
+      const { checkLicense, logAuditEvent, configLoadedEvent } = await import("@urateam/core");
+      const { createHash } = await import("node:crypto");
+      const status = checkLicense(db);
+      const sha = createHash("sha256").update(JSON.stringify(Object.keys(config.pipelineConfigs))).digest("hex");
+      void logAuditEvent(db, configLoadedEvent({ path: "(env-vars)", sha256: sha, tier: status.tier }));
+    } catch {
+      // audit must never crash startup
+    }
+
     // --- Recover runs interrupted by a previous restart ---
     await runner.recoverStuckRuns();
     const port = parseInt(process.env.PORT ?? options.port, 10);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: BUSL-1.1
 #!/usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
 // Auto-load .env file from the current working directory before any command
 // imports read process.env. Uses Node 22's built-in loadEnvFile (no deps).
 // Silently skips if .env is absent (ENOENT). Warns on other errors

--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -48,4 +48,35 @@ describe("audit_events immutability", () => {
       `Unauthorized audit_events mutation in:\n${offenders.join("\n")}`,
     ).toEqual([]);
   });
+
+  it("logAuditEventUnchecked is only called from license.ts", () => {
+    const repoRoot = path.resolve(__dirname, "../../../..");
+    const allowed = [
+      "packages/core/src/audit/writer.ts",
+      "packages/core/src/audit/index.ts",
+      "packages/core/src/license.ts",
+      "packages/core/src/__tests__/audit-immutability.test.ts",
+    ];
+
+    let matches: string[] = [];
+    try {
+      const out = execFileSync(
+        "git",
+        ["grep", "-nE", "logAuditEventUnchecked", "--", "packages/**/*.ts"],
+        { cwd: repoRoot, encoding: "utf8" },
+      );
+      matches = out.trim().split("\n").filter(Boolean);
+    } catch {
+      // no matches
+    }
+
+    const offenders = matches
+      .map((line) => line.split(":")[0]!)
+      .filter((file) => !allowed.some((a) => file.endsWith(a) || file === a));
+
+    expect(
+      offenders,
+      `Unauthorized logAuditEventUnchecked usage in:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
 });

--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -53,7 +53,6 @@ describe("audit_events immutability", () => {
     const repoRoot = path.resolve(__dirname, "../../../..");
     const allowed = [
       "packages/core/src/audit/writer.ts",
-      "packages/core/src/audit/index.ts",
       "packages/core/src/license.ts",
       "packages/core/src/__tests__/audit-immutability.test.ts",
     ];

--- a/packages/core/src/audit/reader.ts
+++ b/packages/core/src/audit/reader.ts
@@ -106,16 +106,21 @@ export async function listAuditEvents(
     .limit(limit * 4);
 
   // Projected: pm_approvals (filter by createdAt)
-  const apprConditions: any[] = [];
-  if (filters.from) apprConditions.push(gte(pmApprovals.createdAt, filters.from));
-  if (filters.to) apprConditions.push(lte(pmApprovals.createdAt, filters.to));
-  if (cursorTs) apprConditions.push(lte(pmApprovals.createdAt, cursorTs));
-  const apprRows = await (db as any)
-    .select()
-    .from(pmApprovals)
-    .where(apprConditions.length ? and(...apprConditions) : undefined)
-    .orderBy(desc(pmApprovals.createdAt))
-    .limit(limit * 4);
+  // Projected pm_approvals always have scope=null, so skip the query entirely
+  // when a scope filter is set — avoids an unbounded fetch.
+  let apprRows: any[] = [];
+  if (!filters.scope) {
+    const apprConditions: any[] = [];
+    if (filters.from) apprConditions.push(gte(pmApprovals.createdAt, filters.from));
+    if (filters.to) apprConditions.push(lte(pmApprovals.createdAt, filters.to));
+    if (cursorTs) apprConditions.push(lte(pmApprovals.createdAt, cursorTs));
+    apprRows = await (db as any)
+      .select()
+      .from(pmApprovals)
+      .where(apprConditions.length ? and(...apprConditions) : undefined)
+      .orderBy(desc(pmApprovals.createdAt))
+      .limit(limit * 4);
+  }
 
   // Projected: budget_alerts (filter by firedAt)
   const alertConditions: any[] = [];

--- a/packages/core/src/audit/reader.ts
+++ b/packages/core/src/audit/reader.ts
@@ -126,6 +126,7 @@ export async function listAuditEvents(
   const alertConditions: any[] = [];
   if (filters.from) alertConditions.push(gte(budgetAlerts.firedAt, filters.from));
   if (filters.to) alertConditions.push(lte(budgetAlerts.firedAt, filters.to));
+  if (filters.scope) alertConditions.push(eq(budgetAlerts.scope, filters.scope));
   if (cursorTs) alertConditions.push(lte(budgetAlerts.firedAt, cursorTs));
   const alertRows = await (db as any)
     .select()

--- a/packages/core/src/auth/workos-client.ts
+++ b/packages/core/src/auth/workos-client.ts
@@ -34,6 +34,9 @@ let cached: WorkosClient | null = null;
 /**
  * Default WorkOS client. Lazily instantiates the SDK on first use so test
  * environments that never call this never need the SDK installed.
+ *
+ * NOTE: The singleton cache is not keyed on apiKey. If the API key is
+ * rotated, the process must be restarted to pick up the new key.
  */
 export async function getDefaultWorkosClient(apiKey: string): Promise<WorkosClient> {
   if (cached) return cached;

--- a/packages/core/src/pm/budget.ts
+++ b/packages/core/src/pm/budget.ts
@@ -112,12 +112,14 @@ export async function evaluateBudget(
   scopes.push(makeScope({ kind: "global" }, globalUsed, globalLimit));
 
   for (const [teamId, used] of teamUsed) {
-    const limit = config.budgets?.perTeam?.[teamId] ?? defaultLimit;
+    const perTeam = config.budgets?.perTeam;
+    const limit = (perTeam && Object.hasOwn(perTeam, teamId)) ? perTeam[teamId] : defaultLimit;
     scopes.push(makeScope({ kind: "team", teamId }, used, limit));
   }
 
   for (const [repoUrl, used] of repoUsed) {
-    const limit = config.budgets?.perRepo?.[repoUrl] ?? defaultLimit;
+    const perRepo = config.budgets?.perRepo;
+    const limit = (perRepo && Object.hasOwn(perRepo, repoUrl)) ? perRepo[repoUrl] : defaultLimit;
     scopes.push(makeScope({ kind: "repo", repoUrl }, used, limit));
   }
 

--- a/packages/dashboard/src/middleware/sso.ts
+++ b/packages/dashboard/src/middleware/sso.ts
@@ -13,6 +13,10 @@ interface SsoMiddlewareDeps {
   sso: SsoConfig;
 }
 
+// CSRF note: the session cookie uses SameSite=Lax. This prevents
+// cross-origin POST from third-party sites (CSRF), but allows top-level
+// navigations (GET). The dashboard CSRF middleware separately rejects
+// state-changing requests without the HX-Request header.
 export function createSsoMiddleware(
   deps: SsoMiddlewareDeps,
 ): MiddlewareHandler {

--- a/packages/dashboard/src/routes/config.ts
+++ b/packages/dashboard/src/routes/config.ts
@@ -13,7 +13,8 @@ export function createConfigRouter(
 
   router.get("/config", requirePermission("config.view"), (c) => {
     const content = configView(pipelineConfigs, repoConfigs);
-    return c.html(layout("Configuration", content, basePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(layout("Configuration", content, basePath, { userEmail: user?.email }));
   });
 
   return router;

--- a/packages/dashboard/src/routes/coordination.ts
+++ b/packages/dashboard/src/routes/coordination.ts
@@ -16,7 +16,8 @@ export function createCoordinationRouter(db: Db, basePath = ""): Hono {
       return c.html(content);
     }
 
-    return c.html(layout("Coordination", content, basePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(layout("Coordination", content, basePath, { userEmail: user?.email }));
   });
 
   // HTMX partial: active coordination feed (polled every 10s)

--- a/packages/dashboard/src/routes/cost.ts
+++ b/packages/dashboard/src/routes/cost.ts
@@ -64,7 +64,8 @@ export function createCostRouter(deps: CostRouterDeps): Hono {
     );
     const content = renderCostPage({ result, filters, costs, basePath });
     if (c.req.header("HX-Request")) return c.html(content);
-    return c.html(layout("Cost & ROI", content, basePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(layout("Cost & ROI", content, basePath, { userEmail: user?.email }));
   });
 
   router.get("/cost/page", async (c) => {

--- a/packages/dashboard/src/routes/errors.ts
+++ b/packages/dashboard/src/routes/errors.ts
@@ -37,7 +37,8 @@ export function createErrorsRouter(db: Db, basePath = ""): Hono {
       .limit(50);
 
     const content = errorsView(stageFailures, errorPatterns);
-    return c.html(layout("Errors", content, basePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(layout("Errors", content, basePath, { userEmail: user?.email }));
   });
 
   return router;

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -65,7 +65,8 @@ export function createRunsRouter(
       return c.html(content);
     }
 
-    return c.html(layout("Pipeline Runs", content, effectiveBasePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(layout("Pipeline Runs", content, effectiveBasePath, { userEmail: user?.email }));
   });
 
   // HTMX partial: feed of latest pipeline runs (polled every 5s)
@@ -91,7 +92,8 @@ export function createRunsRouter(
       .limit(1) as (RunInfo | undefined)[];
 
     if (!run) {
-      return c.html(layout("Not Found", "<p>Run not found</p>", effectiveBasePath), 404);
+      const user = c.get("user" as never) as { email?: string } | undefined;
+      return c.html(layout("Not Found", "<p>Run not found</p>", effectiveBasePath, { userEmail: user?.email }), 404);
     }
 
     const stages = await d
@@ -130,7 +132,7 @@ export function createRunsRouter(
       ? canAccess((user?.role ?? "viewer") as Role, "runs.retry")
       : true;
     const content = runDetailView(run, stages, logs, page, totalLogs, canRetry);
-    return c.html(layout(`Run ${id}`, content, effectiveBasePath));
+    return c.html(layout(`Run ${id}`, content, effectiveBasePath, { userEmail: user?.email }));
   });
 
   router.post(

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -84,6 +84,9 @@ export function createRunsRouter(
     const id = c.req.param("id");
     const page = Math.max(1, parseInt(c.req.query("page") || "1", 10));
     const logsPerPage = 50;
+    const user = c.get("user" as never) as
+      | { id: string; email: string; role?: Role }
+      | undefined;
 
     const [run] = await d
       .select()
@@ -92,7 +95,6 @@ export function createRunsRouter(
       .limit(1) as (RunInfo | undefined)[];
 
     if (!run) {
-      const user = c.get("user" as never) as { email?: string } | undefined;
       return c.html(layout("Not Found", "<p>Run not found</p>", effectiveBasePath, { userEmail: user?.email }), 404);
     }
 
@@ -125,9 +127,6 @@ export function createRunsRouter(
         .offset(offset) as LogEntry[];
     }
 
-    const user = c.get("user" as never) as
-      | { id: string; email: string; role?: Role }
-      | undefined;
     const canRetry = isFeatureLicensed("rbac")
       ? canAccess((user?.role ?? "viewer") as Role, "runs.retry")
       : true;

--- a/packages/dashboard/src/routes/tokens.ts
+++ b/packages/dashboard/src/routes/tokens.ts
@@ -50,7 +50,8 @@ export function createTokensRouter(db: Db, basePath = ""): Hono {
       .orderBy(sql`(COALESCE(SUM(${stageRuns.inputTokens}), 0) + COALESCE(SUM(${stageRuns.outputTokens}), 0)) DESC`);
 
     const content = tokensView(daily, byPipeline, byStage);
-    return c.html(layout("Token Usage", content, basePath));
+    const user = c.get("user" as never) as { email?: string } | undefined;
+    return c.html(layout("Token Usage", content, basePath, { userEmail: user?.email }));
   });
 
   return router;


### PR DESCRIPTION
## Summary
- Thread SSO user context through all dashboard routes so Sign Out renders on every page (not just /audit)
- Add `Object.hasOwn` checks on `config.budgets.perTeam`/`perRepo` to prevent prototype pollution
- Add `logAuditEventUnchecked` lint guard test (allowlist-based, same pattern as immutability test)
- Skip unbounded `pmApprovals` fetch when audit reader scope filter is set (projected events always have `scope: null`)
- Emit `config.loaded` audit event from `ura dev` / `ura start` (env-var configs use `path: "(env-vars)"`)
- Document `SameSite=Lax` CSRF dependency in SSO middleware
- Document WorkOS client singleton cache key rotation requirement
- Fix pre-existing CLI build: move SPDX header after shebang line

## Test plan
- [x] `pnpm build` — all 4 packages pass (CLI build was broken before, now fixed)
- [x] `npx vitest run` — 1077 tests pass, 0 failures
- [x] New `logAuditEventUnchecked` lint guard test passes
- [x] Audit immutability test still passes with new test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)