### PR TITLE
fix: ura dev fail-fast on empty repoConfigs + clearer error message

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -42,6 +42,23 @@ export const devCommand = new Command("dev")
       repoConfigs[process.env.REPO_TEAM_ID] = repoEntry;
     }
 
+    // Fail fast if no repoConfigs could be built. Without this, `ura dev`
+    // looks healthy in logs (webhook server up, dashboard up) but every
+    // inbound Linear webhook fails with "no repo mapping" — usually after
+    // the user has already moved a real issue to Todo. The first-time-user
+    // setup path nearly always lands here because .urateam/.env ships with
+    // `REPO_URL=` and `REPO_TEAM_ID=` blank. See urateam#33.
+    if (Object.keys(repoConfigs).length === 0) {
+      console.error(
+        "Error: no repoConfigs could be built from environment variables.\n" +
+          "Set REPO_TEAM_ID and REPO_URL in .urateam/.env and restart.\n" +
+          "Example:\n" +
+          "  REPO_TEAM_ID=<your Linear team UUID — usually the same as LINEAR_TEAM_ID>\n" +
+          "  REPO_URL=https://github.com/org/repo\n",
+      );
+      process.exit(1);
+    }
+
     const config = {
       webhookSecret: process.env.LINEAR_WEBHOOK_SECRET ?? "dev-secret",
       linearApiKey: process.env.LINEAR_API_KEY ?? "",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -71,6 +71,20 @@ export const startCommand = new Command("start")
       repoConfigs[process.env.REPO_TEAM_ID] = repoEntry;
     }
 
