### PR TITLE
chore(release): bump cli 0.1.5→0.1.6 + create-urateam 0.1.7→0.1.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Ships urateam #40 sub-fixes 1 + 3 (PR #98) to npm.

| Package | From | To | Includes |
|---|---|---|---|
| \`@urateam/cli\` | 0.1.5 | 0.1.6 | startup Claude auth pre-flight at \`ura dev\` / \`ura start\` (#98) |
| \`create-urateam\` | 0.1.7 | 0.1.8 | OSS-tier Claude auth-lifecycle docs in template \`.urateam/README.md\` (#98) |
| \`@urateam/core\` | 0.1.9 | unchanged | no code changes |
| \`@urateam/dashboard\` | 0.1.4 | unchanged | no code changes |

The publish-package helper script skips "version already exists" errors so core + dashboard will simply no-op on the tag.

Sub-fix 2 of #40 (typed \`ClaudeAuthError\` + runner-side handling for mid-pipeline expiry) tracked as separate follow-up #99 — cross-cutting refactor, not bundled here.

## After merge

Tag \`v0.1.11\` on main → publish workflow fires → \`@urateam/cli@0.1.6\` + \`create-urateam@0.1.8\` ship to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)