### PR TITLE
feat(executor): URATEAM_AGENT_PROFILES env var to override per-stage budgets

### DIFF
--- a/packages/core/src/__tests__/agent-profiles.test.ts
+++ b/packages/core/src/__tests__/agent-profiles.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getAgentProfiles,
+  DEFAULT_AGENT_PROFILES,
+  _resetAgentProfilesCache,
+} from "../executor/profiles.js";
+
+const ORIGINAL = process.env.URATEAM_AGENT_PROFILES;
+
+beforeEach(() => {
+  delete process.env.URATEAM_AGENT_PROFILES;
+  _resetAgentProfilesCache();
+});
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.URATEAM_AGENT_PROFILES;
+  else process.env.URATEAM_AGENT_PROFILES = ORIGINAL;
+  _resetAgentProfilesCache();
+});
+
+describe("getAgentProfiles defaults", () => {
+  it("returns the built-in defaults when env var is unset", () => {
+    expect(getAgentProfiles()).toEqual(DEFAULT_AGENT_PROFILES);
+  });
+
+  it("ships the documented test stage budget (urateam#38 baseline)", () => {
+    // The whole point of urateam#38 is that this baseline is too tight
+    // for bootstrapping. The override path is the fix; defaults are
+    // unchanged. Asserting the known shape so a silent default bump
+    // shows up in review.
+    expect(DEFAULT_AGENT_PROFILES.test).toMatchObject({
+      maxTurns: 25,
+      maxInputTokens: 30_000,
+      model: "claude-haiku-4-5",
+    });
+  });
+});
+
+describe("getAgentProfiles env override", () => {
+  it("merges a partial override on top of defaults", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: { maxTurns: 50, maxInputTokens: 80_000 },
+    });
+    const p = getAgentProfiles();
+    expect(p.test.maxTurns).toBe(50);
+    expect(p.test.maxInputTokens).toBe(80_000);
+    // Untouched fields keep their default
+    expect(p.test.model).toBe("claude-haiku-4-5");
+    expect(p.test.tools).toEqual(DEFAULT_AGENT_PROFILES.test!.tools);
+    // Other stages untouched
+    expect(p.implement).toEqual(DEFAULT_AGENT_PROFILES.implement);
+  });
+
+  it("can override the model + tools fields", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: { model: "claude-sonnet-4-6", tools: ["Read", "Bash"] },
+    });
+    const p = getAgentProfiles();
+    expect(p.test.model).toBe("claude-sonnet-4-6");
+    expect(p.test.tools).toEqual(["Read", "Bash"]);
+  });
+
+  it("ignores unknown stage names (logs warn) and keeps defaults intact", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      flarble: { maxTurns: 999 },
+    });
+    const p = getAgentProfiles();
+    expect(p).toEqual(DEFAULT_AGENT_PROFILES);
+    expect((p as any).flarble).toBeUndefined();
+  });
+
+  it("ignores malformed individual fields without dropping the rest of the stage", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: {
+        maxTurns: 50,            // valid → applied
+        maxInputTokens: "lots",  // invalid → ignored
+        model: "",               // invalid (empty) → ignored
+      },
+    });
+    const p = getAgentProfiles();
+    expect(p.test.maxTurns).toBe(50);
+    expect(p.test.maxInputTokens).toBe(30_000); // default kept
+    expect(p.test.model).toBe("claude-haiku-4-5"); // default kept
+  });
+
+  it("rejects negative or zero numbers (must be positive integers)", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: { maxTurns: 0, maxInputTokens: -1 },
+    });
+    const p = getAgentProfiles();
+    expect(p.test.maxTurns).toBe(25); // default kept
+    expect(p.test.maxInputTokens).toBe(30_000); // default kept
+  });
+
+  it("falls back to defaults when env var is malformed JSON", () => {
+    process.env.URATEAM_AGENT_PROFILES = "{not-json";
+    const p = getAgentProfiles();
+    expect(p).toEqual(DEFAULT_AGENT_PROFILES);
+  });
+
+  it("falls back to defaults when env var is a JSON array (must be an object)", () => {
+    process.env.URATEAM_AGENT_PROFILES = "[]";
+    const p = getAgentProfiles();
+    expect(p).toEqual(DEFAULT_AGENT_PROFILES);
+  });
+
+  it("falls back to defaults when env var is `null`", () => {
+    process.env.URATEAM_AGENT_PROFILES = "null";
+    const p = getAgentProfiles();
+    expect(p).toEqual(DEFAULT_AGENT_PROFILES);
+  });
+
+  it("ignores per-stage non-object values without dropping other stages", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: "should-be-an-object",
+      implement: { maxTurns: 75 },
+    });
+    const p = getAgentProfiles();
+    expect(p.test).toEqual(DEFAULT_AGENT_PROFILES.test); // bad value ignored
+    expect(p.implement.maxTurns).toBe(75); // good value applied
+  });
+
+  it("caches the resolved profiles for the process lifetime", () => {
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: { maxTurns: 50 },
+    });
+    const first = getAgentProfiles();
+    // Mutate the env after first read — should not re-read.
+    process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
+      test: { maxTurns: 999 },
+    });
+    const second = getAgentProfiles();
+    expect(second).toBe(first); // same object reference
+    expect(second.test.maxTurns).toBe(50); // not 999
+  });
+});

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { agentProfiles, DEFAULT_MODEL, HAIKU_MODEL } from "../executor/profiles.js";
+// Tests assert on the unmerged baseline shape; use DEFAULT_AGENT_PROFILES
+// instead of the deprecated `agentProfiles` alias to make that intent explicit.
+import {
+  DEFAULT_AGENT_PROFILES as agentProfiles,
+  DEFAULT_MODEL,
+  HAIKU_MODEL,
+} from "../executor/profiles.js";
 import { parseHandoffArtifact } from "../executor/handoff.js";
 import { AGENT_STAGES } from "../types.js";
 

