### PR TITLE
feat: rollup-backed reads for preset cost windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ It is a pnpm monorepo with 3 packages:
 - Day boundary: half-open `[start, end)` with `lt` (not `lte`) to avoid sub-millisecond precision drops on Postgres `TIMESTAMPTZ`
 - Dashboard route `/cost` — summary card + 3 breakdown tables (team/repo/pipeline) + collapsible formula footer + CSV export at `/cost/export.csv`. All 3 routes 404 unless `isFeatureLicensed("cost-roi")`
 - **10k run cap on `aggregateAll`**: when exceeded, results are truncated to the 10k most recent and `summary.truncated = true`; dashboard shows a warning banner
-- Preset windows (7d/30d/90d/365d) currently go through `aggregateAll` live; `readRollupWindow` exists but is deferred to v2 for rollup-backed reads
+- Preset windows (7d/30d/90d/365d) use `aggregateHybrid` — pre-computed rollup rows for whole UTC days before today, plus live `aggregateAll` for today's partial data, merged into one `AggregateResult`. Custom ranges bypass rollups via `opts.enableRollups = false` since arbitrary `from` times don't align to UTC day boundaries. Preset `from` is snapped to UTC midnight via `snapToUtcDayStart`.
 
 ### RBAC / multi-user (Enterprise feature 4.4)
 - Module: `packages/core/src/rbac/` — `matrix.ts` (PERMISSION_MATRIX + canAccess), `user-role-store.ts` (setUserRole, getUserRole, listUsers, applyBootstrapAdmins), `errors.ts` (SelfDemoteError, LastAdminError)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,8 @@ It is a pnpm monorepo with 3 packages:
 - Dashboard route `/cost` — summary card + 3 breakdown tables (team/repo/pipeline) + collapsible formula footer + CSV export at `/cost/export.csv`. All 3 routes 404 unless `isFeatureLicensed("cost-roi")`
 - **10k run cap on `aggregateAll`**: when exceeded, results are truncated to the 10k most recent and `summary.truncated = true`; dashboard shows a warning banner
 - Preset windows (7d/30d/90d/365d) use `aggregateHybrid` — pre-computed rollup rows for whole UTC days before today, plus live `aggregateAll` for today's partial data, merged into one `AggregateResult`. Custom ranges bypass rollups via `opts.enableRollups = false` since arbitrary `from` times don't align to UTC day boundaries. Preset `from` is snapped to UTC midnight via `snapToUtcDayStart`.
+- **Rollup rows are immutable snapshots**: `dollars` and `timeSavedHours` are baked in at rollup compute time using the `modelPricing` and `timeSavedPerPr` config in effect then. Changing those config values later affects only future rollup recomputations, not historical rows. The dashboard's historical view will not backfill pricing changes.
+- **Fresh deployment caveat**: on a fresh deployment (before the first PM tick runs `recomputeCostRollups`), preset windows show only today's live data. Rollup rows populate after the first nightly tick.
 
 ### RBAC / multi-user (Enterprise feature 4.4)
 - Module: `packages/core/src/rbac/` — `matrix.ts` (PERMISSION_MATRIX + canAccess), `user-role-store.ts` (setUserRole, getUserRole, listUsers, applyBootstrapAdmins), `errors.ts` (SelfDemoteError, LastAdminError)

