### PR TITLE
feat: per-scope budget breakdown in PM digest

### DIFF
--- a/packages/core/src/__tests__/pm-slack.test.ts
+++ b/packages/core/src/__tests__/pm-slack.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PmSlackNotifier } from "../pm/slack.js";
-import type { TickResult, BudgetGuardResult } from "../pm/types.js";
+import type { TickResult, BudgetGuardResult, ScopeBudget } from "../pm/types.js";
 
 const mockFetch = vi.fn().mockResolvedValue({
   ok: true,
@@ -46,6 +46,45 @@ describe("PmSlackNotifier", () => {
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.channel).toBe("C0123456789");
     expect(body.blocks).toBeDefined();
+  });
+
+  it("includes per-scope budget breakdown when scopes have warnings", async () => {
+    const scopes: ScopeBudget[] = [
+      { scope: { kind: "global" }, scopeLabel: "global", limit: 1_000_000, used: 800_000, percent: 80, tier: "warn-80" },
+      { scope: { kind: "team", teamId: "TEAM-1" }, scopeLabel: "team TEAM-1", limit: 500_000, used: 450_000, percent: 90, tier: "warn-80" },
+      { scope: { kind: "repo", repoUrl: "https://github.com/test/repo" }, scopeLabel: "repo https://github.com/test/repo", limit: 200_000, used: 100_000, percent: 50, tier: "warn-50" },
+    ];
+    const tick: TickResult = {
+      ...emptyTick(),
+      triaged: [{ issueId: "BEC-1", priority: 2, labels: ["bug"], complexity: "small", rationale: "test", acceptanceCriteria: [] }],
+      budgetGuard: { ...emptyBudget(), activeCount: 1, tokenSpendPercent: 80 },
+      budgetScopes: scopes,
+    };
+    await notifier.postDigest(tick, 3);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const text = body.blocks[0].text.text;
+    expect(text).toContain("Budget by scope");
+    expect(text).toContain("team TEAM-1");
+    expect(text).toContain("90%");
+    expect(text).not.toContain("global");
+  });
+
+  it("omits scope breakdown when all scopes are ok", async () => {
+    const scopes: ScopeBudget[] = [
+      { scope: { kind: "global" }, scopeLabel: "global", limit: 1_000_000, used: 100_000, percent: 10, tier: "ok" },
+      { scope: { kind: "team", teamId: "TEAM-1" }, scopeLabel: "team TEAM-1", limit: 500_000, used: 50_000, percent: 10, tier: "ok" },
+    ];
+    const tick: TickResult = {
+      ...emptyTick(),
+      triaged: [{ issueId: "BEC-2", priority: 2, labels: ["bug"], complexity: "small", rationale: "test", acceptanceCriteria: [] }],
+      budgetGuard: { ...emptyBudget(), activeCount: 1, tokenSpendPercent: 10 },
+      budgetScopes: scopes,
+    };
+    await notifier.postDigest(tick, 3);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const text = body.blocks[0].text.text;
+    expect(text).not.toContain("Budget by scope");
   });
 
   it("skips digest for empty tick", async () => {

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -161,6 +161,7 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           tokenSpendPercent: globalScope?.percent ?? 0,
           dailyTokensUsed: globalScope?.used ?? 0,
         };
+        tick.budgetScopes = evaluation.scopes;
 
         // Emit budget.run_refused audit events for every scope at blocked-100.
         // Recovers the per-scope breakdown that is otherwise dropped when we

--- a/packages/core/src/pm/slack.ts
+++ b/packages/core/src/pm/slack.ts
@@ -36,6 +36,14 @@ export class PmSlackNotifier {
     const lines: string[] = [];
     lines.push(`*PM Agent Run* — ${new Date().toUTCString()}`);
     lines.push(`In-flight: ${bg.activeCount}/${maxInFlight} | Token budget: ${bg.tokenSpendPercent}% used`);
+    const warnScopes = (tick.budgetScopes ?? []).filter((s) => s.tier !== "ok" && s.scope.kind !== "global");
+    if (warnScopes.length > 0) {
+      const scopeLines = warnScopes.map((s) => {
+        const icon = s.tier === "blocked-100" ? "🔴" : s.tier === "warn-80" ? "🟠" : "🟡";
+        return `${icon} ${s.scopeLabel}: ${s.percent}% (${s.used.toLocaleString()}/${s.limit.toLocaleString()})`;
+      });
+      lines.push(`*Budget by scope:* ${scopeLines.join(" | ")}`);
+    }
     if (tick.paused) {
       lines.push("⏸ *Paused* — skipping promote/deprioritize/cancel");
     }

--- a/packages/core/src/pm/slack.ts
+++ b/packages/core/src/pm/slack.ts
@@ -38,11 +38,14 @@ export class PmSlackNotifier {
     lines.push(`In-flight: ${bg.activeCount}/${maxInFlight} | Token budget: ${bg.tokenSpendPercent}% used`);
     const warnScopes = (tick.budgetScopes ?? []).filter((s) => s.tier !== "ok" && s.scope.kind !== "global");
     if (warnScopes.length > 0) {
-      const scopeLines = warnScopes.map((s) => {
+      const maxDisplay = 10;
+      const display = warnScopes.slice(0, maxDisplay);
+      const scopeLines = display.map((s) => {
         const icon = s.tier === "blocked-100" ? "🔴" : s.tier === "warn-80" ? "🟠" : "🟡";
         return `${icon} ${s.scopeLabel}: ${s.percent}% (${s.used.toLocaleString()}/${s.limit.toLocaleString()})`;
       });
-      lines.push(`*Budget by scope:* ${scopeLines.join(" | ")}`);
+      const suffix = warnScopes.length > maxDisplay ? ` +${warnScopes.length - maxDisplay} more` : "";
+      lines.push(`*Budget by scope:* ${scopeLines.join(" | ")}${suffix}`);
     }
     if (tick.paused) {
       lines.push("⏸ *Paused* — skipping promote/deprioritize/cancel");

--- a/packages/core/src/pm/types.ts
+++ b/packages/core/src/pm/types.ts
@@ -96,6 +96,8 @@ export interface TickResult {
   cancelRequested: string[];
   errors: string[];
   budgetGuard: BudgetGuardResult;
+  /** Per-scope budget breakdown from the evaluation (team/repo/global). */
+  budgetScopes?: ScopeBudget[];
   /** True when the PM Agent is paused — promote/deprioritize/cancel were skipped. */
   paused?: boolean;
   /** Issue identifiers auto-recovered from stuck "In Progress" state. */


### PR DESCRIPTION
## Summary
- Add `budgetScopes` field to `TickResult` (threads `ScopeBudget[]` from evaluation)
- Set `tick.budgetScopes = evaluation.scopes` in scheduler after budget evaluation
- Render non-ok team/repo scopes in digest Slack message with color-coded icons (yellow=warn-50, orange=warn-80, red=blocked-100)
- Global scope excluded from breakdown (already shown in header as `Token budget: X% used`)

## Test plan
- [x] `pnpm build` — all 4 packages pass
- [x] 8/8 PM Slack tests pass (2 new: scope rendering + omitted when all ok)
- [x] Existing digest tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)