--- a/packages/core/src/__tests__/stage-models.test.ts
+++ b/packages/core/src/__tests__/stage-models.test.ts
@@ -50,7 +50,7 @@ import { executeStage } from "../executor/executor.js";
 import { createDb, type Db } from "../db/client.js";
 import { pipelineRuns } from "../db/schema.js";
 import { PipelineConfigSchema } from "../types.js";
-import { agentProfiles, DEFAULT_MODEL, HAIKU_MODEL } from "../executor/profiles.js";
+import { DEFAULT_MODEL, HAIKU_MODEL } from "../executor/profiles.js";
 import type { SanitizedIssue, RepoConfig } from "../types.js";
 
 // ── Shared fixtures ───────────────────────────────────────────────────────────

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -10,7 +10,7 @@ import type {
 } from "../types.js";
 import type { Db, AnyDb } from "../db/client.js";
 import { stageRuns, agentLogs } from "../db/schema.js";
-import { agentProfiles } from "./profiles.js";
+import { getAgentProfiles } from "./profiles.js";
 import { assemblePrompt } from "./prompt/assembler.js";
 import { extractHandoff } from "./extract-handoff.js";
 import { buildStagePermissionOptions } from "./permissions.js";
@@ -61,7 +61,7 @@ export async function executeStage(
     throw new Error("await-approval is not an agent stage");
   }
 
-  const profile = agentProfiles[stage];
+  const profile = getAgentProfiles()[stage];
   if (!profile) {
     throw new Error(`No agent profile for stage: ${stage}`);
   }

