### PR TITLE
chore(test): hoist server.test.ts restoreLicense to top-level afterEach

### DIFF
--- a/packages/core/src/__tests__/server.test.ts
+++ b/packages/core/src/__tests__/server.test.ts
@@ -3,6 +3,20 @@ import { createApp, type ServerConfig } from "../server.js";
 import { defaultConfigs } from "../pipeline/config.js";
 import { installTestProLicense, restoreLicense } from "./helpers/license.js";
 
+// Top-level afterEach: any test in this file that calls installTestProLicense
+// (directly or through buildApp setup) leaves cached license state behind
+// because checkLicense() memoizes its result for the lifetime of the worker.
+// This restore happens after every test so the next one starts from a clean
+// OSS baseline, regardless of describe-block ordering or future additions.
+//
+// New contributors: if you add a test that installs a license, you do NOT
+// need a local afterEach — this one covers you. If you add a test that
+// asserts OSS-mode behavior, it will see OSS regardless of the order in
+// which tests run.
+afterEach(async () => {
+  await restoreLicense();
+});
+
 const PM_SLACK_CONFIG = {
   signingSecret: "slack_signing_test",
   botToken: "xoxb-test",
@@ -80,9 +94,7 @@ describe("Unknown routes", () => {
 // PM Slack interface license gating
 // ---------------------------------------------------------------------------
 describe("PM Slack interface mount is license-gated", () => {
-  afterEach(async () => {
-    await restoreLicense();
-  });
+  // restoreLicense is handled by the top-level afterEach.
 
   it("does NOT mount /slack/* routes in OSS mode even when pmSlack is configured", async () => {
     // No license installed → tier is OSS → slack-interface feature unlicensed.


### PR DESCRIPTION
## Summary

Move the `afterEach(restoreLicense)` from the local PM-Slack-gate describe block to the top of `packages/core/src/__tests__/server.test.ts`. Add a doc-comment establishing the contract for future contributors.

## Why

Today the existing layout is correct because vitest 3's forks pool isolates test files and the new gating tests run AFTER the unrelated tests, so the cached license state never leaks into a test that doesn't expect it. But that correctness depends on test ordering — a future contributor who adds a new `installTestProLicense()`-using test ABOVE the Slack block would silently break the OSS-mode assertions in the unrelated tests.

The fix is one extra `afterEach` at file scope plus a comment, so the next person adding a license-installing test doesn't have to think about ordering.

## Test plan

- [x] `pnpm --filter @urateam/core test` — all 1172 tests pass (no behavior change)

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)