### PR TITLE
feat(cli): OSS Claude session auth pre-flight at ura dev / start

### DIFF
--- a/packages/cli/src/__tests__/preflight-claude-auth.test.ts
+++ b/packages/cli/src/__tests__/preflight-claude-auth.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Hoist the mock fn so it's defined before vi.mock's factory runs.
+const { mockIsClaudeAuthValid } = vi.hoisted(() => ({
+  mockIsClaudeAuthValid: vi.fn<() => Promise<boolean>>(),
+}));
+
+// Minimal mock: only `isClaudeAuthValid` is touched by preflightClaudeAuth,
+// so we don't need vi.importActual (which is slow + introduces a startup
+// race where the first test can resolve before the mocked module is fully
+// populated).
+vi.mock("@urateam/core", () => ({
+  isClaudeAuthValid: mockIsClaudeAuthValid,
+}));
+
+import { preflightClaudeAuth } from "../lib/preflight-claude-auth.js";
+
+describe("preflightClaudeAuth", () => {
+  let exitSpy: any;
+  let errorSpy: any;
+
+  beforeEach(() => {
+    mockIsClaudeAuthValid.mockReset();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__EXIT__");
+    }) as never);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("returns silently when isClaudeAuthValid resolves true", async () => {
+    mockIsClaudeAuthValid.mockResolvedValue(true);
+    await preflightClaudeAuth({ command: "ura dev" });
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits 1 with an actionable banner when isClaudeAuthValid resolves false", async () => {
+    mockIsClaudeAuthValid.mockResolvedValue(false);
+    await expect(preflightClaudeAuth({ command: "ura dev" })).rejects.toThrow(
+      "__EXIT__",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const banner = errorSpy.mock.calls[0]![0] as string;
+    expect(banner).toContain("Claude session auth check failed");
+    expect(banner).toContain("claude login");
+    expect(banner).toContain("ura dev");
+    expect(banner).toContain("manual recovery");
+  });
+
+  it("includes the docker-compose hint when containerized=true", async () => {
+    mockIsClaudeAuthValid.mockResolvedValue(false);
+    await expect(
+      preflightClaudeAuth({ command: "ura start", containerized: true }),
+    ).rejects.toThrow("__EXIT__");
+    const banner = errorSpy.mock.calls[0]![0] as string;
+    expect(banner).toContain("docker compose exec");
+    expect(banner).toContain("ura start");
+  });
+
+  it("omits the docker-compose hint by default", async () => {
+    mockIsClaudeAuthValid.mockResolvedValue(false);
+    await expect(preflightClaudeAuth({ command: "ura dev" })).rejects.toThrow(
+      "__EXIT__",
+    );
+    const banner = errorSpy.mock.calls[0]![0] as string;
+    expect(banner).not.toContain("docker compose exec");
+  });
+});

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,29 +1,6 @@
 import { Command } from "commander";
 import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
-
-/**
- * OSS-tier auth pre-flight: probe `claude auth status` before opening any
- * connections / mutating Linear state. The OSS path uses the interactive
- * Claude session which expires silently in the background; without this
- * check the first inbound webhook would burn through tokens, mark the
- * Linear issue as failed, and leave the operator to manually unstick it.
- * See urateam#40.
- *
- * The Claude API tier presumably uses a long-lived API key with no
- * session-lifetime semantics; this gate is a no-op in that case.
- */
-async function preflightClaudeAuth(): Promise<void> {
-  const { isClaudeAuthValid } = await import("@urateam/core");
-  if (await isClaudeAuthValid()) return;
-  console.error(
-    "⚠ Claude session auth check failed at startup.\n" +
-      "  The local `claude` session is missing or expired.\n" +
-      "  Run `claude login` and restart `ura dev` before moving issues to Todo.\n" +
-      "  Without this fix, webhooks will fail mid-pipeline and the agent will\n" +
-      "  mark Linear issues as failed — requiring manual recovery.\n",
-  );
-  process.exit(1);
-}
+import { preflightClaudeAuth } from "../lib/preflight-claude-auth.js";
 
 export const devCommand = new Command("dev")
   .description("Start local development server (webhook + dashboard)")
@@ -85,7 +62,7 @@ export const devCommand = new Command("dev")
 
     // OSS-tier auth pre-flight (urateam#40). Run before opening the DB so a
     // bad auth state doesn't leave any resources to clean up.
