### PR TITLE
chore: rename license issuer to urateams.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config --global user.email "ci@urateam.dev"
+          git config --global user.email "ci@urateams.com"
           git config --global user.name "CI Bot"
 
       - name: Install dependencies

--- a/packages/cli/src/__tests__/helpers/license.ts
+++ b/packages/cli/src/__tests__/helpers/license.ts
@@ -42,7 +42,7 @@ export async function installTestProLicense(
 
   const now = Math.floor(Date.now() / 1000);
   const jwt = makeJwt(privateKey, {
-    iss: "urateam.dev",
+    iss: "urateams.com",
     sub: "cust_test",
     tier,
     seats: 25,

--- a/packages/cli/src/__tests__/license-command.test.ts
+++ b/packages/cli/src/__tests__/license-command.test.ts
@@ -44,7 +44,7 @@ describe("issueLicense", () => {
 
     const { header, payload } = decodeJwt(token);
     expect(header).toEqual({ alg: "EdDSA", typ: "JWT" });
-    expect(payload.iss).toBe("urateam.dev");
+    expect(payload.iss).toBe("urateams.com");
     expect(payload.sub).toBe("cust_acme");
     expect(payload.tier).toBe("enterprise");
     expect(payload.seats).toBe(100);

--- a/packages/cli/src/commands/license.ts
+++ b/packages/cli/src/commands/license.ts
@@ -42,7 +42,7 @@ export function issueLicense(opts: IssueOptions): string {
   const header = { alg: "EdDSA", typ: "JWT" };
   const now = Math.floor(Date.now() / 1000);
   const payload: Record<string, unknown> = {
-    iss: "urateam.dev",
+    iss: "urateams.com",
     sub: opts.customerId,
     tier: opts.tier,
     seats: opts.seats,

--- a/packages/core/src/__tests__/helpers/license.ts
+++ b/packages/core/src/__tests__/helpers/license.ts
@@ -49,7 +49,7 @@ export async function installTestProLicense(
 
   const now = Math.floor(Date.now() / 1000);
   const jwt = makeJwt(privateKey, {
-    iss: "urateam.dev",
+    iss: "urateams.com",
     sub: "cust_test",
     tier,
     seats: 25,

--- a/packages/core/src/__tests__/license-audit-event.test.ts
+++ b/packages/core/src/__tests__/license-audit-event.test.ts
@@ -26,7 +26,7 @@ describe("checkLicense — audit event on invalid license", () => {
       .replace(/=+$/, "");
     const payload = Buffer.from(
       JSON.stringify({
-        iss: "urateam.dev",
+        iss: "urateams.com",
         sub: "cust",
         tier: "pro",
         iat: 1,

--- a/packages/core/src/__tests__/license.test.ts
+++ b/packages/core/src/__tests__/license.test.ts
@@ -106,7 +106,7 @@ describe("checkLicense — JWT validation", () => {
 
   it("accepts a valid pro JWT", () => {
     process.env.URATEAM_LICENSE_KEY = makeJwt(privateKey, {
-      iss: "urateam.dev",
+      iss: "urateams.com",
       sub: "cust_test",
       tier: "pro",
       seats: 25,
@@ -124,7 +124,7 @@ describe("checkLicense — JWT validation", () => {
 
   it("accepts a valid enterprise JWT and unlocks enterprise features", () => {
     process.env.URATEAM_LICENSE_KEY = makeJwt(privateKey, {
-      iss: "urateam.dev",
+      iss: "urateams.com",
       sub: "cust_acme",
       tier: "enterprise",
       seats: null,
@@ -141,7 +141,7 @@ describe("checkLicense — JWT validation", () => {
 
   it("respects an explicit `features` override array in the JWT", () => {
     process.env.URATEAM_LICENSE_KEY = makeJwt(privateKey, {
-      iss: "urateam.dev",
+      iss: "urateams.com",
       sub: "cust_partial",
       tier: "pro",
       seats: 5,
@@ -158,7 +158,7 @@ describe("checkLicense — JWT validation", () => {
 
   it("rejects an expired JWT with invalidReason='expired'", () => {
     process.env.URATEAM_LICENSE_KEY = makeJwt(privateKey, {
-      iss: "urateam.dev",
+      iss: "urateams.com",
       sub: "cust_test",
       tier: "pro",
       seats: 25,
@@ -188,7 +188,7 @@ describe("checkLicense — JWT validation", () => {
   it("rejects a JWT signed with the wrong key (bad signature)", () => {
     const { privateKey: otherPriv } = generateKeyPairSync("ed25519");
     process.env.URATEAM_LICENSE_KEY = makeJwt(otherPriv, {
-      iss: "urateam.dev",
+      iss: "urateams.com",
       sub: "cust_test",
       tier: "enterprise",
       seats: null,
@@ -218,7 +218,7 @@ describe("checkLicense — JWT validation", () => {
     }
 
     const validPayload = {
-      iss: "urateam.dev",
+      iss: "urateams.com",
       sub: "cust_attacker",
       tier: "enterprise",
       seats: null,

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -146,7 +146,7 @@ type VerifyResult =
   | { ok: true; claims: JwtClaims }
   | { ok: false; reason: NonNullable<LicenseStatus["invalidReason"]> };
 
-const ISSUER = "urateam.dev";
+const ISSUER = "urateams.com";
 
 function b64urlDecode(input: string): Buffer {
   const pad = input.length % 4 === 0 ? "" : "=".repeat(4 - (input.length % 4));

--- a/packages/dashboard/src/__tests__/audit.test.ts
+++ b/packages/dashboard/src/__tests__/audit.test.ts
@@ -47,7 +47,7 @@ async function installEnterpriseLicense(): Promise<void> {
 
   const now = Math.floor(Date.now() / 1000);
   const jwt = makeJwt(privateKey, {
-    iss: "urateam.dev",
+    iss: "urateams.com",
     sub: "cust_test",
     tier: "enterprise",
     seats: 25,

--- a/packages/dashboard/src/__tests__/cost.test.ts
+++ b/packages/dashboard/src/__tests__/cost.test.ts
@@ -46,7 +46,7 @@ async function installEnterpriseLicense(): Promise<void> {
 
   const now = Math.floor(Date.now() / 1000);
   const jwt = makeJwt(privateKey, {
-    iss: "urateam.dev",
+    iss: "urateams.com",
     sub: "cust_test",
     tier: "enterprise",
     seats: 25,

--- a/packages/dashboard/src/__tests__/helpers/license.ts
+++ b/packages/dashboard/src/__tests__/helpers/license.ts
@@ -47,7 +47,7 @@ export async function installTestProLicense(
 
   const now = Math.floor(Date.now() / 1000);
   const jwt = makeJwt(privateKey, {
-    iss: "urateam.dev",
+    iss: "urateams.com",
     sub: "cust_test",
     tier,
     seats: 25,


### PR DESCRIPTION
## Summary
- Flip `ISSUER` constant in `packages/core/src/license.ts` from `urateam.dev` → `urateams.com`.
- Flip the `ura license issue` CLI's minted JWT `iss` claim to match.
- Update all test fixtures that assert or use the `urateam.dev` issuer string.

## Why
Phase 2 (Pro self-serve billing) ships in a separate \`urateam-licensing\` repo deployed at \`billing.urateams.com\`. The billing Worker will mint Pro license JWTs with \`iss: urateams.com\`; the validator in \`@urateam/core\` must accept that issuer string or every Pro customer license will fail verification.

Clean cutover — no paying Pro customers exist yet, so there's no back-compat burden. Any hand-minted Enterprise keys issued from this version forward will also use \`urateams.com\`.

## Test plan
- [x] \`cd packages/core && npx vitest run src/__tests__/license.test.ts src/__tests__/license-audit-event.test.ts\` — 14/14 passing
- [x] \`cd packages/cli && npx vitest run src/__tests__/license-command.test.ts\` — 6/6 passing
- [x] \`cd packages/core && npx vitest run\` — 1154/1165 passing (11 pre-existing skips, no regressions)
- [x] \`pnpm build\` — clean across all 3 packages
- [ ] Sonnet review via \`review\` skill
- [ ] Merge

See \`docs/superpowers/specs/2026-04-17-urateam-licensing-phase2-design.md\` § 2.6 and the companion \`Task -1\` in \`docs/superpowers/plans/2026-04-17-urateam-licensing-phase2.md\` for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)