--- a/packages/core/src/__tests__/cost/aggregate.test.ts
+++ b/packages/core/src/__tests__/cost/aggregate.test.ts
@@ -290,6 +290,10 @@ describe("aggregateHybrid", () => {
     expect(r.summary.prsMerged).toBe(3);
     // rollup dollars + live dollars (run2 = 0.1M×$3 + 0.05M×$15 = $1.05)
     expect(r.summary.dollars).toBeCloseTo(10 + 1.05, 2);
+    // ROI re-computed post-merge: timeSaved = 8 (rollup) + 4 (live quick-fix default) = 12h
+    // ROI = (12 × $50) / $11.05 ≈ 54.3×
+    expect(r.summary.timeSavedHours).toBe(12);
+    expect(r.summary.roiMultiplier).toBeCloseTo((12 * 50) / (10 + 1.05), 1);
     // Single team, single repo, single pipeline — breakdowns should have 1 row each
     expect(r.byTeam).toHaveLength(1);
     expect(r.byRepo).toHaveLength(1);

--- a/packages/core/src/__tests__/cost/aggregate.test.ts
+++ b/packages/core/src/__tests__/cost/aggregate.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns, stageRuns } from "../../db/schema.js";
-import { aggregateAll, normalizeTeamId } from "../../cost/aggregate.js";
+import { randomUUID } from "node:crypto";
+import { aggregateAll, aggregateHybrid, normalizeTeamId, snapToUtcDayStart } from "../../cost/aggregate.js";
+import { costRollupsDaily } from "../../db/schema.js";
 
 let db: any;
 
@@ -202,5 +204,143 @@ describe("aggregateAll", () => {
     expect(normalizeTeamId(undefined)).toEqual({ key: "team:unassigned", label: "(unassigned)" });
     expect(normalizeTeamId("")).toEqual({ key: "team:unassigned", label: "(unassigned)" });
     expect(normalizeTeamId("T1")).toEqual({ key: "team:T1", label: "T1" });
+  });
+});
+
+async function seedRollup(opts: {
+  date: string; pipelineKey: string; teamId: string; repoUrl: string;
+  runs: number; prsMerged: number; inputTokens: number; outputTokens: number;
+  dollars: number; timeSavedHours: number;
+}) {
+  await db.insert(costRollupsDaily).values({
+    id: `cr_${randomUUID()}`,
+    date: opts.date,
+    pipelineKey: opts.pipelineKey,
+    linearTeamId: opts.teamId,
+    repoUrl: opts.repoUrl,
+    runs: opts.runs,
+    prsMerged: opts.prsMerged,
+    inputTokens: opts.inputTokens,
+    outputTokens: opts.outputTokens,
+    dollars: opts.dollars,
+    timeSavedHours: opts.timeSavedHours,
+    computedAt: new Date(),
+  });
+}
+
+describe("snapToUtcDayStart", () => {
+  it("snaps mid-day UTC to start-of-day UTC", () => {
+    const d = new Date("2026-04-15T14:30:45.123Z");
+    expect(snapToUtcDayStart(d).toISOString()).toBe("2026-04-15T00:00:00.000Z");
+  });
+  it("is idempotent on midnight UTC", () => {
+    const d = new Date("2026-04-15T00:00:00.000Z");
+    expect(snapToUtcDayStart(d).toISOString()).toBe("2026-04-15T00:00:00.000Z");
+  });
+});
+
+describe("aggregateHybrid", () => {
+  it("falls back to pure live when enableRollups is false", async () => {
+    await seedRun("r1", {
+      pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-10T10:00:00Z"),
+    });
+    // Also seed a rollup that should NOT be read because enableRollups is false.
+    await seedRollup({
+      date: "2026-04-10", pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      runs: 999, prsMerged: 999, inputTokens: 0, outputTokens: 0,
+      dollars: 0, timeSavedHours: 0,
+    });
+    const r = await aggregateHybrid(
+      db,
+      { from: new Date("2026-04-01T00:00:00Z"), to: new Date("2026-04-30T23:59:59Z") },
+      config,
+      { enableRollups: false, now: new Date("2026-04-15T12:00:00Z") },
+    );
+    // Should see only the live run, not the poisoned rollup row
+    expect(r.summary.runs).toBe(1);
+  });
+
+  it("uses rollups for historical days + live for today", async () => {
+    // Historical rollup: 2 runs, 2 PRs, $10, 8h
+    await seedRollup({
+      date: "2026-04-14", pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      runs: 2, prsMerged: 2, inputTokens: 200_000, outputTokens: 100_000,
+      dollars: 10, timeSavedHours: 8,
+    });
+    // Today's live run: 1 run at T+10h
+    await seedRun("r-today", {
+      pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-15T10:00:00Z"),
+    });
+    const r = await aggregateHybrid(
+      db,
+      { from: new Date("2026-04-10T00:00:00Z"), to: new Date("2026-04-15T23:59:59Z") },
+      config,
+      { enableRollups: true, now: new Date("2026-04-15T12:00:00Z") },
+    );
+    // rollup contributes 2 runs; live contributes 1 run
+    expect(r.summary.runs).toBe(3);
+    expect(r.summary.prsMerged).toBe(3);
+    // rollup dollars + live dollars (run2 = 0.1M×$3 + 0.05M×$15 = $1.05)
+    expect(r.summary.dollars).toBeCloseTo(10 + 1.05, 2);
+    // Single team, single repo, single pipeline — breakdowns should have 1 row each
+    expect(r.byTeam).toHaveLength(1);
+    expect(r.byRepo).toHaveLength(1);
+    expect(r.byPipeline).toHaveLength(1);
+  });
+
+  it("uses rollups only when window ends before today's UTC midnight", async () => {
+    await seedRollup({
+      date: "2026-04-13", pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      runs: 5, prsMerged: 5, inputTokens: 0, outputTokens: 0,
+      dollars: 20, timeSavedHours: 20,
+    });
+    // Also a live run from today that should NOT be included (window ends before today)
+    await seedRun("r-today", {
+      pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-15T10:00:00Z"),
+    });
+    const r = await aggregateHybrid(
+      db,
+      // Window: 2026-04-13 00:00Z to 2026-04-14 00:00Z — entirely historical
+      { from: new Date("2026-04-13T00:00:00Z"), to: new Date("2026-04-14T00:00:00Z") },
+      config,
+      { enableRollups: true, now: new Date("2026-04-15T12:00:00Z") },
+    );
+    expect(r.summary.runs).toBe(5);
+    expect(r.summary.dollars).toBeCloseTo(20, 2);
+  });
+
+  it("routes to live-only when window is entirely today", async () => {
+    await seedRun("r-today", {
+      pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      implementInputTokens: 100_000, implementOutputTokens: 50_000,
+      completedAt: new Date("2026-04-15T10:00:00Z"),
+    });
+    // Stale rollup for yesterday — should NOT be read when window is today-only.
+    await seedRollup({
+      date: "2026-04-14", pipelineKey: "quick-fix", teamId: "T1",
+      repoUrl: "https://github.com/acme/api",
+      runs: 999, prsMerged: 999, inputTokens: 0, outputTokens: 0,
+      dollars: 0, timeSavedHours: 0,
+    });
+    const r = await aggregateHybrid(
+      db,
+      { from: new Date("2026-04-15T00:00:00Z"), to: new Date("2026-04-15T23:59:59Z") },
+      config,
+      { enableRollups: true, now: new Date("2026-04-15T12:00:00Z") },
+    );
+    expect(r.summary.runs).toBe(1);
   });
 });

