### PR TITLE
fix(cost): defensive isFeatureLicensed("cost-roi") gates at all entry points

### DIFF
--- a/packages/core/src/__tests__/cost-defensive.test.ts
+++ b/packages/core/src/__tests__/cost-defensive.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createDb } from "../db/client.js";
+import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { computeRunCost } from "../cost/per-run.js";
+import { aggregateAll, aggregateHybrid } from "../cost/aggregate.js";
+import { recomputeCostRollups } from "../cost/rollup.js";
+import { streamCostCsv } from "../cost/csv.js";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
+
+let db: any;
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "quick-fix": { profile: { model: "claude-sonnet-4-6" } } as any,
+  },
+} as any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+});
+
+afterEach(async () => {
+  await restoreLicense();
+});
+
+async function seedOneRun(): Promise<string> {
+  const runId = "pr_test";
+  const completedAt = new Date();
+  await db.insert(pipelineRuns).values({
+    id: runId,
+    issueId: "ISSUE-1",
+    issueTitle: "test",
+    pipelineKey: "quick-fix",
+    repoUrl: "https://example.com/repo",
+    status: "completed",
+    runType: "standard",
+    startedAt: new Date(completedAt.getTime() - 60_000),
+    completedAt,
+    linearTeamId: null,
+  } as any);
+  await db.insert(stageRuns).values({
+    id: "sr_test",
+    pipelineRunId: runId,
+    stage: "implement",
+    status: "completed",
+    startedAt: new Date(completedAt.getTime() - 60_000),
+    completedAt,
+    inputTokens: 1000,
+    outputTokens: 500,
+  } as any);
+  return runId;
+}
+
+async function collect(iter: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const chunk of iter) out += chunk;
+  return out;
+}
+
+describe("cost-roi defensive license gate", () => {
+  describe("OSS mode (no license)", () => {
+    it("computeRunCost returns zero", () => {
+      const cost = computeRunCost(
+        { pipelineKey: "quick-fix", status: "completed", runType: null },
+        [{ stage: "implement", inputTokens: 1000, outputTokens: 500 }],
+        config,
+      );
+      expect(cost).toEqual({ inputTokens: 0, outputTokens: 0, dollars: 0, timeSavedHours: 0 });
+    });
+
+    it("aggregateAll returns empty result", async () => {
+      await seedOneRun();
+      const filters = { from: new Date("2026-01-01"), to: new Date("2027-01-01") };
+      const result = await aggregateAll(db, filters, config);
+      expect(result.summary.runs).toBe(0);
+      expect(result.summary.dollars).toBe(0);
+      expect(result.byTeam).toEqual([]);
+      expect(result.byRepo).toEqual([]);
+      expect(result.byPipeline).toEqual([]);
+      expect(result.byDay).toEqual([]);
+    });
+
+    it("aggregateHybrid returns empty result", async () => {
+      await seedOneRun();
+      const filters = { from: new Date("2026-01-01"), to: new Date("2027-01-01") };
+      const result = await aggregateHybrid(db, filters, config);
+      expect(result.summary.runs).toBe(0);
+      expect(result.byTeam).toEqual([]);
+    });
+
+    it("recomputeCostRollups returns rowsWritten=0 without writing", async () => {
+      await seedOneRun();
+      const result = await recomputeCostRollups(db, config);
+      expect(result).toEqual({ rowsWritten: 0 });
+    });
+
+    it("streamCostCsv yields nothing (empty stream)", async () => {
+      await seedOneRun();
+      const filters = { from: new Date("2026-01-01"), to: new Date("2027-01-01") };
+      const out = await collect(streamCostCsv(db, filters, config));
+      expect(out).toBe("");
+    });
+  });
+
+  describe("pro tier (cost-roi is enterprise-only)", () => {
+    beforeEach(async () => {
+      await installTestProLicense("pro");
+    });
+
+    it("computeRunCost still returns zero", () => {
+      const cost = computeRunCost(
+        { pipelineKey: "quick-fix", status: "completed", runType: null },
+        [{ stage: "implement", inputTokens: 1000, outputTokens: 500 }],
+        config,
+      );
+      expect(cost.dollars).toBe(0);
+    });
+
+    it("aggregateAll still returns empty", async () => {
+      await seedOneRun();
+      const filters = { from: new Date("2026-01-01"), to: new Date("2027-01-01") };
+      const result = await aggregateAll(db, filters, config);
+      expect(result.summary.runs).toBe(0);
+    });
+  });
+
+  describe("enterprise tier (sanity — gate falls through)", () => {
+    beforeEach(async () => {
+      await installTestProLicense("enterprise");
+    });
+
+    it("computeRunCost returns non-zero dollars for non-trivial input", () => {
+      const cost = computeRunCost(
+        { pipelineKey: "quick-fix", status: "completed", runType: null },
+        [{ stage: "implement", inputTokens: 1_000_000, outputTokens: 1_000_000 }],
+        config,
+      );
+      expect(cost.dollars).toBeGreaterThan(0);
+      expect(cost.timeSavedHours).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/core/src/__tests__/cost/aggregate.test.ts
+++ b/packages/core/src/__tests__/cost/aggregate.test.ts
@@ -1,9 +1,19 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns, stageRuns } from "../../db/schema.js";
 import { randomUUID } from "node:crypto";
 import { aggregateAll, aggregateHybrid, normalizeTeamId, snapToUtcDayStart } from "../../cost/aggregate.js";
 import { costRollupsDaily } from "../../db/schema.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+// aggregateAll/Hybrid short-circuit to empty results without an enterprise
+// license (defensive gate). All shape tests assume the gate has passed.
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+});
+afterEach(async () => {
+  await restoreLicense();
+});
 
 let db: any;
 

--- a/packages/core/src/__tests__/cost/csv.test.ts
+++ b/packages/core/src/__tests__/cost/csv.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns, stageRuns } from "../../db/schema.js";
 import { streamCostCsv } from "../../cost/csv.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+// streamCostCsv short-circuits to an empty stream without an enterprise
+// license (defensive gate). All tests assume the gate has passed.
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+});
+afterEach(async () => {
+  await restoreLicense();
+});
 
 async function collect(iter: AsyncIterable<string>): Promise<string> {
   let out = "";

--- a/packages/core/src/__tests__/cost/per-run.test.ts
+++ b/packages/core/src/__tests__/cost/per-run.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { computeRunCost } from "../../cost/per-run.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+// computeRunCost short-circuits to zero without an enterprise license
+// (defensive gate). The cost-shape tests below assume the gate has passed.
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+});
+afterEach(async () => {
+  await restoreLicense();
+});
 
 const config = {
   costs: {

--- a/packages/core/src/__tests__/cost/rollup.test.ts
+++ b/packages/core/src/__tests__/cost/rollup.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDb } from "../../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../../db/schema.js";
 import { recomputeCostRollups } from "../../cost/rollup.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+// recomputeCostRollups short-circuits without an enterprise license
+// (defensive gate). All tests assume the gate has passed.
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+});
+afterEach(async () => {
+  await restoreLicense();
+});
 
 let db: any;
 

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -3,9 +3,21 @@ import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { createLogger } from "../logger.js";
+import { isFeatureLicensed } from "../license.js";
 import type { AggregateResult, BreakdownRow, CostSummary, DailyRow } from "./types.js";
 
 const log = createLogger({ component: "cost.aggregate" });
