### PR TITLE
chore(core): bump version 0.1.5 → 0.1.7 to leap past stale tags

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Phase 2 PR #79 set \`@urateam/core\` to 0.1.5, which is BEHIND the existing \`v0.1.6\` git tag — would confuse the publish-package.sh skip-if-exists path. Bumps to 0.1.7 to cleanly leap past v0.1.5 and v0.1.6 (both have git tags but never actually shipped to npm; \`npm latest\` is still 0.1.4).

## State of the world

| Where | Version | Notes |
|---|---|---|
| npm \`@urateam/core@latest\` | 0.1.4 | Placeholder Ed25519 key from pre-Phase-2 |
| Git tag \`v0.1.5\` | (orphan, no npm) | Publish run failed |
| Git tag \`v0.1.6\` | (orphan, no npm) | Publish run "succeeded" but skipped via skip-if-exists |
| main package.json (post-PR-79) | 0.1.5 | Has the real production key but version is BEHIND v0.1.6 tag |
| **This PR** | **0.1.7** | Real production key + clean version |

## After merge

\`\`\`
git fetch && git checkout main && git pull
git tag v0.1.7
git push origin v0.1.7
\`\`\`

The publish workflow fires on the v0.1.7 tag push. npm should publish 0.1.7 and customers installing \`@urateam/core@latest\` will get the real production key.

## Test plan

- [x] One-line version bump only — no functional change
- [x] CI will pass (no code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)