### PR TITLE
feat(core): embed production Ed25519 public key

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/__tests__/license-public-key.test.ts
+++ b/packages/core/src/__tests__/license-public-key.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createPublicKey } from "node:crypto";
+import { LICENSE_PUBLIC_KEY_DER_B64 } from "../license-public-key.js";
+
+describe("embedded production public key", () => {
+  it("is a structurally valid Ed25519 SPKI-DER base64 string", () => {
+    const buf = Buffer.from(LICENSE_PUBLIC_KEY_DER_B64, "base64");
+    // Ed25519 SPKI: 12-byte ASN.1 prefix + 32-byte raw public key = 44 bytes.
+    // A character transposition or truncation in the constant would typically
+    // still be "parseable" as some key; the length + OID check catches
+    // specifically-bad tweaks the createPublicKey round-trip alone misses.
+    expect(buf.byteLength).toBe(44);
+    // OID for Ed25519 is 1.3.101.112, encoded as hex `2b6570` at bytes 6-8.
+    expect(buf.subarray(6, 9).toString("hex")).toBe("2b6570");
+    const key = createPublicKey({ key: buf, format: "der", type: "spki" });
+    expect(key.asymmetricKeyType).toBe("ed25519");
+  });
+});

--- a/packages/core/src/license-public-key.ts
+++ b/packages/core/src/license-public-key.ts
@@ -6,9 +6,10 @@
  * The corresponding private key (`SIGNING_KEY` Workers Secret) lives on the
  * `urateam-licensing` service at `billing.urateams.com`. It is never committed
  * to this repo. See `urateam-licensing/docs/rotation.md` for the dual-key
- * handoff procedure required when rotating (old + new keys must verify side-
- * by-side for 13 months so outstanding customer JWTs don't fail validation
- * mid-lifetime).
+ * handoff procedure required when rotating: old + new keys must verify side-
+ * by-side for ≥ 390 days (the JWT lifetime constant, 13 × 30 days, NOT 13
+ * calendar months — the constant is ~5.7 days short of a calendar year-plus-
+ * one-month). This way no outstanding customer JWT is rejected mid-lifetime.
  */
 export const LICENSE_PUBLIC_KEY_DER_B64 =
   "MCowBQYDK2VwAyEAgEyvXLTYbpAZriMQVZDuhXnkdDeUiuDiX0Y9+ZFvix4=";

--- a/packages/core/src/license-public-key.ts
+++ b/packages/core/src/license-public-key.ts
@@ -3,12 +3,12 @@
  *
  * Format: SubjectPublicKeyInfo (SPKI) DER, base64-encoded.
  *
- * The corresponding private key is held by the operator and never enters
- * the repository. To rotate the key:
- *   1. Run `pnpm tsx scripts/generate-license-keypair.ts`
- *   2. Replace this constant with the new public key
- *   3. Re-issue all outstanding licenses with the new private key
- *   4. Cut a urateam release; old licenses fail validation after upgrade
+ * The corresponding private key (`SIGNING_KEY` Workers Secret) lives on the
+ * `urateam-licensing` service at `billing.urateams.com`. It is never committed
+ * to this repo. See `urateam-licensing/docs/rotation.md` for the dual-key
+ * handoff procedure required when rotating (old + new keys must verify side-
+ * by-side for 13 months so outstanding customer JWTs don't fail validation
+ * mid-lifetime).
  */
 export const LICENSE_PUBLIC_KEY_DER_B64 =
-  "MCowBQYDK2VwAyEAfdqBhcSi6VOkQ6LnYBSAH1Jq3gAwIhQ8YOiPOYIzhxc=";
+  "MCowBQYDK2VwAyEAgEyvXLTYbpAZriMQVZDuhXnkdDeUiuDiX0Y9+ZFvix4=";

--- a/scripts/generate-license-keypair.ts
+++ b/scripts/generate-license-keypair.ts
@@ -5,9 +5,17 @@
  * Usage:
  *   pnpm tsx scripts/generate-license-keypair.ts
  *
- * Prints the public key (paste into packages/core/src/license-public-key.ts)
- * and the private key (store securely — DO NOT commit). The private key is
- * needed by `ura license issue` and the future Stripe webhook handler.
+ * This script is ONLY for local dev / `ura license issue` offline use.
+ * The production license signing key lives in the `urateam-licensing`
+ * Worker at `billing.urateams.com` — see that repo's
+ * `worker/scripts/gen-signing-key.ts` + `docs/rotation.md`. The public
+ * key at packages/core/src/license-public-key.ts is the published-
+ * product key and should NOT be updated from this script's output
+ * except via the documented rotation procedure.
+ *
+ * Prints the public key and the private key (store securely — DO NOT
+ * commit). The private key is needed by `ura license issue` for
+ * offline Enterprise license minting.
  */
 import { generateKeyPairSync } from "node:crypto";
 


### PR DESCRIPTION
## Summary

Replaces the pre-Phase-2 placeholder Ed25519 public key in \`@urateam/core\` with the real production key paired with the \`SIGNING_KEY\` Workers Secret on \`billing.urateams.com\`. Customer installations verify against this key for offline license validation.

**Not a rotation** — the placeholder was never paired with a production signer, so no dual-key overlap period is required. (For future rotations after real paying customers have outstanding JWTs, the dual-key handoff is documented at \`urateam-licensing/docs/rotation.md\`.)

## Changes

- \`packages/core/src/license-public-key.ts\`: swap constant + update comment to point at urateam-licensing as the canonical issuer.
- \`packages/core/package.json\`: version bump 0.1.4 → 0.1.5 so downstream installs surface the key change via lockfile churn.

## Test plan

- [x] \`pnpm --filter @urateam/core build\` — clean
- [x] \`cd packages/core && npx vitest run\` — 1154/1154 core tests pass (tests override the key at runtime via \`Object.defineProperty\`, so neither placeholder nor real key appears in any assertion)
- [ ] Post-merge: publish \`@urateam/core\` 0.1.5 to unblock real customer verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)