### PR TITLE
perf: cache GitHub team membership in reviewer gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ It is a pnpm monorepo with 3 packages:
 - Violations set `run.shouldDraft = true` and push `ReviewFinding` entries (`category: "policy-path" | "policy-cost"`) into `unresolvedBlockingFindings` — flows through the existing draft-PR renderer
 - Audit events: `policy.path_blocked`, `policy.cost_exceeded`, `policy.override_used`, `policy.reviewers_requested`
 - License gate: `isFeatureLicensed("org-policy")` required at every call site
-- **Known perf follow-up**: `verifyApprovalsReceived` calls `listMembersInOrg` per team per check with no cache — high-frequency CI webhooks on a PR with 5+ required teams can exhaust GitHub's secondary rate limit. Documented TODO in the auto-merge gate block
+- **Team membership cache**: `verifyApprovalsReceived` caches `listMembersInOrg` results in a module-level TTL map keyed by `(org, team_slug)`. Default TTL is 15 minutes. Tests can clear via `_clearTeamMembershipCache()`. Previously uncached — high-frequency CI webhooks on a PR with 5+ required teams could exhaust GitHub's secondary rate limit.
 
 ### Cost & ROI dashboard (Enterprise feature 4.5)
 - Module: `packages/core/src/cost/` — `rates.ts` (model-rate + time-saved resolution), `per-run.ts` (`computeRunCost`), `aggregate.ts` (`aggregateAll` over runs+stages with 10k row cap + `truncated` flag), `rollup.ts` (`recomputeCostRollups`, `readRollupWindow`), `csv.ts` (`streamCostCsv` with formula-injection guard)

