### PR TITLE
fix(rbac): defensive isFeatureLicensed("rbac") gate at canAccess

### DIFF
--- a/packages/core/src/__tests__/rbac-defensive.test.ts
+++ b/packages/core/src/__tests__/rbac-defensive.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { _resetLicenseCache } from "../license.js";
+import { canAccess } from "../rbac/matrix.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+afterEach(async () => {
+  _resetLicenseCache();
+  await restoreLicense();
+});
+
+describe("canAccess defensive license gate", () => {
+  it("returns false in OSS mode regardless of role + action", () => {
+    expect(canAccess("admin", "users.manage")).toBe(false);
+    expect(canAccess("admin", "runs.view")).toBe(false);
+    expect(canAccess("operator", "runs.view")).toBe(false);
+    expect(canAccess("viewer", "runs.view")).toBe(false);
+  });
+
+  it("returns false at pro tier (rbac is enterprise-only)", async () => {
+    await installTestProLicense("pro");
+    expect(canAccess("admin", "users.manage")).toBe(false);
+    expect(canAccess("admin", "runs.view")).toBe(false);
+  });
+
+  it("falls through to the matrix at enterprise tier", async () => {
+    await installTestProLicense("enterprise");
+    // Sanity-check the matrix still drives the result post-gate.
+    expect(canAccess("admin", "users.manage")).toBe(true);
+    expect(canAccess("operator", "users.manage")).toBe(false);
+    expect(canAccess("viewer", "runs.view")).toBe(true);
+    expect(canAccess("viewer", "runs.retry")).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/rbac-defensive.test.ts
+++ b/packages/core/src/__tests__/rbac-defensive.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { _resetLicenseCache } from "../license.js";
 import { canAccess } from "../rbac/matrix.js";
 import { installTestProLicense, restoreLicense } from "./helpers/license.js";
 
 afterEach(async () => {
-  _resetLicenseCache();
+  // restoreLicense() already resets the license cache.
   await restoreLicense();
 });
 

--- a/packages/core/src/__tests__/rbac/matrix.test.ts
+++ b/packages/core/src/__tests__/rbac/matrix.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { canAccess, PERMISSION_MATRIX } from "../../rbac/matrix.js";
 import type { PermissionKey } from "../../rbac/matrix.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
 
 describe("PERMISSION_MATRIX", () => {
+  // canAccess fails closed without an enterprise license (defensive gate).
+  // The matrix-shape tests below assume the gate has passed, so install a
+  // license before each case and restore after.
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+  });
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
   const cases: Array<[PermissionKey, "admin" | "operator" | "viewer", boolean]> = [
     ["runs.view",         "admin",    true],
     ["runs.view",         "operator", true],

--- a/packages/core/src/rbac/matrix.ts
+++ b/packages/core/src/rbac/matrix.ts
@@ -25,13 +25,18 @@ export type PermissionKey = keyof typeof PERMISSION_MATRIX;
  * Check whether `role` is allowed to perform `action`.
  *
  * Defensive license gate: returns `false` (fail closed, "no permission") with
- * a structured warn when the `rbac` feature is not licensed. Today the
- * dashboard middleware (`packages/dashboard/src/middleware/rbac.ts:12`) and
- * the runs UI (`packages/dashboard/src/routes/runs.ts:130`) both short-circuit
- * before calling `canAccess` in OSS mode, so this gate does not change
- * production behavior. It exists so that any future direct caller of the rbac
- * module — a new route, CLI command, third-party integration — cannot silently
- * grant permissions without a license check.
+ * a structured warn when the `rbac` feature is not licensed. The gate is
+ * additive to — not a replacement for — the upstream guards in the dashboard
+ * middleware and the runs UI, both of which already skip calling `canAccess`
+ * in OSS mode. Its purpose is to ensure any future direct caller of the rbac
+ * module — a new route, CLI command, third-party integration — cannot
+ * silently grant permissions without a license check.
+ *
+ * Returns `false` rather than throwing because callers (e.g., the canRetry
+ * ternary in `dashboard/src/routes/runs.ts`) treat the result as a predicate.
+ * Initializers that cannot tolerate a silent denial should mirror the
+ * `getDefaultWorkosClient` pattern in `auth/workos-client.ts` (throws
+ * `LicenseRequiredError`).
  */
 export function canAccess(role: Role, action: PermissionKey): boolean {
   if (!isFeatureLicensed("rbac")) {

--- a/packages/core/src/rbac/matrix.ts
+++ b/packages/core/src/rbac/matrix.ts
@@ -1,4 +1,8 @@
 import type { Role } from "./types.js";
+import { isFeatureLicensed } from "../license.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "rbac" });
 
 export const PERMISSION_MATRIX = {
   "runs.view":         ["admin", "operator", "viewer"],
@@ -17,6 +21,25 @@ export const PERMISSION_MATRIX = {
 
 export type PermissionKey = keyof typeof PERMISSION_MATRIX;
 
+/**
+ * Check whether `role` is allowed to perform `action`.
+ *
+ * Defensive license gate: returns `false` (fail closed, "no permission") with
+ * a structured warn when the `rbac` feature is not licensed. Today the
+ * dashboard middleware (`packages/dashboard/src/middleware/rbac.ts:12`) and
+ * the runs UI (`packages/dashboard/src/routes/runs.ts:130`) both short-circuit
+ * before calling `canAccess` in OSS mode, so this gate does not change
+ * production behavior. It exists so that any future direct caller of the rbac
+ * module — a new route, CLI command, third-party integration — cannot silently
+ * grant permissions without a license check.
+ */
 export function canAccess(role: Role, action: PermissionKey): boolean {
+  if (!isFeatureLicensed("rbac")) {
+    log.warn(
+      { feature: "rbac", action, role },
+      "canAccess called without an enterprise license — denying (fail closed)",
+    );
+    return false;
+  }
   return (PERMISSION_MATRIX[action] as readonly Role[]).includes(role);
 }


### PR DESCRIPTION
## Summary

- `canAccess(role, action)` returns `false` (fail closed, "no permission") + structured warn when the `rbac` feature is not licensed.
- `rbac/matrix.test.ts` now installs an enterprise license in `beforeEach` since the matrix-shape tests assume the gate has passed.
- New `rbac-defensive.test.ts` asserts OSS-mode + pro-tier denial and enterprise pass-through.

## Why

Pre-public-flip hardening, mirrors the SSO gate landed in PR #86. Today both production callers already short-circuit before reaching `canAccess` in OSS mode:

- `packages/dashboard/src/middleware/rbac.ts:12` — `if (!isFeatureLicensed("rbac")) return next();`
- `packages/dashboard/src/routes/runs.ts:130` — `isFeatureLicensed("rbac") ? canAccess(...) : true`

So this gate is pure defense-in-depth: no runtime behavior change in production paths, but any future direct caller (new dashboard route, CLI command, third-party integration) cannot silently grant permissions without a license.

## Scope note

Only `canAccess` is gated. The other rbac entry points (`setUserRole`, `listUsers`, `applyBootstrapAdmins`, `getUserRole`) are intentionally not gated:

- `applyBootstrapAdmins` runs on every dashboard login and is OSS-safe (sets the role column harmlessly when RBAC is unenforced)
- `setUserRole`/`listUsers` are admin-only and already short-circuited by the `requirePermission` middleware in OSS mode

If a future audit wants to extend the gate to those, that's a separate issue.

## Test plan

- [x] `pnpm --filter @urateam/core build` (typecheck)
- [x] `pnpm --filter @urateam/core test` — 1164 tests pass (added 3 in rbac-defensive)
- [x] `pnpm --filter @urateam/dashboard test` — all 194 tests pass (middleware + routes + integration)

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)