### PR TITLE
chore(release): bump core 0.1.8→0.1.9 + cli 0.1.4→0.1.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Coordinated release of the urgent UX-fix wave merged in #93 / #94 / #95.

| Package | From | To | Includes |
|---|---|---|---|
| \`@urateam/core\` | 0.1.8 | 0.1.9 | #94 (\`URATEAM_AGENT_PROFILES\` env override), #95 (extract-handoff git override), #93 (webhook handler error message) |
| \`@urateam/cli\` | 0.1.4 | 0.1.5 | #93 (\`ura dev\` / \`ura start\` fail-fast on empty repoConfigs) |
| \`@urateam/dashboard\` | 0.1.4 | unchanged | no code changes |
| \`create-urateam\` | 0.1.7 | unchanged | no code changes (last published 0.1.7 on the v0.1.9 tag) |

The publish-package helper script skips "version already exists" errors so dashboard + create-urateam will simply no-op on the tag.

## After merge

Tag \`v0.1.10\` on main → publish workflow fires → \`@urateam/core@0.1.9\` + \`@urateam/cli@0.1.5\` ship to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)