### PR TITLE
chore(core): bump version 0.1.7 → 0.1.8

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

First post-public-flip release of \`@urateam/core\`. \`v0.1.7\` is skipped (git tag taken from a failed publish attempt — the prior workflow fired but npm provenance attestation rejected the bundle with `Unsupported GitHub Actions source repository visibility: "private"`).

The repo is now public, so npm provenance can match the workflow's OIDC identity claim against the public source URL.

## What ships in 0.1.8

- Defensive \`isFeatureLicensed\` gates at the SSO (#86), RBAC (#87), and cost-roi (#88) library entry points
- The slack-interface gate fix (#81) and the live signing key embed (#79)
- \`server.test.ts\` hygiene improvement (#89)
- Pre-public-flip metadata cleanup (#90 — \`license\` fields, contact addresses)

## After merge

Tag \`v0.1.8\` on main → publish workflow fires → \`@urateam/core@0.1.8\` lands on npm with provenance attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)