-    await preflightClaudeAuth();
+    await preflightClaudeAuth({ command: "ura dev" });
 
     const config = {
       webhookSecret: process.env.LINEAR_WEBHOOK_SECRET ?? "dev-secret",

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,6 +1,30 @@
 import { Command } from "commander";
 import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
 
+/**
+ * OSS-tier auth pre-flight: probe `claude auth status` before opening any
+ * connections / mutating Linear state. The OSS path uses the interactive
+ * Claude session which expires silently in the background; without this
+ * check the first inbound webhook would burn through tokens, mark the
+ * Linear issue as failed, and leave the operator to manually unstick it.
+ * See urateam#40.
+ *
+ * The Claude API tier presumably uses a long-lived API key with no
+ * session-lifetime semantics; this gate is a no-op in that case.
+ */
+async function preflightClaudeAuth(): Promise<void> {
+  const { isClaudeAuthValid } = await import("@urateam/core");
+  if (await isClaudeAuthValid()) return;
+  console.error(
+    "⚠ Claude session auth check failed at startup.\n" +
+      "  The local `claude` session is missing or expired.\n" +
+      "  Run `claude login` and restart `ura dev` before moving issues to Todo.\n" +
+      "  Without this fix, webhooks will fail mid-pipeline and the agent will\n" +
+      "  mark Linear issues as failed — requiring manual recovery.\n",
+  );
+  process.exit(1);
+}
+
 export const devCommand = new Command("dev")
   .description("Start local development server (webhook + dashboard)")
   .option("--port <port>", "Webhook server port", "3000")
@@ -58,6 +82,10 @@ export const devCommand = new Command("dev")
       );
       process.exit(1);
     }
+
+    // OSS-tier auth pre-flight (urateam#40). Run before opening the DB so a
+    // bad auth state doesn't leave any resources to clean up.
+    await preflightClaudeAuth();
 
     const config = {
       webhookSecret: process.env.LINEAR_WEBHOOK_SECRET ?? "dev-secret",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,26 +1,7 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
-
-/**
- * OSS-tier auth pre-flight: probe `claude auth status` before opening any
- * connections / mutating Linear state. See urateam#40 + the matching
- * helper in dev.ts. No-op when the Claude API tier (long-lived API key)
- * is in use; this is purely OSS protection.
- */
-async function preflightClaudeAuth(): Promise<void> {
-  const { isClaudeAuthValid } = await import("@urateam/core");
-  if (await isClaudeAuthValid()) return;
-  console.error(
-    "⚠ Claude session auth check failed at startup.\n" +
-      "  The local `claude` session is missing or expired.\n" +
-      "  Run `claude login` (or `docker compose exec <service> claude login`\n" +
-      "  if running containerized) and restart `ura start` before processing\n" +
-      "  webhooks. Without this fix, webhooks will fail mid-pipeline and the\n" +
-      "  agent will mark Linear issues as failed — requiring manual recovery.\n",
-  );
-  process.exit(1);
-}
+import { preflightClaudeAuth } from "../lib/preflight-claude-auth.js";
 
 export const startCommand = new Command("start")
   .description("Start production server (webhook + dashboard)")
@@ -186,7 +167,7 @@ export const startCommand = new Command("start")
 
     // OSS-tier auth pre-flight (urateam#40). Run before opening the DB so a
     // bad auth state doesn't leave any resources to clean up.
-    await preflightClaudeAuth();
+    await preflightClaudeAuth({ command: "ura start", containerized: true });
 
     // --- SSO (Enterprise, opt-in via URATEAM_SSO_ENABLED=true) ---
     // Validate SSO env vars BEFORE opening the DB / starting the runner so a

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -2,6 +2,26 @@ import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import { bootstrapSsoFromEnv } from "../sso-bootstrap.js";
 
+/**
+ * OSS-tier auth pre-flight: probe `claude auth status` before opening any
+ * connections / mutating Linear state. See urateam#40 + the matching
+ * helper in dev.ts. No-op when the Claude API tier (long-lived API key)
+ * is in use; this is purely OSS protection.
+ */
+async function preflightClaudeAuth(): Promise<void> {
+  const { isClaudeAuthValid } = await import("@urateam/core");
+  if (await isClaudeAuthValid()) return;
+  console.error(
+    "⚠ Claude session auth check failed at startup.\n" +
+      "  The local `claude` session is missing or expired.\n" +
+      "  Run `claude login` (or `docker compose exec <service> claude login`\n" +
+      "  if running containerized) and restart `ura start` before processing\n" +
+      "  webhooks. Without this fix, webhooks will fail mid-pipeline and the\n" +
+      "  agent will mark Linear issues as failed — requiring manual recovery.\n",
+  );
+  process.exit(1);
+}
+
 export const startCommand = new Command("start")
   .description("Start production server (webhook + dashboard)")
   .option("--port <port>", "Webhook server port", "3000")
@@ -163,6 +183,10 @@ export const startCommand = new Command("start")
       pmConfig,
       githubWebhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
     };
