### PR TITLE
fix(extract-handoff): widen filesChanged override to git diff vs base

### DIFF
--- a/packages/core/src/__tests__/extract-handoff.test.ts
+++ b/packages/core/src/__tests__/extract-handoff.test.ts
@@ -237,6 +237,117 @@ describe("extractHandoff", () => {
     }
   });
 
+  it("override picks up branch-committed files when worktree is clean (urateam#35 widened, autoCommit gap)", async () => {
+    // Reproduces the rotulus PR #16 case from the OSS validation run: the
+    // implement stage modifies files and autoCommitChanges runs between
+    // stages. By the time the review stage's extractHandoff runs, the
+    // worktree is CLEAN — `git status --porcelain` returns nothing — and
+    // the empty-filesChanged override from PR #95 doesn't fire (status-only).
+    //
+    // Widened fix: when baseRef is supplied, also consult
+    // `git diff --name-only baseRef...HEAD` so the committed-on-branch
+    // files surface. This test simulates the autoCommit boundary by
+    // committing a feature edit on a feature branch with a baseline tag
+    // serving as baseRef.
+    const dir = await mkdtemp(join(tmpdir(), "extract-test-"));
+    try {
+      execFileSync("git", ["init", "-b", "main"], { cwd: dir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+      // Initial commit — establishes the base.
+      await writeFile(join(dir, "existing.ts"), "export const a = 1;");
+      execFileSync("git", ["add", "."], { cwd: dir });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir });
+      // Set up a fake `origin/main` so the prod `origin/main` ref form
+      // resolves in the test repo. update-ref creates it without a remote.
+      execFileSync(
+        "git",
+        ["update-ref", "refs/remotes/origin/main", "HEAD"],
+        { cwd: dir },
+      );
+      // Branch + commit two feature files, then leave the worktree clean
+      // (mirrors what autoCommitChanges produces).
+      execFileSync("git", ["checkout", "-b", "agent/iss-1"], { cwd: dir });
+      await writeFile(join(dir, "feature-a.ts"), "export const x = 1;");
+      await writeFile(join(dir, "feature-b.ts"), "export const y = 2;");
+      execFileSync("git", ["add", "."], { cwd: dir });
+      execFileSync("git", ["commit", "-m", "feat: add features"], { cwd: dir });
+
+      // Sanity check: `git status` is empty (autoCommit-clean state).
+      const status = execFileSync("git", ["status", "--porcelain"], { cwd: dir })
+        .toString();
+      expect(status.trim()).toBe("");
+
+      // Agent emits structurally-valid JSON but with empty filesChanged.
+      const brokenArtifact = { ...validArtifact, filesChanged: [] };
+      const output = wrapInJsonBlock(brokenArtifact);
+      const result = await extractHandoff(
+        output,
+        "run-1",
+        "ISS-1",
+        "review",
+        dir,
+        "origin/main",
+      );
+
+      expect(result.structured).toBe(true);
+      // Both feature files surface from the branch-vs-base diff, not status.
+      expect(result.artifact.filesChanged).toContain("feature-a.ts");
+      expect(result.artifact.filesChanged).toContain("feature-b.ts");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("dedupes files that show up in BOTH worktree status and branch-vs-base diff", async () => {
+    // Edge case: agent committed feature-a, then made an additional
+    // uncommitted edit to it. Should appear once, not twice.
+    const dir = await mkdtemp(join(tmpdir(), "extract-test-"));
+    try {
+      execFileSync("git", ["init", "-b", "main"], { cwd: dir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+      await writeFile(join(dir, "existing.ts"), "export const a = 1;");
+      execFileSync("git", ["add", "."], { cwd: dir });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir });
+      execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: dir });
+      execFileSync("git", ["checkout", "-b", "agent/iss-2"], { cwd: dir });
+      await writeFile(join(dir, "feature.ts"), "export const x = 1;");
+      execFileSync("git", ["add", "."], { cwd: dir });
+      execFileSync("git", ["commit", "-m", "feat: feature"], { cwd: dir });
+      // Now modify the same file again — uncommitted.
+      await writeFile(join(dir, "feature.ts"), "export const x = 99;");
+
+      const brokenArtifact = { ...validArtifact, filesChanged: [] };
+      const output = wrapInJsonBlock(brokenArtifact);
+      const result = await extractHandoff(
+        output, "run-1", "ISS-1", "review", dir, "origin/main",
+      );
+
+      expect(result.structured).toBe(true);
+      const occurrences = result.artifact.filesChanged.filter((f) => f === "feature.ts").length;
+      expect(occurrences).toBe(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to status-only when baseRef is undefined (back-compat with PR #95)", async () => {
+    // Existing callers that don't pass baseRef must keep getting the
+    // PR #95 behavior (worktree-only). This guards the optional-arg contract.
+    const dir = await createTestRepo();
+    try {
+      const brokenArtifact = { ...validArtifact, filesChanged: [] };
+      const output = wrapInJsonBlock(brokenArtifact);
+      const result = await extractHandoff(output, "run-1", "ISS-1", "implement", dir);
+      // Worktree has the modified file.txt from createTestRepo; override fires.
+      expect(result.structured).toBe(true);
+      expect(result.artifact.filesChanged).toContain("file.txt");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("override correctly resolves renamed files to the new name (parseGitPorcelain XY old -> new)", async () => {
     // Build a clean repo state with a single committed file, then do
     // ONLY a rename so porcelain emits the rename arrow form unambiguously.

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -179,12 +179,16 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
     turns = result.turns;
     lastTextContent = result.lastText;
 
+    // Pass `origin/<defaultBranch>` as baseRef so extractHandoff's
+    // empty-filesChanged override picks up commits the agent made on the
+    // branch in earlier stages (urateam#35 widened-fix gap from PR #95).
     const handoffResult = await extractHandoff(
       lastTextContent,
       runId,
       issueId,
       stage,
       workdir,
+      `origin/${repoConfig.defaultBranch}`,
     );
 
     await db

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -182,6 +182,9 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
     // Pass `origin/<defaultBranch>` as baseRef so extractHandoff's
     // empty-filesChanged override picks up commits the agent made on the
     // branch in earlier stages (urateam#35 widened-fix gap from PR #95).
+    // Note: extractHandoff takes the FULL ref form including `origin/` —
+    // `getChangedFiles` in repo/git.ts takes a bare branch and prefixes
+    // internally; don't conflate the two contracts.
     const handoffResult = await extractHandoff(
       lastTextContent,
       runId,

--- a/packages/core/src/executor/extract-handoff.ts
+++ b/packages/core/src/executor/extract-handoff.ts
@@ -138,13 +138,20 @@ export async function extractHandoff(
   };
 
   try {
-    // Slow path uses the same union (worktree + branch-vs-base diff) as the
-    // fast-path override so a review-stage handoff after autoCommitChanges
-    // still surfaces the implement-stage files. baseRef may be undefined for
-    // back-compat; in that case only the worktree is consulted.
+    // Slow path uses the same union helper. Necessary for the RALPH call
+    // sites in pipeline/runner.ts which always take the slow path
+    // (they invoke extractHandoff with agentOutput="" so parseJsonBlock
+    // returns null). The fast-path override in PR #95 + this PR's widening
+    // were the load-bearing fix for the rotulus#16 PR-body bug; the slow
+    // path benefits incidentally.
+    //
+    // diffStat must scan the same range as filesChanged or the "Modified
+    // N files: <stat tail>" approach string can be misleading (empty stat
+    // alongside non-empty files when the worktree is autoCommit-clean).
+    const statRange = baseRef ? `${baseRef}...HEAD` : "HEAD";
     const [filesChanged, diffStat] = await Promise.all([
       gitChangedFilesAcross(workdir, baseRef),
-      gitExecSafe(["diff", "--stat", "HEAD"], workdir),
+      gitExecSafe(["diff", "--stat", statRange], workdir),
     ]);
 
     // Best-effort summary from agent output. The last few lines often contain

--- a/packages/core/src/executor/extract-handoff.ts
+++ b/packages/core/src/executor/extract-handoff.ts
@@ -23,17 +23,59 @@ function parseGitPorcelain(statusOutput: string): string[] {
 }
 
 /**
+ * Parse `git diff --name-only` output into a list of changed file paths.
+ * Newline-separated; one path per line.
+ */
+function parseGitDiffNames(output: string): string[] {
+  if (!output) return [];
+  return output.split("\n").map((p) => p.trim()).filter(Boolean);
+}
+
+/**
+ * Compute "what did the agent change in this branch" by combining the
+ * uncommitted worktree state (`git status --porcelain`) with the
+ * already-committed-on-the-branch diff against `baseRef` (`git diff
+ * --name-only baseRef...HEAD`).
+ *
+ * Both signals are needed because the runner runs `autoCommitChanges`
+ * between stages — which means a review-stage handoff sees a clean
+ * worktree, even though the implement stage just modified 15 files. Status
+ * alone misses those committed-then-rewound changes.
+ *
+ * fail-open: gitExecRaw resolves to "" on error, so a missing baseRef
+ * (e.g., no `origin/main` configured in a test repo) is silent.
+ */
+async function gitChangedFilesAcross(
+  workdir: string,
+  baseRef: string | undefined,
+): Promise<string[]> {
+  const statusOutput = await gitExecRaw(["status", "--porcelain"], workdir);
+  const fromStatus = parseGitPorcelain(statusOutput);
+  if (!baseRef) return fromStatus;
+  const diffOutput = await gitExecRaw(
+    ["diff", "--name-only", `${baseRef}...HEAD`],
+    workdir,
+  );
+  const fromDiff = parseGitDiffNames(diffOutput);
+  // Dedupe in case a file shows up in both (unlikely but possible if the
+  // agent partially committed and then made more edits).
+  return Array.from(new Set([...fromStatus, ...fromDiff]));
+}
+
+/**
  * Extract a structured handoff artifact from the stage agent's raw output
  * and the actual worktree state.
  *
  * Strategy:
  * 1. Fast path: if the agent already produced valid JSON, use it — but
- *    cross-check against `git status --porcelain` and override an empty
- *    `filesChanged` list when the worktree actually has changes (urateam#35).
- *    Without this guard, an agent that emits `filesChanged: []` for a
- *    multi-file PR (or self-critique JSON in `summary`) leaves the PR body
- *    rendered as "No file changes recorded" + "No test changes" even though
- *    the diff has 15+ files.
+ *    cross-check against the union of `git status --porcelain` (uncommitted)
+ *    and `git diff --name-only baseRef...HEAD` (committed on this branch
+ *    since it diverged from baseRef). Override an empty `filesChanged`
+ *    list when git shows real changes (urateam#35). The committed-half
+ *    of that union is load-bearing: the runner runs autoCommitChanges
+ *    between stages, so by review-stage time the worktree is clean even
+ *    though the implement stage modified N files. Status alone misses
+ *    that case (gap from PR #95).
  * 2. Otherwise, run git commands to get actual file changes and build the
  *    handoff programmatically from the diff + agent's raw text output
  *
@@ -45,35 +87,40 @@ export async function extractHandoff(
   issueId: string,
   stage: string,
   workdir: string,
+  /**
+   * Optional base ref (e.g., "origin/main") to compare HEAD against for the
+   * "agent committed work on the branch" portion of the empty-filesChanged
+   * override. When absent, only the worktree (`git status --porcelain`) is
+   * consulted — i.e., the PR #95 behavior. Pass the full ref form including
+   * any `origin/` prefix the caller wants.
+   */
+  baseRef?: string,
 ): Promise<HandoffParseResult> {
   // Fast path: if the agent already produced valid structured JSON, use it
   const fastResult = parseHandoffArtifact(agentOutput, runId, issueId, stage);
   if (fastResult.structured) {
-    // Sanity check against the worktree: an empty `filesChanged` from the
-    // agent is the symptom of urateam#35 — the agent's structured output
-    // can be malformed (e.g., self-critique JSON leaks into `summary` and
+    // Sanity check against git: an empty `filesChanged` from the agent is
+    // the symptom of urateam#35 — the agent's structured output can be
+    // malformed (e.g., self-critique JSON leaks into `summary` and
     // `filesChanged: []` is emitted alongside) while the diff is real.
-    // Trust git as the authoritative source of "what changed in the
-    // worktree" only when the agent says nothing changed.
+    // Trust git as the authoritative source only when the agent says
+    // nothing changed.
     //
     // We deliberately do NOT override a non-empty agent list, even when it
     // disagrees with git — agents may legitimately filter their list (e.g.,
     // exclude generated files), and the rotulus PR #7 symptom that drives
     // this fix is specifically the empty-on-multi-file case.
     //
-    // No try/catch: gitExecRaw fails-open to "" on error rather than
-    // rejecting (see git.ts), and `parseGitPorcelain("")` returns []. So a
-    // git failure naturally short-circuits the override without throwing.
-    // Mutation of fastResult.artifact is safe — fastResult is a local var
-    // produced by parseHandoffArtifact and not aliased anywhere else before
-    // we return it.
+    // gitExecRaw fails-open to "" on error rather than rejecting, so a
+    // missing remote/baseRef is silent. Mutation of fastResult.artifact
+    // is safe — fastResult is a local var produced by parseHandoffArtifact
+    // and not aliased anywhere else before we return it.
     if (fastResult.artifact.filesChanged.length === 0) {
-      const statusOutput = await gitExecRaw(["status", "--porcelain"], workdir);
-      const gitFilesChanged = parseGitPorcelain(statusOutput);
+      const gitFilesChanged = await gitChangedFilesAcross(workdir, baseRef);
       if (gitFilesChanged.length > 0) {
         log.warn(
-          { stage, gitFilesChanged: gitFilesChanged.length },
-          "agent reported empty filesChanged but git shows real changes — overriding with git diff (urateam#35)",
+          { stage, gitFilesChanged: gitFilesChanged.length, baseRef: baseRef ?? "(worktree only)" },
+          "agent reported empty filesChanged but git shows real changes — overriding (urateam#35)",
         );
         fastResult.artifact.filesChanged = gitFilesChanged;
       }
@@ -91,15 +138,14 @@ export async function extractHandoff(
   };
 
   try {
-    // Run both git commands in parallel — they're independent
-    const [statusOutput, diffStat] = await Promise.all([
-      gitExecRaw(["status", "--porcelain"], workdir),
+    // Slow path uses the same union (worktree + branch-vs-base diff) as the
+    // fast-path override so a review-stage handoff after autoCommitChanges
+    // still surfaces the implement-stage files. baseRef may be undefined for
+    // back-compat; in that case only the worktree is consulted.
+    const [filesChanged, diffStat] = await Promise.all([
+      gitChangedFilesAcross(workdir, baseRef),
       gitExecSafe(["diff", "--stat", "HEAD"], workdir),
     ]);
-
-    // Parse porcelain output: "XY filename" — 2 status chars + 1 space + path
-    // For renames: "XY old -> new"
-    const filesChanged = parseGitPorcelain(statusOutput);
 
     // Best-effort summary from agent output. The last few lines often contain
     // tool noise rather than meaningful prose. filesChanged is the reliable signal.

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -861,6 +861,7 @@ export class PipelineRunner {
               sanitizedIssue.id,
               stage,
               worktreePath,
+              `origin/${repoConfig.defaultBranch}`,
             );
 
             runLog.info({ iteration, maxIterations: ralphIterations }, "RALPH: checking requirements");
@@ -1265,6 +1266,7 @@ export class PipelineRunner {
                 sanitizedIssue.id,
                 fixStage,
                 worktreePath,
+                `origin/${repoConfig.defaultBranch}`,
               );
               runLog.info({ rfIteration }, "RALPH: re-checking requirements after review-fix implement");
               const rfCheck = await checkRequirements(sanitizedIssue, rfHandoffResult, worktreePath);

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -861,6 +861,7 @@ export class PipelineRunner {
               sanitizedIssue.id,
               stage,
               worktreePath,
+              // Full ref form (extractHandoff doesn't prepend `origin/`).
               `origin/${repoConfig.defaultBranch}`,
             );
 
@@ -1266,6 +1267,7 @@ export class PipelineRunner {
                 sanitizedIssue.id,
                 fixStage,
                 worktreePath,
+                // Full ref form (extractHandoff doesn't prepend `origin/`).
                 `origin/${repoConfig.defaultBranch}`,
               );
               runLog.info({ rfIteration }, "RALPH: re-checking requirements after review-fix implement");


### PR DESCRIPTION
## Summary

Closes the fix gap from PR #95 surfaced by the rotulus OSS validation: \`@urateam/core@0.1.9\` shipped with the empty-\`filesChanged\` override based on \`git status --porcelain\`, but the rotulus PR #16 still rendered "No file changes recorded" despite 2 committed files. Diagnosis:

The runner calls \`autoCommitChanges\` **between stages**. By the time the review stage's \`extractHandoff\` runs, the worktree is CLEAN — \`git status\` returns empty — so the PR #95 override has nothing to populate.

## Fix

Widen the empty-override to consult the union of:
- \`git status --porcelain\` (uncommitted, the PR #95 path)
- \`git diff --name-only baseRef...HEAD\` (committed since branch diverged from baseRef)

Deduped. Both signals matter — autoCommit produces the second; agent edits after autoCommit produce the first.

\`extractHandoff\` gains an optional \`baseRef\` 6th param. The 3 production call sites (\`executor.ts\`, two in \`runner.ts\`) now pass \`origin/\${repoConfig.defaultBranch}\`. The slow path (programmatic build when Zod validation fails) uses the same union helper so review-stage handoffs after autoCommit still surface implement-stage files.

Back-compat: \`baseRef\` is optional. Tests / future callers that don't pass it get exact PR #95 behavior.

## Test plan

- [x] \`pnpm --filter @urateam/core build\` (typecheck)
- [x] \`pnpm --filter @urateam/core test\` — 1192 tests pass (was 1184; +3 in extract-handoff suite)

3 new tests:
- **Branch-committed files surface when worktree is clean** — reproduces the rotulus case using \`git update-ref refs/remotes/origin/main\` to fake the remote
- **Dedupes files in BOTH status and base diff** — partial edits after autoCommit
- **Back-compat: status-only when \`baseRef\` is undefined** — locks in the PR #95 contract for callers that haven't been updated

## After merge

Bump \`@urateam/core\` 0.1.9 → 0.1.10, tag, ship to npm. Then re-run the rotulus OSS validation to confirm.

Closes the gap surfaced in #35 (Bugs 2+3 second pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)