### PR TITLE
fix(auth): defensive isFeatureLicensed("sso") gate at WorkOS entry

### DIFF
--- a/packages/cli/src/__tests__/sso-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/sso-bootstrap.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
 
+const stubWorkosClient = vi.fn(async (_apiKey: string) => ({
+  getAuthorizationUrl: async () => "https://stub/auth",
+  authenticateWithCode: async () => ({
+    user: {
+      id: "u",
+      email: "u@example.com",
+      firstName: null,
+      lastName: null,
+    },
+  }),
+}));
+
 // Stub the core module so we don't actually hit WorkOS during tests.
 vi.mock("@urateam/core", async () => {
   const actual = await vi.importActual<typeof import("@urateam/core")>(
@@ -8,17 +20,7 @@ vi.mock("@urateam/core", async () => {
   );
   return {
     ...actual,
-    getDefaultWorkosClient: vi.fn(async (_apiKey: string) => ({
-      getAuthorizationUrl: async () => "https://stub/auth",
-      authenticateWithCode: async () => ({
-        user: {
-          id: "u",
-          email: "u@example.com",
-          firstName: null,
-          lastName: null,
-        },
-      }),
-    })),
+    getDefaultWorkosClient: stubWorkosClient,
   };
 });
 
@@ -92,5 +94,20 @@ describe("bootstrapSsoFromEnv", { timeout: 15_000 }, () => {
       URATEAM_SSO_ALLOWED_DOMAIN: "acme.com",
     });
     expect(result!.sso.allowedDomain).toBe("acme.com");
+  });
+
+  it("exits with an actionable message when getDefaultWorkosClient throws LicenseRequiredError", async () => {
+    const { LicenseRequiredError } = await import("@urateam/core");
+    stubWorkosClient.mockRejectedValueOnce(
+      new LicenseRequiredError("sso", "pro"),
+    );
+    await expect(bootstrapSsoFromEnv({ ...FULL_ENV })).rejects.toThrow(
+      "__EXIT__",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const msg = errorSpy.mock.calls[0]!.join(" ");
+    expect(msg).toContain("requires an enterprise license");
+    expect(msg).toContain("Current tier: pro");
+    expect(msg).toContain("support@urateams.com");
   });
 });

--- a/packages/cli/src/sso-bootstrap.ts
+++ b/packages/cli/src/sso-bootstrap.ts
@@ -62,7 +62,7 @@ export async function bootstrapSsoFromEnv(
     process.exit(1);
   }
 
