### PR TITLE
chore(release): bump dashboard 0.1.4→0.1.5

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Ships PR #102 (urateam #101) to npm. Single-file version bump.

| Package | From | To |
|---|---|---|
| \`@urateam/dashboard\` | 0.1.4 | 0.1.5 |
| \`@urateam/core\` | 0.1.9 | unchanged |
| \`@urateam/cli\` | 0.1.6 | unchanged |
| \`create-urateam\` | 0.1.8 | unchanged |

## After merge

Tag \`v0.1.12\` on main → publish workflow fires → \`@urateam/dashboard@0.1.5\` ships to npm with provenance. The other three packages no-op (already at their published versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)