--- a/packages/core/src/executor/index.ts
+++ b/packages/core/src/executor/index.ts
@@ -1,4 +1,4 @@
-export { agentProfiles } from "./profiles.js";
+export { agentProfiles, getAgentProfiles, DEFAULT_AGENT_PROFILES } from "./profiles.js";
 export {
   checkTestQuality,
   analyzeTestFile,

--- a/packages/core/src/executor/profiles.ts
+++ b/packages/core/src/executor/profiles.ts
@@ -1,9 +1,23 @@
 import type { AgentProfile } from "../types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "executor.profiles" });
 
 export const DEFAULT_MODEL = "claude-sonnet-4-6";
 export const HAIKU_MODEL = "claude-haiku-4-5";
 
-export const agentProfiles: Record<string, AgentProfile> = {
+/**
+ * Default budget + tool surface for each pipeline stage. The defaults are
+ * sized for a "mature repo" — implement stage does real work, test stage
+ * runs an existing test suite, etc. They are intentionally NOT sized for
+ * bootstrapping new infrastructure (e.g., adding vitest + RN test setup
+ * from scratch in the test stage), which can blow through the default
+ * budget; see urateam#38.
+ *
+ * Operators with bootstrapping needs can override individual fields per
+ * stage via the URATEAM_AGENT_PROFILES env var (see `getAgentProfiles`).
+ */
+export const DEFAULT_AGENT_PROFILES: Record<string, AgentProfile> = {
   triage: {
     tools: ["Read", "Glob", "Grep", "WebSearch"],
     maxInputTokens: 30_000,
@@ -35,3 +49,145 @@ export const agentProfiles: Record<string, AgentProfile> = {
     model: DEFAULT_MODEL,
   },
 };
+
+/**
+ * Backward-compat re-export. Prefer `getAgentProfiles()` so per-process
+ * env-var overrides are honored.
+ */
+export const agentProfiles = DEFAULT_AGENT_PROFILES;
+
+let cachedProfiles: Record<string, AgentProfile> | null = null;
+
+interface PartialProfile {
+  tools?: unknown;
+  maxInputTokens?: unknown;
+  maxTurns?: unknown;
+  model?: unknown;
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+function isPositiveInteger(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v > 0;
+}
+
+/**
+ * Apply a single override object on top of a base profile. Unknown stages
+ * are dropped with a warn (op-side typo protection). Known stages with
+ * malformed fields are dropped field-by-field (don't let one bad field
+ * tank the whole stage).
+ */
+function mergeOverride(base: AgentProfile, override: PartialProfile): AgentProfile {
+  const merged: AgentProfile = { ...base };
+  if (isStringArray(override.tools)) {
+    merged.tools = override.tools;
+  } else if (override.tools !== undefined) {
+    log.warn(
+      { stage: undefined, field: "tools", got: typeof override.tools },
+      "URATEAM_AGENT_PROFILES override: tools must be a string array — ignoring this field",
+    );
+  }
+  if (isPositiveInteger(override.maxInputTokens)) {
+    merged.maxInputTokens = override.maxInputTokens;
+  } else if (override.maxInputTokens !== undefined) {
+    log.warn(
+      { field: "maxInputTokens", got: override.maxInputTokens },
+      "URATEAM_AGENT_PROFILES override: maxInputTokens must be a positive integer — ignoring this field",
+    );
+  }
+  if (isPositiveInteger(override.maxTurns)) {
+    merged.maxTurns = override.maxTurns;
+  } else if (override.maxTurns !== undefined) {
+    log.warn(
+      { field: "maxTurns", got: override.maxTurns },
+      "URATEAM_AGENT_PROFILES override: maxTurns must be a positive integer — ignoring this field",
+    );
+  }
+  if (typeof override.model === "string" && override.model.length > 0) {
+    merged.model = override.model;
+  } else if (override.model !== undefined) {
+    log.warn(
+      { field: "model", got: override.model },
+      "URATEAM_AGENT_PROFILES override: model must be a non-empty string — ignoring this field",
+    );
+  }
+  return merged;
+}
+
+/**
+ * Return the active per-stage agent profiles. Defaults can be overridden
+ * for the current process via the `URATEAM_AGENT_PROFILES` env var, which
+ * is parsed as JSON and merged on top of the defaults stage-by-stage:
+ *
+ *   URATEAM_AGENT_PROFILES='{"test":{"maxTurns":50,"maxInputTokens":80000}}'
+ *
+ * Only the fields named in the override are changed; everything else keeps
+ * its default. Unknown stage names log a warn and are ignored. Malformed
+ * fields log a warn and are ignored without dropping the rest of the stage.
+ *
+ * Result is cached for process lifetime. Call `_resetAgentProfilesCache()`
+ * (test-only) to re-read the env var.
+ */
+export function getAgentProfiles(): Record<string, AgentProfile> {
+  if (cachedProfiles) return cachedProfiles;
+
+  const raw = process.env.URATEAM_AGENT_PROFILES;
+  if (!raw) {
+    cachedProfiles = DEFAULT_AGENT_PROFILES;
+    return cachedProfiles;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn(
+      { err: (err as Error).message },
+      "URATEAM_AGENT_PROFILES is not valid JSON — falling back to defaults",
+    );
+    cachedProfiles = DEFAULT_AGENT_PROFILES;
+    return cachedProfiles;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    log.warn(
+      "URATEAM_AGENT_PROFILES must be a JSON object keyed by stage name — falling back to defaults",
+    );
+    cachedProfiles = DEFAULT_AGENT_PROFILES;
+    return cachedProfiles;
+  }
+
+  const overrides = parsed as Record<string, PartialProfile>;
+  const result: Record<string, AgentProfile> = { ...DEFAULT_AGENT_PROFILES };
+  for (const [stage, override] of Object.entries(overrides)) {
+    if (!(stage in DEFAULT_AGENT_PROFILES)) {
+      log.warn(
+        { stage, knownStages: Object.keys(DEFAULT_AGENT_PROFILES) },
+        "URATEAM_AGENT_PROFILES override targets unknown stage — ignoring",
+      );
+      continue;
+    }
+    if (!override || typeof override !== "object" || Array.isArray(override)) {
+      log.warn(
+        { stage, got: typeof override },
+        "URATEAM_AGENT_PROFILES per-stage value must be an object — ignoring",
+      );
+      continue;
+    }
+    result[stage] = mergeOverride(DEFAULT_AGENT_PROFILES[stage]!, override);
+    log.info(
+      { stage, profile: result[stage] },
+      "URATEAM_AGENT_PROFILES override applied",
+    );
+  }
+
+  cachedProfiles = result;
+  return cachedProfiles;
+}
+
+/** Test-only: reset the cached profiles so a new env var value takes effect. */
+export function _resetAgentProfilesCache(): void {
+  cachedProfiles = null;
+}

--- a/packages/core/src/executor/profiles.ts
+++ b/packages/core/src/executor/profiles.ts
@@ -7,6 +7,20 @@ export const DEFAULT_MODEL = "claude-sonnet-4-6";
 export const HAIKU_MODEL = "claude-haiku-4-5";
 
 /**
+ * Recursively freeze an object so accidental mutation by callers throws
+ * (in strict mode) rather than silently corrupting the shared defaults.
+ */
+function deepFreeze<T>(o: T): T {
+  if (o === null || typeof o !== "object") return o;
+  for (const v of Object.values(o as object)) deepFreeze(v);
+  return Object.freeze(o);
+}
+
+/** Upper bounds for env-var overrides — protect against fat-finger like {"maxTurns": 999999}. */
+const MAX_TURNS_CEILING = 500;
+const MAX_INPUT_TOKENS_CEILING = 500_000;
+
+/**
  * Default budget + tool surface for each pipeline stage. The defaults are
  * sized for a "mature repo" — implement stage does real work, test stage
  * runs an existing test suite, etc. They are intentionally NOT sized for
@@ -16,8 +30,12 @@ export const HAIKU_MODEL = "claude-haiku-4-5";
  *
  * Operators with bootstrapping needs can override individual fields per
  * stage via the URATEAM_AGENT_PROFILES env var (see `getAgentProfiles`).
+ *
+ * Deep-frozen so accidental mutation by a caller (e.g., a test that does
+ * `getAgentProfiles().test.maxTurns = 999`) throws instead of silently
+ * corrupting the shared defaults for the rest of process lifetime.
  */
-export const DEFAULT_AGENT_PROFILES: Record<string, AgentProfile> = {
+export const DEFAULT_AGENT_PROFILES: Record<string, AgentProfile> = deepFreeze({
   triage: {
     tools: ["Read", "Glob", "Grep", "WebSearch"],
     maxInputTokens: 30_000,
@@ -48,11 +66,16 @@ export const DEFAULT_AGENT_PROFILES: Record<string, AgentProfile> = {
     maxTurns: 20,
     model: DEFAULT_MODEL,
   },
-};
+});
 
 /**
  * Backward-compat re-export. Prefer `getAgentProfiles()` so per-process
  * env-var overrides are honored.
+ *
+ * @deprecated Use `getAgentProfiles()` for active profiles (env-var-merged).
+ *   This alias only ever returns the unmerged defaults — useful for
+ *   asserting the default shape in tests, but wrong for any consumer
+ *   that wants the runtime-effective values.
  */
 export const agentProfiles = DEFAULT_AGENT_PROFILES;
 
@@ -69,47 +92,57 @@ function isStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.every((x) => typeof x === "string");
 }
 
-function isPositiveInteger(v: unknown): v is number {
-  return typeof v === "number" && Number.isInteger(v) && v > 0;
+function isPositiveIntegerWithin(v: unknown, max: number): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v > 0 && v <= max;
 }
 
 /**
  * Apply a single override object on top of a base profile. Unknown stages
  * are dropped with a warn (op-side typo protection). Known stages with
  * malformed fields are dropped field-by-field (don't let one bad field
- * tank the whole stage).
+ * tank the whole stage). The stage name is included in every warn payload
+ * so operators can pinpoint which stage triggered each warning.
+ *
+ * Returns a fresh object — never mutates `base`. The `tools` array is
+ * copied either from the override or from a fresh `[...base.tools]` copy
+ * so callers cannot reach back into DEFAULT_AGENT_PROFILES via the
+ * returned reference.
  */
-function mergeOverride(base: AgentProfile, override: PartialProfile): AgentProfile {
-  const merged: AgentProfile = { ...base };
+function mergeOverride(
+  base: AgentProfile,
+  override: PartialProfile,
+  stage: string,
+): AgentProfile {
+  const merged: AgentProfile = { ...base, tools: [...base.tools] };
   if (isStringArray(override.tools)) {
-    merged.tools = override.tools;
+    merged.tools = override.tools.slice();
   } else if (override.tools !== undefined) {
     log.warn(
-      { stage: undefined, field: "tools", got: typeof override.tools },
+      { stage, field: "tools", got: typeof override.tools },
       "URATEAM_AGENT_PROFILES override: tools must be a string array — ignoring this field",
     );
   }
-  if (isPositiveInteger(override.maxInputTokens)) {
+  if (isPositiveIntegerWithin(override.maxInputTokens, MAX_INPUT_TOKENS_CEILING)) {
     merged.maxInputTokens = override.maxInputTokens;
   } else if (override.maxInputTokens !== undefined) {
     log.warn(
-      { field: "maxInputTokens", got: override.maxInputTokens },
-      "URATEAM_AGENT_PROFILES override: maxInputTokens must be a positive integer — ignoring this field",
+      { stage, field: "maxInputTokens", got: override.maxInputTokens, ceiling: MAX_INPUT_TOKENS_CEILING },
+      "URATEAM_AGENT_PROFILES override: maxInputTokens must be a positive integer ≤ ceiling — ignoring this field",
     );
   }
-  if (isPositiveInteger(override.maxTurns)) {
+  if (isPositiveIntegerWithin(override.maxTurns, MAX_TURNS_CEILING)) {
     merged.maxTurns = override.maxTurns;
   } else if (override.maxTurns !== undefined) {
     log.warn(
-      { field: "maxTurns", got: override.maxTurns },
-      "URATEAM_AGENT_PROFILES override: maxTurns must be a positive integer — ignoring this field",
+      { stage, field: "maxTurns", got: override.maxTurns, ceiling: MAX_TURNS_CEILING },
+      "URATEAM_AGENT_PROFILES override: maxTurns must be a positive integer ≤ ceiling — ignoring this field",
     );
   }
   if (typeof override.model === "string" && override.model.length > 0) {
     merged.model = override.model;
   } else if (override.model !== undefined) {
     log.warn(
-      { field: "model", got: override.model },
+      { stage, field: "model", got: override.model },
       "URATEAM_AGENT_PROFILES override: model must be a non-empty string — ignoring this field",
     );
   }
@@ -176,7 +209,7 @@ export function getAgentProfiles(): Record<string, AgentProfile> {
       );
       continue;
     }
-    result[stage] = mergeOverride(DEFAULT_AGENT_PROFILES[stage]!, override);
+    result[stage] = mergeOverride(DEFAULT_AGENT_PROFILES[stage]!, override, stage);
     log.info(
       { stage, profile: result[stage] },
       "URATEAM_AGENT_PROFILES override applied",

--- a/packages/create-urateam/template/.urateam/.env.example
+++ b/packages/create-urateam/template/.urateam/.env.example
@@ -16,6 +16,11 @@ DASHBOARD_USER=admin
 DASHBOARD_PASSWORD=
 
 # === Optional ===
+# Override per-stage agent budget (maxTurns / maxInputTokens / model / tools).
+# Useful when the test stage has to bootstrap test infra from scratch and
+# burns through the default 25-turn cap. See urateam#38.
+# URATEAM_AGENT_PROFILES='{"test":{"maxTurns":50,"maxInputTokens":80000}}'
+
 # SLACK_WEBHOOK_URL=
 # DISCORD_WEBHOOK_URL=
 # GITHUB_WEBHOOK_SECRET=


### PR DESCRIPTION
## Summary

Closes urateam #38. Hardcoded agent profiles (`maxTurns`, `maxInputTokens`, `tools`, `model`) in `packages/core/src/executor/profiles.ts` were not configurable via env, config file, or runtime flag — leaving operators no escape hatch when the default test-stage budget (25 turns / 30k input tokens / Haiku) blew up on real tasks that needed to bootstrap test infra.

## Change

New `URATEAM_AGENT_PROFILES` env var, parsed as JSON, merged per-field on top of defaults:

```sh
URATEAM_AGENT_PROFILES='{"test":{"maxTurns":50,"maxInputTokens":80000}}' ura dev
```

- Defaults unchanged (no token/cost behavior change for existing operators).
- New `getAgentProfiles()` resolves overrides and caches for process lifetime; the executor now consumes it instead of the static import.
- `agentProfiles` stays as a back-compat alias for the unmerged defaults.
- Per-field type validation: invalid fields log a warn and are dropped without tanking the rest of the stage. Unknown stage names log a warn and are ignored. Malformed JSON falls back to defaults.

## What this does NOT do

- Does NOT raise default values. The issue documents that 25 turns is too tight for bootstrapping; raising defaults would change token/cost behavior for everyone. Operators who hit the bootstrapping case set the env var.
- Does NOT add a config-file path. JSON env var is the simplest deliverable consistent with the codebase (every other operator config is env-based).

## Test plan

- [x] `pnpm --filter @urateam/core build` (typecheck)
- [x] `pnpm --filter @urateam/core test` — 1184 tests pass (was 1172; +12 in `agent-profiles.test.ts`)

12 new tests cover: default fallback, partial-field merge, model + tools override, unknown-stage warn-and-ignore, malformed-field warn-and-default, positive-integer guard, JSON-parse fallback, JSON-array fallback, `null` fallback, per-stage-non-object handling, process-lifetime cache.

No version bump — will batch with #33 (PR #93) and #35 in a single release PR.

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)