+
+function emptyAggregateResult(filters: AggregateFilters): AggregateResult {
+  return {
+    summary: {
+      window: { from: filters.from, to: filters.to },
+      runs: 0, prsMerged: 0, inputTokens: 0, outputTokens: 0,
+      dollars: 0, timeSavedHours: 0, roiMultiplier: 0,
+    },
+    byTeam: [], byRepo: [], byPipeline: [], byDay: [],
+  };
+}
 
 const DEFAULT_MAX_RUNS = 10_000;
 
@@ -51,6 +63,13 @@ export async function aggregateAll(
   config: CostConfig,
   opts: { maxRuns?: number } = {},
 ): Promise<AggregateResult> {
+  if (!isFeatureLicensed("cost-roi")) {
+    log.warn(
+      { feature: "cost-roi" },
+      "aggregateAll called without an enterprise license — returning empty result",
+    );
+    return emptyAggregateResult(filters);
+  }
   const hourlyRate = config.costs?.hourlyEngRate ?? 50;
   const maxRuns = opts.maxRuns ?? DEFAULT_MAX_RUNS;
 
@@ -336,6 +355,13 @@ export async function aggregateHybrid(
   config: CostConfig,
   opts: { maxRuns?: number; now?: Date; enableRollups?: boolean } = {},
 ): Promise<AggregateResult> {
+  if (!isFeatureLicensed("cost-roi")) {
+    log.warn(
+      { feature: "cost-roi" },
+      "aggregateHybrid called without an enterprise license — returning empty result",
+    );
+    return emptyAggregateResult(filters);
+  }
   const enableRollups = opts.enableRollups ?? false;
   if (!enableRollups) {
     return aggregateAll(db, filters, config, opts);

--- a/packages/core/src/cost/csv.ts
+++ b/packages/core/src/cost/csv.ts
@@ -2,6 +2,10 @@ import type { AnyDb } from "../db/client.js";
 import { and, gte, lt, inArray } from "drizzle-orm";
 import { pipelineRuns, stageRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
+import { isFeatureLicensed } from "../license.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "cost.csv" });
 
 const HEADER =
   "completed_at,run_id,issue_id,pipeline_key,linear_team_id,repo_url,input_tokens,output_tokens,dollars,time_saved_hours";
@@ -36,6 +40,13 @@ export async function* streamCostCsv(
   config: CostConfig,
   maxRuns: number = DEFAULT_CSV_MAX_RUNS,
 ): AsyncIterable<string> {
+  if (!isFeatureLicensed("cost-roi")) {
+    log.warn(
+      { feature: "cost-roi" },
+      "streamCostCsv called without an enterprise license — returning empty stream",
+    );
+    return;
+  }
   yield HEADER + "\n";
 
   const runs = await db

--- a/packages/core/src/cost/per-run.ts
+++ b/packages/core/src/cost/per-run.ts
@@ -1,5 +1,16 @@
 import { resolveModelRate, resolveTimeSavedPerPr } from "./rates.js";
 import type { RunCost } from "./types.js";
+import { isFeatureLicensed } from "../license.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "cost.per-run" });
+
+const ZERO_COST: RunCost = {
+  inputTokens: 0,
+  outputTokens: 0,
+  dollars: 0,
+  timeSavedHours: 0,
+};
 
 interface PipelineRunRow {
   pipelineKey: string;
@@ -31,6 +42,13 @@ export function computeRunCost(
   stages: StageRunRow[],
   config: CostConfig,
 ): RunCost {
+  if (!isFeatureLicensed("cost-roi")) {
+    log.warn(
+      { feature: "cost-roi", pipelineKey: run.pipelineKey },
+      "computeRunCost called without an enterprise license — returning zero cost",
+    );
+    return { ...ZERO_COST };
+  }
   const pc = config.pipelineConfigs?.[run.pipelineKey];
   let dollars = 0;
   let inputTokens = 0;

--- a/packages/core/src/cost/rollup.ts
+++ b/packages/core/src/cost/rollup.ts
@@ -4,6 +4,7 @@ import type { AnyDb } from "../db/client.js";
 import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { createLogger } from "../logger.js";
+import { isFeatureLicensed } from "../license.js";
 
 const log = createLogger({ component: "cost.rollup" });
 
@@ -149,6 +150,13 @@ export async function recomputeCostRollups(
   db: AnyDb,
   config: CostConfig,
 ): Promise<{ rowsWritten: number }> {
+  if (!isFeatureLicensed("cost-roi")) {
+    log.warn(
+      { feature: "cost-roi" },
+      "recomputeCostRollups called without an enterprise license — skipping",
+    );
+    return { rowsWritten: 0 };
+  }
   // Determine yesterday (UTC). Rollups only cover completed UTC days.
   const now = new Date();
   const yesterdayUtc = new Date(Date.UTC(

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -491,6 +491,11 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
 
         // Cost & ROI daily rollup (no-op if unlicensed).
         // Wrapped in try/catch — rollup failure must not crash the tick.
+        // The isFeatureLicensed check here is the SECONDARY guard — the
+        // primary gate now lives inside recomputeCostRollups itself. This
+        // outer check skips the call entirely (saves a function frame +
+        // one structured warn log per tick) and should not be removed
+        // even if the inner gate looks sufficient.
         try {
           if (isFeatureLicensed("cost-roi")) {
             await recomputeCostRollups(db, config as any);


### PR DESCRIPTION
## Summary

Mirrors the SSO gate (PR #86) and RBAC gate (PR #87). Adds an `isFeatureLicensed("cost-roi")` gate at every public entry function in the cost module, so future direct callers cannot silently trigger paid cost-calculation paths without an enterprise license:

| Function | OSS-mode behavior |
|---|---|
| `computeRunCost` | returns zero `RunCost` + warn (the kernel) |
| `aggregateAll` / `aggregateHybrid` | return empty `AggregateResult` + warn |
| `recomputeCostRollups` | returns `{ rowsWritten: 0 }` + warn (no db writes) |
| `streamCostCsv` | returns an empty async stream + warn |

## Why

Pre-public-flip hardening. Both production callers already short-circuit before reaching cost code:

- `packages/core/src/pm/scheduler.ts:495` — `if (isFeatureLicensed("cost-roi")) { await recomputeCostRollups(...) }`
- `packages/dashboard/src/routes/cost.ts:52,56` — `if (!isFeatureLicensed("cost-roi")) return c.notFound();`

So this gate does not change runtime behavior. It exists so the kernel `computeRunCost` and the public IO entry points are self-evidently gated — a new dashboard route, CLI command, or third-party integration can't accidentally bill cost work without a license.

## Test plan

- [x] `pnpm --filter @urateam/core build` (typecheck)
- [x] `pnpm --filter @urateam/core test` — 1172 tests pass (existing 4 cost test files now install enterprise license in beforeEach; added `cost-defensive.test.ts` with 8 tests covering all 5 entry points)
- [x] `pnpm --filter @urateam/dashboard test` — 194 tests pass

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)