### PR TITLE
fix(create-urateam): emit .urateam/pnpm-workspace.yaml to fix pnpm-monorepo scaffold

### DIFF
--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/create-urateam/src/__tests__/integration/tarball.test.ts
+++ b/packages/create-urateam/src/__tests__/integration/tarball.test.ts
@@ -124,11 +124,31 @@ describe("create-urateam — installed tarball", () => {
     expect(existsSync(join(projectDir, ".urateam", "Dockerfile"))).toBe(true);
     expect(existsSync(join(projectDir, ".urateam", "docker-compose.yml"))).toBe(true);
     expect(existsSync(join(projectDir, ".urateam", "README.md"))).toBe(true);
+    expect(existsSync(join(projectDir, ".urateam", ".npmrc"))).toBe(true);
 
     // Project root files
     expect(existsSync(join(projectDir, "CLAUDE.md"))).toBe(true);
     expect(existsSync(join(projectDir, "README.md"))).toBe(true);
     expect(existsSync(join(projectDir, ".gitignore"))).toBe(true);
+  });
+
+  it(".npmrc from installed copy has ignore-workspace=true (regression guard for urateam#31)", () => {
+    const projectDir = join(workRoot, "npmrc-check");
+    installedScaffold({
+      projectDir,
+      projectName: "npmrc-check",
+      linearApiKey: "lin_api_test",
+      linearTeamId: "team-test",
+      repoUrl: "https://github.com/test/repo",
+      defaultBranch: "main",
+    });
+
+    // npm publish strips files literally named `.npmrc` from tarballs by
+    // default, the same way it strips `.gitignore`. Inlining the content
+    // (URATEAM_NPMRC in src/index.ts) sidesteps that — this test fails
+    // if anyone reverts to shipping the file through template/.urateam/.
+    const npmrc = readFileSync(join(projectDir, ".urateam", ".npmrc"), "utf-8");
+    expect(npmrc).toContain("ignore-workspace=true");
   });
 
   it(".gitignore from installed copy has urateam entries (regression guard for 0.1.4 ENOENT)", () => {

--- a/packages/create-urateam/src/__tests__/integration/tarball.test.ts
+++ b/packages/create-urateam/src/__tests__/integration/tarball.test.ts
@@ -7,6 +7,7 @@ import {
   existsSync,
   readFileSync,
   readdirSync,
+  writeFileSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -124,7 +125,7 @@ describe("create-urateam — installed tarball", () => {
     expect(existsSync(join(projectDir, ".urateam", "Dockerfile"))).toBe(true);
     expect(existsSync(join(projectDir, ".urateam", "docker-compose.yml"))).toBe(true);
     expect(existsSync(join(projectDir, ".urateam", "README.md"))).toBe(true);
-    expect(existsSync(join(projectDir, ".urateam", ".npmrc"))).toBe(true);
+    expect(existsSync(join(projectDir, ".urateam", "pnpm-workspace.yaml"))).toBe(true);
 
     // Project root files
     expect(existsSync(join(projectDir, "CLAUDE.md"))).toBe(true);
@@ -132,24 +133,83 @@ describe("create-urateam — installed tarball", () => {
     expect(existsSync(join(projectDir, ".gitignore"))).toBe(true);
   });
 
-  it(".npmrc from installed copy has ignore-workspace=true (regression guard for urateam#31)", () => {
-    const projectDir = join(workRoot, "npmrc-check");
+  it("pnpm-workspace.yaml from installed copy stops the upward walk (regression guard for urateam#31)", () => {
+    const projectDir = join(workRoot, "pnpm-ws-check");
     installedScaffold({
       projectDir,
-      projectName: "npmrc-check",
+      projectName: "pnpm-ws-check",
       linearApiKey: "lin_api_test",
       linearTeamId: "team-test",
       repoUrl: "https://github.com/test/repo",
       defaultBranch: "main",
     });
 
-    // npm publish strips files literally named `.npmrc` from tarballs by
-    // default, the same way it strips `.gitignore`. Inlining the content
-    // (URATEAM_NPMRC in src/index.ts) sidesteps that — this test fails
-    // if anyone reverts to shipping the file through template/.urateam/.
-    const npmrc = readFileSync(join(projectDir, ".urateam", ".npmrc"), "utf-8");
-    expect(npmrc).toContain("ignore-workspace=true");
+    const ws = readFileSync(
+      join(projectDir, ".urateam", "pnpm-workspace.yaml"),
+      "utf-8",
+    );
+    expect(ws).toContain("packages: []");
   });
+
+  it(
+    "pnpm install inside scaffolded .urateam/ ignores parent workspace and resolves locally (urateam#31 behavioral guard)",
+    { timeout: 120_000 },
+    () => {
+      // Create a parent directory with a pnpm-workspace.yaml that would
+      // ordinarily swallow .urateam/ (the bug from #31). Then run scaffold,
+      // run a real `pnpm install --offline=false` inside .urateam/, and
+      // assert the lockfile + node_modules land under .urateam/, not the
+      // parent. Uses --prefer-offline to keep CI fast on warm caches.
+      const monorepoRoot = join(workRoot, "fake-monorepo");
+      mkdirSync(monorepoRoot, { recursive: true });
+      writeFileSync(
+        join(monorepoRoot, "pnpm-workspace.yaml"),
+        'packages:\n  - "apps/*"\n',
+      );
+      mkdirSync(join(monorepoRoot, "apps", "stub"), { recursive: true });
+      writeFileSync(
+        join(monorepoRoot, "apps", "stub", "package.json"),
+        '{"name":"stub","version":"0.0.0","private":true}',
+      );
+
+      const projectDir = monorepoRoot;
+      installedScaffold({
+        projectDir,
+        projectName: "fake-monorepo",
+        linearApiKey: "lin_api_test",
+        linearTeamId: "team-test",
+        repoUrl: "https://github.com/test/repo",
+        defaultBranch: "main",
+      });
+
+      // Pre-flight: confirm scaffold emitted the marker file.
+      expect(existsSync(join(projectDir, ".urateam", "pnpm-workspace.yaml"))).toBe(true);
+
+      // Replace the @urateam/cli dep with a small public package so the
+      // install completes quickly and doesn't depend on the cli being
+      // published. We're testing pnpm's workspace-walk behavior, not the
+      // cli itself.
+      const sidecarPkgPath = join(projectDir, ".urateam", "package.json");
+      const sidecarPkg = JSON.parse(readFileSync(sidecarPkgPath, "utf-8"));
+      sidecarPkg.dependencies = { "is-odd": "3.0.1" };
+      writeFileSync(sidecarPkgPath, JSON.stringify(sidecarPkg, null, 2));
+
+      execFileSync("pnpm", ["install", "--prefer-offline"], {
+        cwd: join(projectDir, ".urateam"),
+        stdio: "pipe",
+      });
+
+      // Sidecar deps land in .urateam/, NOT in the parent.
+      expect(
+        existsSync(join(projectDir, ".urateam", "node_modules", "is-odd")),
+      ).toBe(true);
+      expect(existsSync(join(projectDir, ".urateam", "pnpm-lock.yaml"))).toBe(
+        true,
+      );
+      // Negative: the parent must not have been touched.
+      expect(existsSync(join(projectDir, "pnpm-lock.yaml"))).toBe(false);
+    },
+  );
 
   it(".gitignore from installed copy has urateam entries (regression guard for 0.1.4 ENOENT)", () => {
     const projectDir = join(workRoot, "gitignore-check");

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -70,6 +70,16 @@ describe("scaffold — sidecar pattern", () => {
       expect(content).toContain(".urateam/node_modules/");
     });
 
+    it("creates .urateam/.npmrc with ignore-workspace=true (pnpm monorepo fix, urateam#31)", () => {
+      const projectDir = join(tempDir, "my-project");
+      scaffold(baseOptions(projectDir, "my-project"));
+
+      const npmrcPath = join(projectDir, ".urateam", ".npmrc");
+      expect(existsSync(npmrcPath)).toBe(true);
+      const content = readFileSync(npmrcPath, "utf-8");
+      expect(content).toContain("ignore-workspace=true");
+    });
+
     it(".urateam/package.json has sidecar name and @urateam/cli dependency", () => {
       const projectDir = join(tempDir, "cool-agent");
       scaffold(baseOptions(projectDir, "cool-agent"));
@@ -298,6 +308,23 @@ describe("scaffold — sidecar pattern", () => {
         readFileSync(join(projectDir, ".urateam", "package.json"), "utf-8"),
       );
       expect(pkgAfter.dependencies["some-custom-plugin"]).toBe("^1.0.0");
+    });
+
+    it("preserves existing .urateam/.npmrc with custom settings", () => {
+      const projectDir = join(tempDir, "rerun-project");
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      // Simulate user customizing .npmrc (e.g., adding a registry override
+      // alongside the workspace flag).
+      const customNpmrc =
+        "ignore-workspace=true\n@my-scope:registry=https://npm.pkg.example.com\n";
+      writeFileSync(join(projectDir, ".urateam", ".npmrc"), customNpmrc);
+
+      // Re-run scaffold — must not clobber the user's customization.
+      scaffold(baseOptions(projectDir, "rerun-project"));
+
+      const after = readFileSync(join(projectDir, ".urateam", ".npmrc"), "utf-8");
+      expect(after).toBe(customNpmrc);
     });
 
     it("refreshes template files like Dockerfile and docker-compose.yml", () => {

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -70,14 +70,16 @@ describe("scaffold — sidecar pattern", () => {
       expect(content).toContain(".urateam/node_modules/");
     });
 
-    it("creates .urateam/.npmrc with ignore-workspace=true (pnpm monorepo fix, urateam#31)", () => {
+    it("creates .urateam/pnpm-workspace.yaml (pnpm monorepo fix, urateam#31)", () => {
       const projectDir = join(tempDir, "my-project");
       scaffold(baseOptions(projectDir, "my-project"));
 
-      const npmrcPath = join(projectDir, ".urateam", ".npmrc");
-      expect(existsSync(npmrcPath)).toBe(true);
-      const content = readFileSync(npmrcPath, "utf-8");
-      expect(content).toContain("ignore-workspace=true");
+      const wsPath = join(projectDir, ".urateam", "pnpm-workspace.yaml");
+      expect(existsSync(wsPath)).toBe(true);
+      const content = readFileSync(wsPath, "utf-8");
+      // Empty `packages:` list stops pnpm's upward workspace walk at .urateam/
+      // so `pnpm install` installs the sidecar's own deps locally.
+      expect(content).toContain("packages: []");
     });
 
     it(".urateam/package.json has sidecar name and @urateam/cli dependency", () => {
@@ -308,23 +310,6 @@ describe("scaffold — sidecar pattern", () => {
         readFileSync(join(projectDir, ".urateam", "package.json"), "utf-8"),
       );
       expect(pkgAfter.dependencies["some-custom-plugin"]).toBe("^1.0.0");
-    });
-
-    it("preserves existing .urateam/.npmrc with custom settings", () => {
-      const projectDir = join(tempDir, "rerun-project");
-      scaffold(baseOptions(projectDir, "rerun-project"));
-
-      // Simulate user customizing .npmrc (e.g., adding a registry override
-      // alongside the workspace flag).
-      const customNpmrc =
-        "ignore-workspace=true\n@my-scope:registry=https://npm.pkg.example.com\n";
-      writeFileSync(join(projectDir, ".urateam", ".npmrc"), customNpmrc);
-
-      // Re-run scaffold — must not clobber the user's customization.
-      scaffold(baseOptions(projectDir, "rerun-project"));
-
-      const after = readFileSync(join(projectDir, ".urateam", ".npmrc"), "utf-8");
-      expect(after).toBe(customNpmrc);
     });
 
     it("refreshes template files like Dockerfile and docker-compose.yml", () => {

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -93,6 +93,23 @@ export function scaffold(options: ScaffoldOptions): void {
     writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   }
 
+  // Write .urateam/.npmrc only if absent. The `ignore-workspace=true` flag
+  // tells pnpm to treat .urateam/ as an isolated project rather than walking
+  // up to a parent pnpm-workspace.yaml — without it, `pnpm install` inside
+  // .urateam/ silently resolves the parent workspace's projects instead of
+  // installing the sidecar's own deps, and `pnpm dev` fails with
+  // `sh: ura: command not found`. See urateam#31.
+  //
+  // IMPORTANT: This file is intentionally NOT shipped via template/.urateam/.
+  // npm publish strips files named `.npmrc` from the published tarball by
+  // default, so loading from template/ would ENOENT at runtime in an
+  // installed copy. Inlining sidesteps the packaging pitfall (same pattern
+  // as URATEAM_GITIGNORE below).
+  const npmrcPath = join(urateamDir, ".npmrc");
+  if (!existsSync(npmrcPath)) {
+    writeFileSync(npmrcPath, URATEAM_NPMRC);
+  }
+
   // Write .urateam/.env only if absent — preserves real credentials on re-run.
   // On first run, generates a random DASHBOARD_PASSWORD and fills in values
   // from user prompts. On re-run, the existing .env is kept intact so users
@@ -162,6 +179,22 @@ const URATEAM_GITIGNORE = `# urateam sidecar
 .urateam/node_modules/
 .urateam/dist/
 .urateam/pnpm-lock.yaml
+`;
+
+/**
+ * Inlined .npmrc for the urateam sidecar.
+ *
+ * `ignore-workspace=true` makes pnpm treat .urateam/ as an isolated project
+ * even when a parent `pnpm-workspace.yaml` exists. Without it, scaffolding
+ * into a pnpm monorepo causes `pnpm install` inside .urateam/ to resolve
+ * the parent workspace and skip the sidecar's own deps. See urateam#31.
+ *
+ * Inlined (rather than shipped via template/) because npm publish strips
+ * `.npmrc` from published tarballs.
+ */
+const URATEAM_NPMRC = `# Treat .urateam/ as outside any parent pnpm workspace so its own deps install.
+# See https://pnpm.io/npmrc#ignore-workspace
+ignore-workspace=true
 `;
 
 // CLI entrypoint — only runs when executed directly (not when imported for testing)

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -93,23 +93,6 @@ export function scaffold(options: ScaffoldOptions): void {
     writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   }
 
-  // Write .urateam/.npmrc only if absent. The `ignore-workspace=true` flag
-  // tells pnpm to treat .urateam/ as an isolated project rather than walking
-  // up to a parent pnpm-workspace.yaml — without it, `pnpm install` inside
-  // .urateam/ silently resolves the parent workspace's projects instead of
-  // installing the sidecar's own deps, and `pnpm dev` fails with
-  // `sh: ura: command not found`. See urateam#31.
-  //
-  // IMPORTANT: This file is intentionally NOT shipped via template/.urateam/.
-  // npm publish strips files named `.npmrc` from the published tarball by
-  // default, so loading from template/ would ENOENT at runtime in an
-  // installed copy. Inlining sidesteps the packaging pitfall (same pattern
-  // as URATEAM_GITIGNORE below).
-  const npmrcPath = join(urateamDir, ".npmrc");
-  if (!existsSync(npmrcPath)) {
-    writeFileSync(npmrcPath, URATEAM_NPMRC);
-  }
-
   // Write .urateam/.env only if absent — preserves real credentials on re-run.
   // On first run, generates a random DASHBOARD_PASSWORD and fills in values
   // from user prompts. On re-run, the existing .env is kept intact so users
@@ -181,21 +164,6 @@ const URATEAM_GITIGNORE = `# urateam sidecar
 .urateam/pnpm-lock.yaml
 `;
 
-/**
- * Inlined .npmrc for the urateam sidecar.
- *
- * `ignore-workspace=true` makes pnpm treat .urateam/ as an isolated project
- * even when a parent `pnpm-workspace.yaml` exists. Without it, scaffolding
- * into a pnpm monorepo causes `pnpm install` inside .urateam/ to resolve
- * the parent workspace and skip the sidecar's own deps. See urateam#31.
- *
- * Inlined (rather than shipped via template/) because npm publish strips
- * `.npmrc` from published tarballs.
- */
-const URATEAM_NPMRC = `# Treat .urateam/ as outside any parent pnpm workspace so its own deps install.
-# See https://pnpm.io/npmrc#ignore-workspace
-ignore-workspace=true
-`;
 
 // CLI entrypoint — only runs when executed directly (not when imported for testing)
 async function main() {

--- a/packages/create-urateam/template/.urateam/pnpm-workspace.yaml
+++ b/packages/create-urateam/template/.urateam/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+# Empty workspace marker. Stops pnpm's upward `pnpm-workspace.yaml` walk at
+# this directory, so `pnpm install` inside .urateam/ installs the sidecar's
+# own deps locally rather than resolving a parent workspace's projects. See
+# urateam#31. The `.npmrc` `ignore-workspace=true` flag does NOT work for this
+# (it only takes effect as a CLI argument, not from .npmrc, in pnpm 9.x).
+# npm and yarn ignore this file entirely, so it's a no-op for non-pnpm users.
+packages: []


### PR DESCRIPTION
## Summary

Closes urateam #31. Scaffolding into a project with a parent `pnpm-workspace.yaml` silently broke — `pnpm install` inside `.urateam/` walked up, resolved the parent workspace's projects, and skipped the sidecar's own deps, leaving `pnpm dev` to crash with `sh: ura: command not found`.

**Fix:** emit an empty `.urateam/pnpm-workspace.yaml` (`packages: []`). pnpm stops its upward walk at the first `pnpm-workspace.yaml` it finds, treating `.urateam/` as its own workspace root.

## Important: original .npmrc approach didn't work

The first commit on this branch (a829d52) tried the issue author's proposed fix — a `.urateam/.npmrc` with `ignore-workspace=true`. **Sonnet's empirical review caught that pnpm 9.x silently ignores this flag when it comes from `.npmrc` — it only takes effect as a CLI argument.** I reproduced the failure independently:

```
parent/pnpm-workspace.yaml + .urateam/.npmrc(ignore-workspace=true)
  → pnpm install in .urateam/ leaks lockfile to parent (bug remains)
```

Pivoted to `pnpm-workspace.yaml` in commit 4709a7a, which I verified works.

## What changed (final state)

- `packages/create-urateam/template/.urateam/pnpm-workspace.yaml` — new (shipped through `template/`; npm publish does NOT strip `.yaml` files, only `.gitignore` and `.npmrc`)
- 1 new unit test: scaffold creates the marker file
- 2 new integration tests: file exists in tarball-installed copy, **AND** a real `pnpm install` inside a scaffolded `.urateam/` (with a parent `pnpm-workspace.yaml`) succeeds with deps landing locally — load-bearing proof the fix works (pure content assertions would have silently passed under the broken `.npmrc` approach)
- `create-urateam` version bumped 0.1.6 → 0.1.7

## Test plan

- [x] `pnpm --filter create-urateam build` (typecheck)
- [x] `pnpm --filter create-urateam test` — 22 unit tests pass
- [x] `pnpm --filter create-urateam test:integration` — 7 integration tests pass (was 5; +2)
- [x] Behavioral test does real `pnpm install` in 1.6s, confirms locality

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)