### PR TITLE
docs: refresh README with current packages, tier matrix, dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # urateam
 
-Autonomous software delivery framework. Connect your ticketing system, and agents implement, test, review, and ship code — automatically.
+Autonomous software delivery framework. Connect Linear + GitHub, agents implement, test, review, and ship code — automatically.
 
 ## Quick Start
 
@@ -14,19 +14,45 @@ ura dev
 
 | Package | Description |
 |---------|-------------|
-| `@urateam/core` | Pipeline runner, DB, executor, webhooks, PM Agent |
-| `@urateam/dashboard` | Ops dashboard (Hono + HTMX) |
-| `@urateam/cli` | CLI tool (`ura dev`, `ura start`) |
+| `@urateam/core` | Pipeline runner, DB, executor, webhooks, PM Agent, audit log, license |
+| `@urateam/dashboard` | Ops dashboard (Hono + HTMX) with cost/ROI, audit, users, coordination |
+| `@urateam/cli` | CLI (`ura dev`, `ura start`, `ura run`, `ura admin`) |
 | `create-urateam` | Project scaffolding |
+
+## Tiers
+
+| Tier | Pitch |
+|---|---|
+| **OSS** | Self-hosted, BYO Anthropic key. Free. |
+| **Pro** | Multi-repo, advanced auto-merge, deep review, PM Agent with Slack interface + conflict detection + approval workflows. |
+| **Enterprise** | Adds SSO (WorkOS), audit log + export, spend caps & alerts, RBAC, cost & ROI dashboard, org policy / guardrails. Sales-led. |
+
+See `docs/superpowers/specs/2026-04-13-enterprise-tier-design.md` for the full feature matrix.
 
 ## Development
 
 ```bash
-pnpm install
-pnpm build
-pnpm test
+pnpm install              # install all dependencies
+pnpm build                # build all packages (via Turborepo)
+pnpm test                 # unit tests only (~60s)
+pnpm test:integration     # BEC-99 cross-worktree + other heavy git integration tests
 ```
+
+Per-package tests:
+
+```bash
+cd packages/core && npx vitest run                            # core unit tests
+cd packages/core && npx vitest run src/__tests__/<file>       # specific test
+cd packages/core && npx vitest --changed                      # tests affected by uncommitted changes
+```
+
+## Documentation
+
+- `CLAUDE.md` — architecture, conventions, module map. Kept current as features ship.
+- `deploy/` — Docker, Caddy, setup scripts. Per-feature setup docs (`SSO_SETUP.md`, `RBAC_SETUP.md`).
+- `docs/superpowers/specs/` — design specs, one per feature.
+- `examples/` — basic, monorepo, multi-repo, custom stages configurations.
 
 ## License
 
-BSL 1.1 — see [LICENSE](./LICENSE)
+BSL 1.1 — see [LICENSE](./LICENSE). Managed Service use requires a commercial license.


### PR DESCRIPTION
## Summary
- Adds \`@urateam/core\` feature list for Phase 1 (audit log, license, enterprise features)
- Adds tier matrix (OSS / Pro / Enterprise) with one-line pitch each
- Expands dev workflow section with the actual test commands from CLAUDE.md
- Points to \`docs/superpowers/specs/\` for design specs and \`deploy/\` for setup docs

## Test plan
- [x] Docs-only change