-  const { SsoConfigSchema, getDefaultWorkosClient } = await import(
+  const { SsoConfigSchema, getDefaultWorkosClient, LicenseRequiredError } = await import(
     "@urateam/core"
   );
 
@@ -86,6 +86,19 @@ export async function bootstrapSsoFromEnv(
     process.exit(1);
   }
 
-  const workos = await getDefaultWorkosClient(sso.workosApiKey);
+  let workos;
+  try {
+    workos = await getDefaultWorkosClient(sso.workosApiKey);
+  } catch (err) {
+    if (err instanceof LicenseRequiredError) {
+      console.error(
+        `URATEAM_SSO_ENABLED=true but the "sso" feature requires an enterprise license. ` +
+          `Current tier: ${err.actualTier}. ` +
+          `Either unset URATEAM_SSO_ENABLED or contact support@urateams.com to upgrade.`,
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
   return { sso, workos };
 }

--- a/packages/core/src/__tests__/sso-license.test.ts
+++ b/packages/core/src/__tests__/sso-license.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { _resetLicenseCache, LicenseRequiredError } from "../license.js";
+import { getDefaultWorkosClient, _resetWorkosClient } from "../auth/workos-client.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+afterEach(async () => {
+  _resetWorkosClient();
+  _resetLicenseCache();
+  await restoreLicense();
+});
+
+describe("getDefaultWorkosClient license gate", () => {
+  it("rejects with LicenseRequiredError in OSS mode", async () => {
+    await expect(getDefaultWorkosClient("sk_test_unused")).rejects.toBeInstanceOf(
+      LicenseRequiredError,
+    );
+  });
+
+  it("LicenseRequiredError carries the feature key", async () => {
+    try {
+      await getDefaultWorkosClient("sk_test_unused");
+      expect.fail("expected LicenseRequiredError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LicenseRequiredError);
+      expect((err as LicenseRequiredError).feature).toBe("sso");
+    }
+  });
+
+  it("does not attempt to import the WorkOS SDK in OSS mode", async () => {
+    // The SDK package is not declared as a dep of @urateam/core (intentional —
+    // dashboard provides it at runtime). If the gate didn't fire, the dynamic
+    // import would throw a "Cannot find module" error rather than our typed
+    // LicenseRequiredError. Asserting the typed error implicitly proves the
+    // gate runs before the import.
+    await expect(getDefaultWorkosClient("sk_test_unused")).rejects.toMatchObject({
+      name: "LicenseRequiredError",
+      feature: "sso",
+    });
+  });
+
+  it("not licensed at pro tier", async () => {
+    await installTestProLicense("pro");
+    await expect(getDefaultWorkosClient("sk_test_unused")).rejects.toBeInstanceOf(
+      LicenseRequiredError,
+    );
+  });
+
+  // Note: positive-path "with enterprise license, returns a client" is not
+  // asserted here because the @workos-inc/node SDK is not installed in
+  // @urateam/core's node_modules. The dashboard's own integration tests
+  // exercise the licensed path with the SDK present.
+});

--- a/packages/core/src/__tests__/sso-license.test.ts
+++ b/packages/core/src/__tests__/sso-license.test.ts
@@ -16,13 +16,14 @@ describe("getDefaultWorkosClient license gate", () => {
     );
   });
 
-  it("LicenseRequiredError carries the feature key", async () => {
+  it("LicenseRequiredError carries feature + actual tier (oss in OSS mode)", async () => {
     try {
       await getDefaultWorkosClient("sk_test_unused");
       expect.fail("expected LicenseRequiredError");
     } catch (err) {
       expect(err).toBeInstanceOf(LicenseRequiredError);
       expect((err as LicenseRequiredError).feature).toBe("sso");
+      expect((err as LicenseRequiredError).actualTier).toBe("oss");
     }
   });
 
@@ -38,11 +39,13 @@ describe("getDefaultWorkosClient license gate", () => {
     });
   });
 
-  it("not licensed at pro tier", async () => {
+  it("rejects with actualTier='pro' when license is pro (sso is enterprise-only)", async () => {
     await installTestProLicense("pro");
-    await expect(getDefaultWorkosClient("sk_test_unused")).rejects.toBeInstanceOf(
-      LicenseRequiredError,
-    );
+    await expect(getDefaultWorkosClient("sk_test_unused")).rejects.toMatchObject({
+      name: "LicenseRequiredError",
+      feature: "sso",
+      actualTier: "pro",
+    });
   });
 
   // Note: positive-path "with enterprise license, returns a client" is not

--- a/packages/core/src/auth/workos-client.ts
+++ b/packages/core/src/auth/workos-client.ts
@@ -1,3 +1,8 @@
+import { isFeatureLicensed, LicenseRequiredError } from "../license.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "auth.workos" });
+
 /**
  * Thin interface over @workos-inc/node so tests can inject a stub
  * without importing the SDK or hitting the network.
@@ -37,8 +42,21 @@ let cached: WorkosClient | null = null;
  *
  * NOTE: The singleton cache is not keyed on apiKey. If the API key is
  * rotated, the process must be restarted to pick up the new key.
+ *
+ * Throws `LicenseRequiredError` if the `sso` feature is not licensed. This is
+ * a defensive library-boundary gate: even though dashboard wiring already
+ * skips SSO mounting in OSS mode, any direct caller of this function (CLI
+ * bootstrap, future routes, third-party integrations) cannot accidentally
+ * load the WorkOS SDK without a license.
  */
 export async function getDefaultWorkosClient(apiKey: string): Promise<WorkosClient> {
+  if (!isFeatureLicensed("sso")) {
+    log.warn(
+      { feature: "sso" },
+      "getDefaultWorkosClient called without an enterprise license — refusing to load WorkOS SDK",
+    );
+    throw new LicenseRequiredError("sso");
+  }
   if (cached) return cached;
   // Dynamic import so the dep is loaded only when actually used.
   // The SDK lives in @urateam/dashboard (the only package that activates SSO),

--- a/packages/core/src/auth/workos-client.ts
+++ b/packages/core/src/auth/workos-client.ts
@@ -1,4 +1,4 @@
-import { isFeatureLicensed, LicenseRequiredError } from "../license.js";
+import { checkLicense, LicenseRequiredError } from "../license.js";
 import { createLogger } from "../logger.js";
 
 const log = createLogger({ component: "auth.workos" });
@@ -41,7 +41,10 @@ let cached: WorkosClient | null = null;
  * environments that never call this never need the SDK installed.
  *
  * NOTE: The singleton cache is not keyed on apiKey. If the API key is
- * rotated, the process must be restarted to pick up the new key.
+ * rotated, the process must be restarted to pick up the new key. The cache
+ * is also coupled to the license cache: if a future change introduces
+ * in-process license refresh (see `_resetLicenseCache`), call
+ * `_resetWorkosClient()` too so the next call re-evaluates the gate.
  *
  * Throws `LicenseRequiredError` if the `sso` feature is not licensed. This is
  * a defensive library-boundary gate: even though dashboard wiring already
@@ -50,12 +53,13 @@ let cached: WorkosClient | null = null;
  * load the WorkOS SDK without a license.
  */
 export async function getDefaultWorkosClient(apiKey: string): Promise<WorkosClient> {
-  if (!isFeatureLicensed("sso")) {
+  const status = checkLicense();
+  if (!status.features.has("sso")) {
     log.warn(
-      { feature: "sso" },
+      { feature: "sso", tier: status.tier },
       "getDefaultWorkosClient called without an enterprise license — refusing to load WorkOS SDK",
     );
-    throw new LicenseRequiredError("sso");
+    throw new LicenseRequiredError("sso", status.tier);
   }
   if (cached) return cached;
   // Dynamic import so the dep is loaded only when actually used.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 export * from "./types.js";
-export { checkLicense, isFeatureLicensed, type LicenseStatus } from "./license.js";
+export {
+  checkLicense,
+  isFeatureLicensed,
+  LicenseRequiredError,
+  type LicenseStatus,
+} from "./license.js";
 export * from "./audit/index.js";
 export * from "./auth/index.js";
 export * from "./policy/index.js";

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -137,15 +137,22 @@ export function isFeatureLicensed(feature: string): boolean {
  * unlocks it. Library entry points for gated features (SSO, RBAC, cost
  * calculation, etc.) throw this when callers can't be served a safe default
  * — the caller MUST hold a valid license to proceed.
+ *
+ * `actualTier` is the tier the current process is running under (e.g., a
+ * pro-tier customer trying to use an enterprise-only feature gets `"pro"`),
+ * so the error message and log fields are accurate even when the gap is
+ * "wrong tier" rather than "no license at all".
  */
 export class LicenseRequiredError extends Error {
   readonly feature: string;
-  constructor(feature: string) {
+  readonly actualTier: Tier;
+  constructor(feature: string, actualTier: Tier = "oss") {
     super(
-      `feature "${feature}" requires a license that unlocks it; running in OSS mode`,
+      `feature "${feature}" requires a license that unlocks it; current tier: ${actualTier}`,
     );
     this.name = "LicenseRequiredError";
     this.feature = feature;
+    this.actualTier = actualTier;
   }
 }
 

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -132,6 +132,23 @@ export function isFeatureLicensed(feature: string): boolean {
   return checkLicense().features.has(feature);
 }
 
+/**
+ * Thrown when a commercially gated feature is invoked without a license that
+ * unlocks it. Library entry points for gated features (SSO, RBAC, cost
+ * calculation, etc.) throw this when callers can't be served a safe default
+ * — the caller MUST hold a valid license to proceed.
+ */
+export class LicenseRequiredError extends Error {
+  readonly feature: string;
+  constructor(feature: string) {
+    super(
+      `feature "${feature}" requires a license that unlocks it; running in OSS mode`,
+    );
+    this.name = "LicenseRequiredError";
+    this.feature = feature;
+  }
+}
+
 interface JwtClaims {
   iss: string;
   sub: string;


### PR DESCRIPTION
## Summary

- `getDefaultWorkosClient` now throws `LicenseRequiredError("sso")` + structured warn when called in OSS mode (or pro tier without `sso` feature). Mirrors the slack-interface gate at `server.ts:127` and multi-repo gate at `server.ts:66`.
- Adds a shared `LicenseRequiredError` class to `license.ts` (re-exported from `@urateam/core`) so #83 (RBAC) and #84 (cost-roi) can reuse the same error type.

## Why

Pre-public-flip hardening. Today the dashboard already skips SSO mounting gracefully when the feature is unlicensed (`dashboard/src/server.ts:159`), but that protection lives at the orchestration layer — any future direct caller of the auth module (new dashboard route, CLI command, third-party integration) could load the WorkOS SDK without a license check. The library-boundary gate means license enforcement is self-evident from any single entry point.

## Test plan

- [x] `pnpm --filter @urateam/core build` (typecheck)
- [x] `pnpm --filter @urateam/core test` — all 1160 tests + 4 new tests in `sso-license.test.ts` pass
- [x] `pnpm --filter @urateam/cli test` — sso-bootstrap.test.ts (which mocks `getDefaultWorkosClient`) still passes (5 tests)
- [x] `pnpm --filter @urateam/dashboard test` — sso-integration + sso-middleware tests still pass (194 total)

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)