### PR TITLE
chore(release): cascade core 0.1.10 to cli 0.1.7 + dashboard 0.1.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Version-bump-only PR. No code changes.

| Package | From | To |
|---|---|---|
| \`@urateam/cli\` | 0.1.6 | 0.1.7 |
| \`@urateam/dashboard\` | 0.1.5 | 0.1.6 |
| \`@urateam/core\` | 0.1.10 | unchanged |
| \`create-urateam\` | 0.1.8 | unchanged |

## Why

\`@urateam/cli\` and \`@urateam/dashboard\` depend on \`@urateam/core\` via \`workspace:*\`, which the publish-package script resolves at pack time to whatever core version is in the workspace. The currently-published cli@0.1.6 + dashboard@0.1.5 were packed when core was 0.1.9, so they're pinned on core@0.1.9 in the registry.

Republishing both re-pins them on \`@urateam/core@0.1.10\` (the widened extract-handoff fix from PR #104). Downstream consumers running \`pnpm install\` against the latest cli now get the fix transitively — no overrides needed.

## Follow-up worth filing

Switch internal \`workspace:*\` deps to \`workspace:^\` so patch-level core updates propagate without manual wrapper bumps.

## After merge

Tag \`v0.1.14\` → publish workflow ships cli@0.1.7 + dashboard@0.1.6 with provenance. Then on rotulus: \`pnpm install\` (or remove lockfile + reinstall) → \`pnpm why @urateam/core\` should show 0.1.10 collapsed across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)