+
+    // OSS-tier auth pre-flight (urateam#40). Run before opening the DB so a
+    // bad auth state doesn't leave any resources to clean up.
+    await preflightClaudeAuth();
 
     // --- SSO (Enterprise, opt-in via URATEAM_SSO_ENABLED=true) ---
     // Validate SSO env vars BEFORE opening the DB / starting the runner so a

--- a/packages/cli/src/lib/preflight-claude-auth.ts
+++ b/packages/cli/src/lib/preflight-claude-auth.ts
@@ -1,0 +1,43 @@
+/**
+ * OSS-tier Claude session auth pre-flight, shared by `ura dev` and `ura start`.
+ *
+ * The OSS tier of urateam runs against the local `claude` CLI session, which
+ * expires silently in the background (typically weekly). Without this gate
+ * the first inbound Linear webhook after expiry would burn through tokens,
+ * fail mid-pipeline, and leave the operator to manually unstick the Linear
+ * issue from "in progress" before re-authing. The Anthropic API tier
+ * (long-lived API key) has no session-lifetime semantics — `isClaudeAuthValid`
+ * resolves true there and the gate is a no-op.
+ *
+ * On failure: prints an operator-actionable banner and exits 1.
+ *
+ * See urateam#40.
+ */
+export async function preflightClaudeAuth(opts: {
+  /**
+   * The bin name to surface in the banner (`ura dev` vs `ura start`).
+   * Surfacing the actual entry point the operator typed reduces confusion.
+   */
+  command: "ura dev" | "ura start";
+  /**
+   * When true, the banner mentions the `docker compose exec ... claude login`
+   * variant. Used by `ura start` (production / containerized).
+   */
+  containerized?: boolean;
+}): Promise<void> {
+  const { isClaudeAuthValid } = await import("@urateam/core");
+  if (await isClaudeAuthValid()) return;
+
+  const reauth = opts.containerized
+    ? "Run `claude login` (or `docker compose exec <service> claude login` if running\n" +
+      "  containerized)"
+    : "Run `claude login`";
+  console.error(
+    "⚠ Claude session auth check failed at startup.\n" +
+      "  The local `claude` session is missing or expired.\n" +
+      `  ${reauth} and restart \`${opts.command}\`. Without this fix,\n` +
+      "  webhooks will fail mid-pipeline and the agent will mark Linear issues\n" +
+      "  as failed — requiring manual recovery.\n",
+  );
+  process.exit(1);
+}

--- a/packages/create-urateam/template/.urateam/README.md
+++ b/packages/create-urateam/template/.urateam/README.md
@@ -9,7 +9,37 @@ to implement features, fix bugs, and create PRs automatically.
 
 1. Fill in `.env` with your Linear API key, webhook secret, team ID, and repo URL
 2. Install dependencies: `pnpm install`
