### PR TITLE
chore: pre-public-flip cleanup — license metadata + contact addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ Examples of unacceptable behavior:
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project team at conduct@urateam.dev.
+reported to the project team at conduct@urateams.com.
 
 ## Attribution
 

--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ Change Date:          2030-04-11
 Change License:       Apache License, Version 2.0
 
 For information about alternative licensing arrangements for the Licensed Work,
-please contact licensing@urateam.dev.
+please contact licensing@urateams.com.
 
 Notice
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting Vulnerabilities
 
-Please report security vulnerabilities by emailing security@urateam.dev.
+Please report security vulnerabilities by emailing security@urateams.com.
 
 Do **NOT** open a public issue for security vulnerabilities.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "urateam",
   "private": true,
+  "license": "BUSL-1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/JonB32/urateam.git"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@urateam/cli",
   "version": "0.1.4",
+  "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@urateam/core",
   "version": "0.1.7",
+  "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-urateam",
   "version": "0.1.6",
+  "license": "BUSL-1.1",
   "type": "module",
   "bin": {
     "create-urateam": "dist/index.js"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@urateam/dashboard",
   "version": "0.1.4",
+  "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",


### PR DESCRIPTION
## Summary

Pre-public-flip security audit findings (MEDIUM, all addressed):

- Add \`\"license\": \"BUSL-1.1\"\` to root + 4 published packages. Without this field, npm tarballs ship with \`UNLICENSED\` warnings and downstream scanners can't auto-detect the license. The \`LICENSE\` file (BSL 1.1) and SPDX headers in source are unchanged.
- Update \`LICENSE\` / \`SECURITY.md\` / \`CODE_OF_CONDUCT.md\` contact addresses from \`*@urateam.dev\` → \`*@urateams.com\`. The project domain rename landed pre-Phase-2 (issuer cutover, see \`chore/issuer-urateams-com\`); the contact addresses had not been swapped yet. Once public, customers will email the listed addresses.

Historical references to \`urateam.dev\` in \`docs/superpowers/{plans,specs}/\` are intentionally left as-is — those describe pre-cutover state.

## Test plan

- [x] \`pnpm --filter @urateam/core build\` passes (typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)