--- a/packages/core/src/__tests__/policy/reviewer-gate.test.ts
+++ b/packages/core/src/__tests__/policy/reviewer-gate.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
-import { buildReviewerRequest, verifyApprovalsReceived } from "../../policy/reviewer-gate.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  buildReviewerRequest,
+  verifyApprovalsReceived,
+  _clearTeamMembershipCache,
+} from "../../policy/reviewer-gate.js";
+
+beforeEach(() => {
+  _clearTeamMembershipCache();
+});
 
 describe("buildReviewerRequest", () => {
   it("returns null when policy undefined", () => {
@@ -90,6 +98,35 @@ describe("verifyApprovalsReceived", () => {
       { users: [], teams: ["security"] },
     );
     expect(r.satisfied).toBe(true);
+  });
+
+  it("caches team membership across repeated calls with same (org, team)", async () => {
+    const octokit = stubOctokit(["alice"], { security: ["alice", "carol"] });
+    // First call — fetches and caches
+    await verifyApprovalsReceived(octokit, "owner", "repo", 1, { users: [], teams: ["security"] });
+    expect(octokit.teams.listMembersInOrg).toHaveBeenCalledTimes(1);
+    // Second call on same PR — cache hit, no new fetch
+    await verifyApprovalsReceived(octokit, "owner", "repo", 1, { users: [], teams: ["security"] });
+    expect(octokit.teams.listMembersInOrg).toHaveBeenCalledTimes(1);
+    // Different PR, same team — still cached
+    await verifyApprovalsReceived(octokit, "owner", "repo", 2, { users: [], teams: ["security"] });
+    expect(octokit.teams.listMembersInOrg).toHaveBeenCalledTimes(1);
+  });
+
+  it("cache is keyed on (org, team) — different orgs don't share cache", async () => {
+    const octokit = stubOctokit(["alice"], { security: ["alice"] });
+    await verifyApprovalsReceived(octokit, "org1", "repo", 1, { users: [], teams: ["security"] });
+    await verifyApprovalsReceived(octokit, "org2", "repo", 1, { users: [], teams: ["security"] });
+    expect(octokit.teams.listMembersInOrg).toHaveBeenCalledTimes(2);
+  });
+
+  it("cache is cleared by _clearTeamMembershipCache", async () => {
+    const octokit = stubOctokit(["alice"], { security: ["alice"] });
+    await verifyApprovalsReceived(octokit, "owner", "repo", 1, { users: [], teams: ["security"] });
+    expect(octokit.teams.listMembersInOrg).toHaveBeenCalledTimes(1);
+    _clearTeamMembershipCache();
+    await verifyApprovalsReceived(octokit, "owner", "repo", 1, { users: [], teams: ["security"] });
+    expect(octokit.teams.listMembersInOrg).toHaveBeenCalledTimes(2);
   });
 
   it("not satisfied when no member of a required team has approved", async () => {

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -1896,9 +1896,6 @@ export class PipelineRunner {
                 if (owner && repo && prNumber) {
                   try {
                     const octokit = await createGitHubClient(this.githubConfig);
-                    // TODO(perf): cache listMembersInOrg results per (org, team) for ~5min to
-                    // avoid secondary rate limit exhaustion on high-frequency CI webhooks.
-                    // See spec §13 deferred items.
                     const check = await verifyApprovalsReceived(
                       octokit as any,
                       owner,

--- a/packages/core/src/policy/reviewer-gate.ts
+++ b/packages/core/src/policy/reviewer-gate.ts
@@ -1,5 +1,29 @@
 import type { Policy } from "../types.js";
 
+/**
+ * TTL cache for GitHub team membership lookups. High-frequency CI webhooks on
+ * a PR with multiple required teams otherwise call `listMembersInOrg` on every
+ * check, exhausting GitHub's secondary rate limit.
+ *
+ * Cache key: `${org}/${team_slug}`. Stale entries are evicted on read.
+ * Default TTL: 15 minutes (team rosters change infrequently).
+ *
+ * This is module-level state — acceptable here because (a) team membership is
+ * not tenant-scoped in any way within a single process, and (b) the cache is
+ * memory-only so key rotation requires a process restart anyway.
+ */
+const TEAM_CACHE_TTL_MS = 15 * 60 * 1000;
+interface TeamCacheEntry {
+  members: string[]; // lowercased logins
+  expiresAt: number;
+}
+const teamCache = new Map<string, TeamCacheEntry>();
+
+/** Test-only: clear the team membership cache between runs. */
+export function _clearTeamMembershipCache(): void {
+  teamCache.clear();
+}
+
 export interface ReviewerRequest {
   users: string[];
   teams: string[];
@@ -65,9 +89,19 @@ export async function verifyApprovalsReceived(
   const missingUsers = required.users.filter((u) => !approved.has(u.toLowerCase()));
 
   const missingTeams: string[] = [];
+  const now = Date.now();
   for (const team of required.teams) {
-    const members = await octokit.teams.listMembersInOrg({ org: owner, team_slug: team });
-    const memberSet = new Set(members.data.map((m) => m.login.toLowerCase()));
+    const cacheKey = `${owner}/${team}`;
+    let memberLogins: string[];
+    const cached = teamCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      memberLogins = cached.members;
+    } else {
+      const members = await octokit.teams.listMembersInOrg({ org: owner, team_slug: team });
+      memberLogins = members.data.map((m) => m.login.toLowerCase());
+      teamCache.set(cacheKey, { members: memberLogins, expiresAt: now + TEAM_CACHE_TTL_MS });
+    }
+    const memberSet = new Set(memberLogins);
     const anyApproved = Array.from(approved).some((u) => memberSet.has(u));
     if (!anyApproved) missingTeams.push(team);
   }

--- a/packages/core/src/policy/reviewer-gate.ts
+++ b/packages/core/src/policy/reviewer-gate.ts
@@ -91,7 +91,10 @@ export async function verifyApprovalsReceived(
   const missingTeams: string[] = [];
   const now = Date.now();
   for (const team of required.teams) {
-    const cacheKey = `${owner}/${team}`;
+    // Null byte separator: unambiguous even if a future API allows "/" in
+    // org or team slugs. GitHub today forbids "/" in both, so this is
+    // defensive rather than strictly necessary.
+    const cacheKey = `${owner}\x00${team}`;
     let memberLogins: string[];
     const cached = teamCache.get(cacheKey);
     if (cached && cached.expiresAt > now) {


### PR DESCRIPTION
## Summary
- Module-level TTL cache (15 min) in \`reviewer-gate.ts\` keyed by \`(org, team_slug)\` for \`listMembersInOrg\` responses
- Stale entries evicted on read (no background sweep needed)
- Exports \`_clearTeamMembershipCache()\` for test isolation
- Previously uncached: high-frequency CI webhooks on PRs with 5+ required teams could exhaust GitHub's secondary rate limit

## Test plan
- [x] \`pnpm build\` — all 4 packages pass
- [x] 14/14 reviewer-gate tests pass (3 new cache tests: hit on repeat call, keyed on org, clear works)
- [x] 3/3 auto-merge-reviewer-gate tests still pass
- [x] CLAUDE.md updated — replaced \"Known perf follow-up\" with cache description

🤖 Generated with [Claude Code](https://claude.com/claude-code)