+    // Fail fast if no repoConfigs could be built. Same guard as `ura dev` —
+    // without it the webhook server starts looking healthy and silently
+    // fails every inbound Linear event with "no repo mapping". See urateam#33.
+    if (Object.keys(repoConfigs).length === 0) {
+      console.error(
+        "Error: no repoConfigs could be built from environment variables.\n" +
+          "Set REPO_TEAM_ID and REPO_URL and restart.\n" +
+          "Example:\n" +
+          "  REPO_TEAM_ID=<your Linear team UUID — usually the same as LINEAR_TEAM_ID>\n" +
+          "  REPO_URL=https://github.com/org/repo\n",
+      );
+      process.exit(1);
+    }
+
     // GitHub App config (optional)
     let github: import("@urateam/core").GitHubConfig | undefined;
     if (process.env.GITHUB_APP_ID && process.env.GITHUB_PRIVATE_KEY_PATH) {

--- a/packages/core/src/webhook/handler.ts
+++ b/packages/core/src/webhook/handler.ts
@@ -181,7 +181,11 @@ export function createWebhookHandler(config: WebhookHandlerConfig): Hono {
         if (!repoConfig) {
           log.error(
             { teamId: stateChange.issue.teamId, projectId: stateChange.issue.projectId ?? "none", issueId: stateChange.issue.identifier },
-            "no repo mapping for team/project — check repoConfigs keys match your Linear team/project IDs",
+            // The wording deliberately names the env vars (not a "config file") because
+            // `ura dev` builds repoConfigs from env, not from a config file — see urateam#33.
+            // The `ura run` path uses repos.config.ts; this branch is only reached by
+            // `ura dev` and similar entry points.
+            "no repo mapping for team — set REPO_TEAM_ID + REPO_URL in .urateam/.env (ura dev) or check repos.config.ts (ura run); the team UUID logged here must match",
           );
           return c.json({
             ok: false,

--- a/packages/core/src/webhook/handler.ts
+++ b/packages/core/src/webhook/handler.ts
@@ -181,11 +181,11 @@ export function createWebhookHandler(config: WebhookHandlerConfig): Hono {
         if (!repoConfig) {
           log.error(
             { teamId: stateChange.issue.teamId, projectId: stateChange.issue.projectId ?? "none", issueId: stateChange.issue.identifier },
-            // The wording deliberately names the env vars (not a "config file") because
-            // `ura dev` builds repoConfigs from env, not from a config file — see urateam#33.
-            // The `ura run` path uses repos.config.ts; this branch is only reached by
-            // `ura dev` and similar entry points.
-            "no repo mapping for team — set REPO_TEAM_ID + REPO_URL in .urateam/.env (ura dev) or check repos.config.ts (ura run); the team UUID logged here must match",
+            // Library-level error reachable from any consumer of createWebhookHandler.
+            // Names the most common entry-point root causes (env vars for `ura dev` /
+            // `ura start`, config file for `ura run`) rather than the misleading
+            // "check repoConfigs keys" wording the issue called out. See urateam#33.
+            "no repo mapping for team — set REPO_TEAM_ID + REPO_URL in .env (ura dev / ura start) or check repos.config.ts (ura run); the team UUID logged here must match",
           );
           return c.json({
             ok: false,

--- a/packages/create-urateam/template/.urateam/.env.example
+++ b/packages/create-urateam/template/.urateam/.env.example
@@ -1,9 +1,12 @@
-# === Required ===
+# === Required to boot ===
+# `ura dev` exits with an error if any of these are missing or blank.
 LINEAR_API_KEY=
 LINEAR_WEBHOOK_SECRET=
 LINEAR_TEAM_ID=
 
-# Repository
+# Repository — REQUIRED. Without REPO_TEAM_ID + REPO_URL the webhook server
+# starts but every inbound Linear event fails with "no repo mapping". In the
+# common single-team setup, REPO_TEAM_ID is the same UUID as LINEAR_TEAM_ID.
 REPO_URL=
 REPO_DEFAULT_BRANCH=main
 REPO_TEAM_ID=

--- a/packages/create-urateam/template/.urateam/.env.example
+++ b/packages/create-urateam/template/.urateam/.env.example
@@ -1,12 +1,13 @@
-# === Required to boot ===
-# `ura dev` exits with an error if any of these are missing or blank.
+# === Required ===
 LINEAR_API_KEY=
 LINEAR_WEBHOOK_SECRET=
 LINEAR_TEAM_ID=
 
-# Repository — REQUIRED. Without REPO_TEAM_ID + REPO_URL the webhook server
-# starts but every inbound Linear event fails with "no repo mapping". In the
-# common single-team setup, REPO_TEAM_ID is the same UUID as LINEAR_TEAM_ID.
+# Repository — REQUIRED to boot. `ura dev` and `ura start` exit with an
+# error if REPO_TEAM_ID or REPO_URL are missing or blank. Without these
+# the webhook server otherwise starts looking healthy but silently fails
+# every inbound Linear event with "no repo mapping". In the common
+# single-team setup, REPO_TEAM_ID is the same UUID as LINEAR_TEAM_ID.
 REPO_URL=
 REPO_DEFAULT_BRANCH=main
 REPO_TEAM_ID=


### PR DESCRIPTION
## Summary

Closes urateam #33. Three fixes targeting the ura-dev → first-webhook UX trap that hits every first-time user on a freshly-scaffolded sidecar.

## What changed

1. **`packages/cli/src/commands/dev.ts`** — `ura dev` now exits at startup with an actionable error if no `repoConfigs` could be built from env vars. Previously the webhook + dashboard servers came up looking healthy, then every inbound Linear event failed with "no repo mapping" — usually after the user had moved a real issue to Todo.

2. **`packages/core/src/webhook/handler.ts`** — the "no repo mapping" runtime error now names the actual root cause: env vars for `ura dev` / config file for `ura run`. The old wording ("check repoConfigs keys") sent users hunting for a config file that `ura dev` doesn't read.

3. **`packages/create-urateam/template/.urateam/.env.example`** — calls out `REPO_TEAM_ID` + `REPO_URL` as required-to-boot, with a note that `REPO_TEAM_ID` is usually the same UUID as `LINEAR_TEAM_ID` in single-team setups. The actual `.env` file the scaffolder generates already pre-fills these from prompts; only `.env.example` (the doc reference) needed the clarification.

## No version bumps

Will batch with #38 and #35 in a single release PR so users get a coherent set of UX improvements at once instead of churning through three separate npm versions.

## Test plan

- [x] `pnpm --filter @urateam/core test` — 1172 tests pass
- [x] `pnpm --filter @urateam/cli test` — 55 tests pass
- [x] `pnpm --filter create-urateam test` — 22 tests pass

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)