--- a/packages/core/src/__tests__/cost/rollup.test.ts
+++ b/packages/core/src/__tests__/cost/rollup.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../../db/schema.js";
-import { recomputeCostRollups, readRollupWindow } from "../../cost/rollup.js";
+import { recomputeCostRollups } from "../../cost/rollup.js";
 
 let db: any;
 
@@ -127,16 +127,6 @@ describe("recomputeCostRollups", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].linearTeamId).toBe("");
     expect(rows[0].runs).toBe(2);
-  });
-
-  it("readRollupWindow returns rows inside the window", async () => {
-    const yesterday = new Date(Date.now() - 86400_000);
-    await seedCompletedRun("r1", yesterday);
-    await recomputeCostRollups(db, config);
-    const from = new Date(Date.now() - 7 * 86400_000);
-    const to = new Date();
-    const rows = await readRollupWindow(db, from, to);
-    expect(rows.length).toBeGreaterThan(0);
   });
 
   it("backfills up to 30 days on first run when rollup table is empty", async () => {

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -1,6 +1,6 @@
 import { and, gte, lt, inArray } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
-import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { createLogger } from "../logger.js";
 import type { AggregateResult, BreakdownRow, CostSummary } from "./types.js";
@@ -157,3 +157,210 @@ export async function aggregateAll(
     byPipeline: finalize(Array.from(byPipeline.values())),
   };
 }
+
+/** Snap a Date down to the start of its UTC day (00:00:00.000 UTC). */
+export function snapToUtcDayStart(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function utcDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Aggregate pre-computed rollup rows for UTC dates in [fromDate, toDate).
+ * Both bounds are YYYY-MM-DD strings. Returns an AggregateResult whose
+ * window.from/to reflect the caller-supplied Date objects (not the date
+ * strings), so the summary is consistent with the caller's framing.
+ */
+async function aggregateFromRollups(
+  db: AnyDb,
+  fromDate: string,
+  toDate: string,
+  window: { from: Date; to: Date },
+  hourlyRate: number,
+): Promise<AggregateResult> {
+  // Half-open [fromDate, toDate) — use gte(date) + lt(date) on the date string.
+  const rows: any[] = await db.select().from(costRollupsDaily).where(
+    and(
+      gte(costRollupsDaily.date, fromDate),
+      lt(costRollupsDaily.date, toDate),
+    ),
+  );
+
+  const summary: CostSummary = {
+    window,
+    runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
+    dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+  };
+  const byTeam = new Map<string, BreakdownRow>();
+  const byRepo = new Map<string, BreakdownRow>();
+  const byPipeline = new Map<string, BreakdownRow>();
+
+  for (const r of rows) {
+    summary.runs += r.runs;
+    summary.prsMerged += r.prsMerged;
+    summary.inputTokens += r.inputTokens;
+    summary.outputTokens += r.outputTokens;
+    summary.dollars += r.dollars;
+    summary.timeSavedHours += r.timeSavedHours;
+
+    // rollup stores linearTeamId as "" sentinel for unassigned (see rollup.ts)
+    const teamId = r.linearTeamId === "" ? null : r.linearTeamId;
+    const { key: teamKey, label: teamLabel } = normalizeTeamId(teamId);
+    if (!byTeam.has(teamKey)) byTeam.set(teamKey, emptyBucket(teamKey, teamLabel));
+    const tb = byTeam.get(teamKey)!;
+    tb.runs += r.runs; tb.prsMerged += r.prsMerged;
+    tb.inputTokens += r.inputTokens; tb.outputTokens += r.outputTokens;
+    tb.dollars += r.dollars; tb.timeSavedHours += r.timeSavedHours;
+
+    const repoKey = `repo:${r.repoUrl}`;
+    if (!byRepo.has(repoKey)) byRepo.set(repoKey, emptyBucket(repoKey, r.repoUrl));
+    const rb = byRepo.get(repoKey)!;
+    rb.runs += r.runs; rb.prsMerged += r.prsMerged;
+    rb.inputTokens += r.inputTokens; rb.outputTokens += r.outputTokens;
+    rb.dollars += r.dollars; rb.timeSavedHours += r.timeSavedHours;
+
+    const pipelineKey = `pipeline:${r.pipelineKey}`;
+    if (!byPipeline.has(pipelineKey)) byPipeline.set(pipelineKey, emptyBucket(pipelineKey, r.pipelineKey));
+    const pb = byPipeline.get(pipelineKey)!;
+    pb.runs += r.runs; pb.prsMerged += r.prsMerged;
+    pb.inputTokens += r.inputTokens; pb.outputTokens += r.outputTokens;
+    pb.dollars += r.dollars; pb.timeSavedHours += r.timeSavedHours;
+  }
+
+  summary.roiMultiplier = finalizeRoi(summary, hourlyRate);
+  const sort = (a: BreakdownRow, b: BreakdownRow) => b.dollars - a.dollars;
+  const finalize = (rows: BreakdownRow[]) => {
+    for (const r of rows) r.roiMultiplier = finalizeRoi(r, hourlyRate);
+    return rows.sort(sort);
+  };
+
+  return {
+    summary,
+    byTeam: finalize(Array.from(byTeam.values())),
+    byRepo: finalize(Array.from(byRepo.values())),
+    byPipeline: finalize(Array.from(byPipeline.values())),
+  };
+}
+
+function mergeBreakdowns(
+  a: BreakdownRow[],
+  b: BreakdownRow[],
+  hourlyRate: number,
+): BreakdownRow[] {
+  const byKey = new Map<string, BreakdownRow>();
+  for (const row of [...a, ...b]) {
+    const existing = byKey.get(row.key);
+    if (!existing) {
+      byKey.set(row.key, { ...row });
+    } else {
+      existing.runs += row.runs;
+      existing.prsMerged += row.prsMerged;
+      existing.inputTokens += row.inputTokens;
+      existing.outputTokens += row.outputTokens;
+      existing.dollars += row.dollars;
+      existing.timeSavedHours += row.timeSavedHours;
+    }
+  }
+  const merged = Array.from(byKey.values());
+  for (const r of merged) r.roiMultiplier = finalizeRoi(r, hourlyRate);
+  return merged.sort((x, y) => y.dollars - x.dollars);
+}
+
+/**
+ * Hybrid aggregate: uses pre-computed rollup rows for whole UTC days before
+ * today, and live `aggregateAll` for today's partial data. The two halves are
+ * summed into a single `AggregateResult`.
+ *
+ * When `opts.enableRollups` is false (the default for arbitrary custom
+ * windows), falls back to pure live aggregation.
+ *
+ * IMPORTANT: `filters.from` must be at a UTC day boundary (00:00 UTC) for
+ * rollup-backed reads to be exact — the rollup table stores per-day totals.
+ * For preset windows (7d/30d/90d/365d) the caller is expected to snap `from`
+ * via `snapToUtcDayStart`. For non-aligned `from`, this function still routes
+ * through rollups but will slightly over-count by including the full first
+ * UTC day — acceptable for preset usage, unsuitable for arbitrary windows
+ * (hence the opt-in `enableRollups` flag).
+ */
+export async function aggregateHybrid(
+  db: AnyDb,
+  filters: AggregateFilters,
+  config: CostConfig,
+  opts: { maxRuns?: number; now?: Date; enableRollups?: boolean } = {},
+): Promise<AggregateResult> {
+  const enableRollups = opts.enableRollups ?? false;
+  if (!enableRollups) {
+    return aggregateAll(db, filters, config, opts);
+  }
+
+  const hourlyRate = config.costs?.hourlyEngRate ?? 50;
+  const now = opts.now ?? new Date();
+  const todayUtcStart = snapToUtcDayStart(now);
+
+  // If the window doesn't span any completed UTC days, fall through to pure live.
+  if (filters.from >= todayUtcStart) {
+    return aggregateAll(db, filters, config, opts);
+  }
+
+  // Compute the rollup window (whole UTC days) and the live remainder (today).
+  const rollupEndDateStr = utcDateStr(todayUtcStart);
+  const rollupFromDateStr = utcDateStr(filters.from);
+  // If the user's window ends before today's UTC midnight, rollup covers the
+  // full window and there's no live component.
+  const rollupOnlyCutoff = filters.to <= todayUtcStart ? filters.to : todayUtcStart;
+  const rollupToDateStr = utcDateStr(rollupOnlyCutoff);
+
+  const rollupPart = await aggregateFromRollups(
+    db,
+    rollupFromDateStr,
+    // Make the rollup-date bound inclusive of the last full UTC day in the
+    // window by adding one day — aggregateFromRollups uses lt on the date
+    // string, which would otherwise exclude the last completed day.
+    rollupOnlyCutoff < todayUtcStart ? rollupToDateStr : rollupEndDateStr,
+    { from: filters.from, to: filters.to },
+    hourlyRate,
+  );
+
+  // If the window ends before today's midnight, we're done.
+  if (filters.to <= todayUtcStart) {
+    log.debug({ from: rollupFromDateStr, to: rollupToDateStr }, "aggregateHybrid: rollup-only path");
+    return rollupPart;
+  }
+
+  // Live query for today's partial data [todayUtcStart, filters.to).
+  const livePart = await aggregateAll(
+    db,
+    { from: todayUtcStart, to: filters.to },
+    config,
+    opts,
+  );
+
+  log.debug(
+    { rollupDays: rollupFromDateStr + "..." + rollupEndDateStr, liveFrom: todayUtcStart.toISOString() },
+    "aggregateHybrid: rollup + live merge",
+  );
+
+  // Merge summary
+  const mergedSummary: CostSummary = {
+    window: { from: filters.from, to: filters.to },
+    runs: rollupPart.summary.runs + livePart.summary.runs,
+    prsMerged: rollupPart.summary.prsMerged + livePart.summary.prsMerged,
+    inputTokens: rollupPart.summary.inputTokens + livePart.summary.inputTokens,
+    outputTokens: rollupPart.summary.outputTokens + livePart.summary.outputTokens,
+    dollars: rollupPart.summary.dollars + livePart.summary.dollars,
+    timeSavedHours: rollupPart.summary.timeSavedHours + livePart.summary.timeSavedHours,
+    roiMultiplier: 0,
+    ...(livePart.summary.truncated ? { truncated: true } : {}),
+  };
+  mergedSummary.roiMultiplier = finalizeRoi(mergedSummary, hourlyRate);
+
+  return {
+    summary: mergedSummary,
+    byTeam: mergeBreakdowns(rollupPart.byTeam, livePart.byTeam, hourlyRate),
+    byRepo: mergeBreakdowns(rollupPart.byRepo, livePart.byRepo, hourlyRate),
+    byPipeline: mergeBreakdowns(rollupPart.byPipeline, livePart.byPipeline, hourlyRate),
+  };
+}
+

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -315,9 +315,11 @@ export async function aggregateHybrid(
   const rollupPart = await aggregateFromRollups(
     db,
     rollupFromDateStr,
-    // Make the rollup-date bound inclusive of the last full UTC day in the
-    // window by adding one day — aggregateFromRollups uses lt on the date
-    // string, which would otherwise exclude the last completed day.
+    // Upper bound is exclusive (lt on date string). `rollupEndDateStr` is
+    // today's date, so lt excludes today and includes through yesterday.
+    // When the window ends before today (rollup-only path), the upper bound
+    // is the window's `to` date so lt(date, windowTo) includes everything
+    // strictly before windowTo's UTC date.
     rollupOnlyCutoff < todayUtcStart ? rollupToDateStr : rollupEndDateStr,
     { from: filters.from, to: filters.to },
     hourlyRate,

--- a/packages/core/src/cost/rollup.ts
+++ b/packages/core/src/cost/rollup.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, gte, lt, lte, inArray, max } from "drizzle-orm";
+import { and, gte, lt, inArray, max } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
@@ -203,17 +203,3 @@ export async function recomputeCostRollups(
   return { rowsWritten: totalRowsWritten };
 }
 
-export async function readRollupWindow(
-  db: AnyDb,
-  from: Date,
-  to: Date,
-): Promise<any[]> {
-  const fromDate = utcDateStr(from);
-  const toDate = utcDateStr(to);
-  return await db.select().from(costRollupsDaily).where(
-    and(
-      gte(costRollupsDaily.date, fromDate),
-      lte(costRollupsDaily.date, toDate),
-    ),
-  );
-}

--- a/packages/dashboard/src/routes/cost.ts
+++ b/packages/dashboard/src/routes/cost.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Db, CostsConfig, PipelineConfig } from "@urateam/core";
-import { isFeatureLicensed, aggregateAll, streamCostCsv } from "@urateam/core";
+import { isFeatureLicensed, aggregateHybrid, snapToUtcDayStart, streamCostCsv } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { renderCostPage } from "../views/cost.js";
 
@@ -28,8 +28,11 @@ function parseWindow(url: URL): { from: Date; to: Date; preset: string } {
     if (isNaN(from.getTime())) from = new Date(now.getTime() - 30 * 86_400_000);
     if (isNaN(to.getTime())) to = now;
   } else {
+    // For preset windows: snap `from` to UTC day start so `aggregateHybrid`
+    // can read pre-computed rollup rows without boundary slicing. The window
+    // effectively becomes "last N complete UTC days + today-so-far".
     const days = preset === "7d" ? 7 : preset === "90d" ? 90 : preset === "365d" ? 365 : 30;
-    from = new Date(now.getTime() - days * 86_400_000);
+    from = new Date(snapToUtcDayStart(now).getTime() - days * 86_400_000);
   }
   return { from, to, preset };
 }
@@ -57,10 +60,13 @@ export function createCostRouter(deps: CostRouterDeps): Hono {
   router.get("/cost", async (c) => {
     const url = new URL(c.req.url);
     const filters = parseWindow(url);
-    const result = await aggregateAll(
+    const result = await aggregateHybrid(
       deps.db as any,
       { from: filters.from, to: filters.to },
       { costs, pipelineConfigs },
+      // Rollup-backed reads only for preset windows (where `from` is snapped
+      // to UTC midnight). Custom ranges go through live aggregation.
+      { enableRollups: filters.preset !== "custom" },
     );
     const content = renderCostPage({ result, filters, costs, basePath });
     if (c.req.header("HX-Request")) return c.html(content);
@@ -71,10 +77,11 @@ export function createCostRouter(deps: CostRouterDeps): Hono {
   router.get("/cost/page", async (c) => {
     const url = new URL(c.req.url);
     const filters = parseWindow(url);
-    const result = await aggregateAll(
+    const result = await aggregateHybrid(
       deps.db as any,
       { from: filters.from, to: filters.to },
       { costs, pipelineConfigs },
+      { enableRollups: filters.preset !== "custom" },
     );
     return c.html(renderCostPage({ result, filters, costs, basePath, partial: true }));
   });


### PR DESCRIPTION
## Summary
- New \`aggregateHybrid(db, filters, config, opts)\` that splits queries at today's UTC midnight: pre-computed rollup rows for whole historical days + live \`aggregateAll\` for today's partial data
- New \`snapToUtcDayStart(date)\` helper
- \`/cost\` route uses \`aggregateHybrid\` with \`enableRollups: true\` for preset windows (7d/30d/90d/365d) and snaps preset \`from\` to UTC midnight so the rollup read is exact
- Custom windows keep live-only behavior (arbitrary \`from\` times don't align to UTC day boundaries)
- Rollup-only path when window ends before today's UTC midnight; live-only path when window is entirely today
- Performance: large windows (90d/365d) no longer scan all pipeline_runs + stage_runs in the window — historical totals come from 1 row per (date × pipeline × team × repo) bucket

## Test plan
- [x] \`pnpm build\` — all 4 packages pass
- [x] 13/13 core aggregate tests pass (4 new: \`enableRollups: false\` fallback, hybrid split, rollup-only window, today-only live)
- [x] 2/2 snapToUtcDayStart tests pass
- [x] 5/5 dashboard cost tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)