### PR TITLE
fix(server): gate PM Slack interface mount behind slack-interface license

### DIFF
--- a/packages/core/src/__tests__/server.test.ts
+++ b/packages/core/src/__tests__/server.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { createApp } from "../server.js";
+import { describe, it, expect, afterEach } from "vitest";
+import { createApp, type ServerConfig } from "../server.js";
 import { defaultConfigs } from "../pipeline/config.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
 
-async function buildApp() {
+const PM_SLACK_CONFIG = {
+  signingSecret: "slack_signing_test",
+  botToken: "xoxb-test",
+  channelId: "C_TEST",
+  teamIds: ["T_TEST"],
+};
+
+async function buildApp(overrides: Partial<ServerConfig> = {}) {
   return createApp({
     webhookSecret: "whsec_test_secret",
     linearApiKey: "lin_api_test",
@@ -15,6 +23,7 @@ async function buildApp() {
         buildCommand: "npm run build",
       },
     },
+    ...overrides,
   });
 }
 
@@ -64,5 +73,33 @@ describe("Unknown routes", () => {
     const res = await app.request("/does-not-exist");
 
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PM Slack interface license gating
+// ---------------------------------------------------------------------------
+describe("PM Slack interface mount is license-gated", () => {
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("does NOT mount /slack/* routes in OSS mode even when pmSlack is configured", async () => {
+    // No license installed → tier is OSS → slack-interface feature unlicensed.
+    const { app } = await buildApp({ pmSlack: PM_SLACK_CONFIG });
+    const res = await app.request("/slack/events", { method: "POST" });
+    // If the route had mounted, it'd return some Slack-handler status (200 / 401 sig
+    // verification fail / 400 bad body). 404 confirms the route isn't mounted.
+    expect(res.status).toBe(404);
+  });
+
+  it("DOES mount /slack/* routes when a Pro license is installed", async () => {
+    await installTestProLicense();
+    const { app } = await buildApp({ pmSlack: PM_SLACK_CONFIG });
+    const res = await app.request("/slack/events", { method: "POST" });
+    // Route is mounted — status must NOT be 404. Slack handler will reject the
+    // empty unsigned body via its own validation, so any non-404 status confirms
+    // the mount.
+    expect(res.status).not.toBe(404);
   });
 });

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -124,17 +124,23 @@ export async function createApp(config: ServerConfig) {
     app.route("/", githubWebhookApp);
   }
 
-  // PM Agent Slack interface (optional)
+  // PM Agent Slack interface (optional, license-gated)
   if (config.pmSlack) {
-    const { createSlackInterface } = await import("./pm/slack-interface.js");
-    const { router: slackRouter } = createSlackInterface({
-      signingSecret: config.pmSlack.signingSecret,
-      botToken: config.pmSlack.botToken,
-      channelId: config.pmSlack.channelId,
-      linearApiKey: config.linearApiKey,
-      teamIds: config.pmSlack.teamIds,
-    });
-    app.route("/", slackRouter);
+    if (!isFeatureLicensed("slack-interface")) {
+      log.warn(
+        "pmSlack is configured but the slack-interface feature requires a Pro license — Slack routes will NOT be mounted",
+      );
+    } else {
+      const { createSlackInterface } = await import("./pm/slack-interface.js");
+      const { router: slackRouter } = createSlackInterface({
+        signingSecret: config.pmSlack.signingSecret,
+        botToken: config.pmSlack.botToken,
+        channelId: config.pmSlack.channelId,
+        linearApiKey: config.linearApiKey,
+        teamIds: config.pmSlack.teamIds,
+      });
+      app.route("/", slackRouter);
+    }
   }
 
   // Health check

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -128,6 +128,7 @@ export async function createApp(config: ServerConfig) {
   if (config.pmSlack) {
     if (!isFeatureLicensed("slack-interface")) {
       log.warn(
+        { feature: "slack-interface" },
         "pmSlack is configured but the slack-interface feature requires a Pro license — Slack routes will NOT be mounted",
       );
     } else {


### PR DESCRIPTION
## Summary

Pre-public-flip security audit found one real gap: the PM Slack interface (POST \`/slack/events\`, POST \`/slack/commands\`) mounted on \`if (config.pmSlack)\` alone, with no \`isFeatureLicensed("slack-interface")\` gate. The feature is defined as Pro-tier in license.ts but never enforced.

A self-hoster on OSS who put Slack credentials in their config got the full PM Slack feature for free. With the repo public, this becomes a trivially-discoverable bypass path.

## Fix

Mirrors the existing multi-repo gate pattern from \`server.ts:66\` — warn-and-skip rather than throw, so the rest of the deployment keeps working.

## Tests

- New: OSS mode + pmSlack config → \`POST /slack/events\` returns 404 (not mounted)
- New: Pro license installed + pmSlack config → \`POST /slack/events\` returns non-404 (mounted)
- Existing 3 server tests still pass

## Audit context

Other potential leak vectors checked + cleared:
- License signature verification path: no env-var/dev-mode bypass.
- No committed secrets, .env files, or private keys.
- Only the public Ed25519 key in source.
- PM scheduler gates SSO/RBAC/cost-roi via license at the orchestration layer (defensible but implicit; deferred follow-up to add defensive checks at module entry points).

## Recommendation

Merge this, then it's safe to flip the repo public. The deferred defensive-checks-in-SSO/RBAC pass is hardening, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)