### PR TITLE
fix(dashboard): resolve serveStatic against module dir + ship dist/static/

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/dashboard"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node --input-type=module -e \"import{cpSync}from'node:fs';cpSync('src/static','dist/static',{recursive:true})\"",
     "test": "vitest run",
     "dev": "tsx watch src/server.ts"
   },

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -2,6 +2,8 @@
 import { Hono } from "hono";
 import { basicAuth } from "hono/basic-auth";
 import { serveStatic } from "@hono/node-server/serve-static";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { createLogger, isFeatureLicensed } from "@urateam/core";
 import type {
   Db,
@@ -198,8 +200,17 @@ export function createDashboard(config: DashboardConfig): Hono {
     });
   }
 
-  // Static files
-  app.use("/static/*", serveStatic({ root: "./packages/dashboard/src/" }));
+  // Static files. Resolve `static/` relative to this module's installed
+  // location, not the consumer's cwd. Without this, npm-installed users
+  // (every operator running from a `.urateam/` sidecar) hit a startup
+  // warning because `./packages/dashboard/src/` is repo-relative and
+  // doesn't exist outside the urateam monorepo. See urateam#101.
+  //
+  // After build, `import.meta.url` resolves to dist/server.js, so the
+  // join lands at dist/static/ — where the build script copies src/static/
+  // before publishing.
+  const dashboardModuleDir = dirname(fileURLToPath(import.meta.url));
+  app.use("/static/*", serveStatic({ root: join(dashboardModuleDir, "static") }));
 
   // Mount routes — pass basePath so every layout() call uses the correct prefix.
   const runsRouter = createRunsRouter(config.db, basePath);


### PR DESCRIPTION
## Summary

Closes urateam #101. Two compounding bugs hit every npm-installed dashboard consumer:

1. **`server.ts:202`** used a hardcoded monorepo-relative root for `serveStatic` (\`./packages/dashboard/src/\`), which doesn't resolve outside the urateam monorepo. Operators running \`ura dev\` / \`ura start\` from a \`.urateam/\` sidecar saw a startup warning.
2. **`package.json`** shipped only `dist/`, and the build was just `tsc`. \`src/static/style.css\` never made it into the published tarball — verified absent via \`pnpm pack\`.

So even after fixing #1, \`GET /static/style.css\` would 404 on every npm-installed copy.

## Fix

- **`server.ts`** — resolve the static root relative to the dashboard module's installed location via `import.meta.url + path.dirname`. After build, \`import.meta.url\` resolves to \`dist/server.js\`, so the join lands at \`dist/static/\` where the build script puts the assets.
- **`package.json` build** — \`tsc && cpSync('src/static','dist/static')\` — matches `@urateam/core`'s existing pattern for shipping `src/db/migrations/` alongside the compiled JS.

## Verification

- [x] `pnpm --filter @urateam/dashboard build` produces `dist/static/style.css`
- [x] `pnpm pack` includes `package/dist/static/style.css` in the tarball
- [x] `pnpm --filter @urateam/dashboard test` — all 194 tests still pass
- [ ] After release: rotulus-style sidecar reinstall + `pnpm dev` shows no `serveStatic` warning, `curl /static/style.css` returns the CSS

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)