-3. Start the agent: `pnpm dev` (SQLite, local dev) or `pnpm start` (production)
+3. **Authenticate Claude** (OSS path only — see [Claude auth lifecycle](#claude-auth-lifecycle-oss-tier) below): `claude login`
+4. Start the agent: `pnpm dev` (SQLite, local dev) or `pnpm start` (production)
+
+## Claude auth lifecycle (OSS tier)
+
+The free / OSS tier of urateam runs against the local `claude` CLI session,
+**not** an Anthropic API key. That session expires periodically (typically
+weekly) and **`ura dev` will refuse to start when the session is invalid** —
+this prevents the failure mode where webhooks fail mid-pipeline and Linear
+issues get marked as failed before you notice.
+
+If you see this banner at startup:
+
+```
+⚠ Claude session auth check failed at startup.
+  The local `claude` session is missing or expired.
+  Run `claude login` and restart `ura dev` before moving issues to Todo.
+```
+
+…run `claude login` (interactive — opens a browser), then restart `pnpm dev`
+or `pnpm start`. Once running, urateam re-checks the session before each
+agent invocation, so a session that expires mid-day is caught before it
+mutates Linear state.
+
+**Production note:** if you're running in a container, the auth probe runs
+inside the container too. Use `docker compose exec <service> claude login`
+to re-authenticate.
+
+**Upgrading off this:** the Anthropic API tier (long-lived API key) doesn't
+have session-lifetime semantics, so this whole concern goes away. See the
+[urateam docs](https://github.com/JonB32/urateam) for upgrade paths.
 
 ## Expose the webhook
 

--- a/packages/create-urateam/template/.urateam/README.md
+++ b/packages/create-urateam/template/.urateam/README.md
@@ -20,12 +20,15 @@ weekly) and **`ura dev` will refuse to start when the session is invalid** —
 this prevents the failure mode where webhooks fail mid-pipeline and Linear
 issues get marked as failed before you notice.
 
-If you see this banner at startup:
+If you see this banner at startup (the exact wording varies slightly between
+`pnpm dev` and `pnpm start`):
 
 ```
 ⚠ Claude session auth check failed at startup.
   The local `claude` session is missing or expired.
-  Run `claude login` and restart `ura dev` before moving issues to Todo.
+  Run `claude login` and restart `ura dev`. Without this fix,
+  webhooks will fail mid-pipeline and the agent will mark Linear issues
+  as failed — requiring manual recovery.
 ```
 
 …run `claude login` (interactive — opens a browser), then restart `pnpm dev`
@@ -33,9 +36,9 @@ or `pnpm start`. Once running, urateam re-checks the session before each
 agent invocation, so a session that expires mid-day is caught before it
 mutates Linear state.
 
-**Production note:** if you're running in a container, the auth probe runs
-inside the container too. Use `docker compose exec <service> claude login`
-to re-authenticate.
+**Production / containerized:** the production banner shown by `pnpm start`
+mentions the docker-compose form: `docker compose exec <service> claude login`.
+Use that variant when re-authing inside a running container.
 
 **Upgrading off this:** the Anthropic API tier (long-lived API key) doesn't
 have session-lifetime semantics, so this whole concern goes away. See the


### PR DESCRIPTION
## Summary

Closes **sub-fixes 1 + 3** of urateam #40. Sub-fix 2 (runner-side auth-error differentiation) deferred — see scope notes below.

The OSS tier runs against the local \`claude\` CLI session, which expires silently in the background (typically weekly). Without this fix, the first inbound Linear webhook after expiry would burn through tokens mid-pipeline and mark the Linear issue as failed before the operator noticed — requiring manual Linear recovery on top of \`claude login\`.

## What changed

- **\`packages/cli/src/commands/dev.ts\`** + **\`start.ts\`**: pre-flight \`isClaudeAuthValid()\` check before opening the DB or mounting routes. Failure prints an operator-actionable banner + exits 1. Cached 5 min internally so restart-loops are cheap.
- **\`packages/create-urateam/template/.urateam/README.md\`**: new section documenting the Claude auth lifecycle for OSS tier — when to expect the banner, container vs bare-metal re-auth, and the upgrade path to the Anthropic API tier.

The existing per-stage auth check inside the executor (\`executor.ts:107\`) catches mid-day expiration; the new startup check catches the more common "operator forgot to re-auth before flipping an issue to Todo" case before any Linear state mutates.

## Sub-fix 2 deferred (scope note)

The issue also asks for the runner to recognize auth-expiry errors specifically and avoid mutating Linear state when one fires. That requires introducing a typed \`ClaudeAuthError\` and threading the distinction through \`pipeline/runner.ts\`, \`pm/scheduler.ts\`, and the webhook handler — a cross-cutting state-machine refactor. Recommend a separate issue/PR.

The startup check addresses the most common-case symptom (operator-forgot-to-reauth) without the refactor.

## Test plan

- [x] \`pnpm --filter @urateam/cli build\` (typecheck)
- [x] \`pnpm --filter @urateam/cli test\` — 55 tests pass
- [x] \`pnpm --filter create-urateam test\` — 22 tests pass

Partially closes #40 (sub-fixes 1 + 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)