### PR TITLE
chore(release): bump core 0.1.9→0.1.10

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Ships PR #104 to npm. Single-package version bump.

| Package | From | To |
|---|---|---|
| \`@urateam/core\` | 0.1.9 | 0.1.10 |
| others | unchanged |

## After merge

Tag \`v0.1.13\` on main → publish workflow → \`@urateam/core@0.1.10\` on npm with provenance. Then re-run rotulus OSS validation to confirm #35 Bugs 2+3 no longer reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)