### PR TITLE
fix(ralph): fail closed on requirements-check evaluation failure

### DIFF
--- a/packages/core/src/__tests__/pr-description.test.ts
+++ b/packages/core/src/__tests__/pr-description.test.ts
@@ -390,6 +390,39 @@ describe("PR Description Enrichment (BEC-83)", () => {
       expect(body).toContain("RALPH found 1 unmet acceptance criteria");
     });
 
+    it("uses 'RALPH evaluation failed' draft reason when ralphEvaluationFailed (urateam#108)", () => {
+      // Distinct copy from "RALPH found N unmet criteria" because the
+      // evaluator itself crashed — there were zero criteria checked.
+      // Reviewers reading "1 unmet criteria" would search for a failing
+      // requirement and find nothing, wasting time. Locks in the fix.
+      const handoff: any = {
+        summary: "Test",
+        filesChanged: [],
+        approach: "test",
+        context: { issueIntent: "test", constraints: [], assumptions: [] },
+        tokenBudget: { contextTokensUsed: 10000, recommendedMaxTurns: 10 },
+      };
+
+      const body = generatePRDescription({
+        handoff,
+        issueId: "BEC-810",
+        shouldDraft: true,
+        ralphSatisfied: false,
+        ralphEvaluationFailed: true,
+        ralphEvaluationError: "Reached maximum number of turns (6)",
+        unresolvedBlockingFindings: [],
+        ralphGaps: [],
+      });
+
+      expect(body).toContain("> **Draft PR**");
+      expect(body).toContain("RALPH evaluation failed");
+      expect(body).toContain("Reached maximum number of turns (6)");
+      expect(body).toContain("human review required");
+      // Critically: must NOT use the "found N unmet criteria" wording.
+      expect(body).not.toContain("RALPH found 0 unmet acceptance criteria");
+      expect(body).not.toContain("RALPH found 1 unmet acceptance criteria");
+    });
+
     it("includes blocking review findings count in draft status", () => {
       const handoff: any = {
         summary: "Test",

--- a/packages/core/src/__tests__/ralph.test.ts
+++ b/packages/core/src/__tests__/ralph.test.ts
@@ -138,7 +138,11 @@ describe("checkRequirements", () => {
 
     const result = await checkRequirements(issue, makeHandoff(), "/tmp");
     expect(result.satisfied).toBe(false);
-    expect(result.evaluationFailed).toBeFalsy();
+    // Tighter than toBeFalsy() — the success-path contract is that the
+    // field is absent entirely, not just falsy. Catches regressions where
+    // someone adds `evaluationFailed: false` on every return out of misplaced
+    // defensive habit (which would still pass toBeFalsy but break narrowing).
+    expect(result.evaluationFailed).toBeUndefined();
     expect(result.gaps).toEqual(["Missing pagination"]);
   });
 });

--- a/packages/core/src/__tests__/ralph.test.ts
+++ b/packages/core/src/__tests__/ralph.test.ts
@@ -84,16 +84,62 @@ describe("checkRequirements", () => {
     expect(result.gaps[0]).toContain("Pagination");
   });
 
-  it("returns satisfied on agent error (fail-open)", async () => {
+  // urateam#108 — fail closed on eval failure (was fail-open). The previous
+  // behavior masked SDK errors / maxTurns exhaustion as "all requirements
+  // satisfied", letting broken eval ship as ready-to-merge PRs.
+  it("returns evaluationFailed: true when the agent SDK throws (fail-closed)", async () => {
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
     (query as any).mockReturnValue(
       (async function* () {
-        throw new Error("SDK error");
+        throw new Error("Reached maximum number of turns (6)");
       })(),
     );
 
     const result = await checkRequirements(issue, makeHandoff(), "/tmp");
-    expect(result.satisfied).toBe(true);
+    expect(result.satisfied).toBe(false);
+    expect(result.evaluationFailed).toBe(true);
+    expect(result.evaluationError).toContain("RALPH check agent failed");
+    expect(result.evaluationError).toContain("Reached maximum number of turns");
+    expect(result.gaps).toEqual([]); // no fake gaps invented
+  });
+
+  it("returns evaluationFailed: true when agent emits no parseable JSON block", async () => {
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    (query as any).mockReturnValue(
+      (async function* () {
+        yield {
+          type: "assistant",
+          content: [{ type: "text", text: "I think it looks fine." }],
+        };
+      })(),
+    );
+
+    const result = await checkRequirements(issue, makeHandoff(), "/tmp");
+    expect(result.satisfied).toBe(false);
+    expect(result.evaluationFailed).toBe(true);
+    expect(result.evaluationError).toContain("no parseable structured output");
+  });
+
+  it("does NOT mark evaluationFailed when agent legitimately returns satisfied: false with gaps", async () => {
+    // Negative-control: a genuine "agent ran successfully and found gaps"
+    // case must not get flagged as eval failure.
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    (query as any).mockReturnValue(
+      (async function* () {
+        yield {
+          type: "assistant",
+          content: [{
+            type: "text",
+            text: '```json\n{"satisfied": false, "gaps": ["Missing pagination"], "suggestions": []}\n```',
+          }],
+        };
+      })(),
+    );
+
+    const result = await checkRequirements(issue, makeHandoff(), "/tmp");
+    expect(result.satisfied).toBe(false);
+    expect(result.evaluationFailed).toBeFalsy();
+    expect(result.gaps).toEqual(["Missing pagination"]);
   });
 });
 

--- a/packages/core/src/executor/ralph.ts
+++ b/packages/core/src/executor/ralph.ts
@@ -12,6 +12,21 @@ export interface RalphCheckResult {
   satisfied: boolean;
   gaps: string[];
   suggestions: string[];
+  /**
+   * Set when the requirements-check agent itself failed (threw, ran out of
+   * turns, or produced no parseable JSON). Distinct from `satisfied: false`
+   * with a populated `gaps` list — that means the agent ran successfully and
+   * found real gaps. `evaluationFailed: true` means we have NO information
+   * about whether the criteria were met.
+   *
+   * Callers should treat this as "must surface to a human" — it is NEVER
+   * safe to treat as `satisfied: true`, but also wasteful to feed back
+   * into a re-implement loop because retrying the same eval-failure
+   * conditions will probably hit the same wall.
+   */
+  evaluationFailed?: boolean;
+  /** Human-readable reason for the evaluation failure. Used in PR-body draft notes. */
+  evaluationError?: string;
 }
 
 /**
@@ -102,13 +117,35 @@ Be strict but fair. If the code addresses the intent of a criterion even if not 
       };
     }
 
+    // Agent ran but emitted no parseable JSON — we have NO evidence the
+    // criteria were checked. Fail closed. Surfacing this as `satisfied:
+    // false + evaluationFailed: true` lets the caller draft the PR with an
+    // honest "RALPH eval failed, human review required" note rather than
+    // silently shipping it as ready (urateam follow-up to PR #95 fail-open
+    // observed during rotulus#17 OSS validation).
     log.warn("requirements check agent did not produce structured output");
-    return { satisfied: true, gaps: [], suggestions: [] };
+    return {
+      satisfied: false,
+      gaps: [],
+      suggestions: [],
+      evaluationFailed: true,
+      evaluationError:
+        "RALPH check agent completed but produced no parseable structured output — gaps could not be evaluated",
+    };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     log.error({ err: msg }, "requirements check agent failed");
-    // Don't block the pipeline on check failure
-    return { satisfied: true, gaps: [], suggestions: [] };
+    // Same fail-closed semantics as the no-JSON case above. The previous
+    // behavior here returned satisfied: true with a comment "Don't block
+    // the pipeline on check failure" — that masked real failures (e.g., the
+    // 6-turn cap exhaustion observed on rotulus#17) as positive signals.
+    return {
+      satisfied: false,
+      gaps: [],
+      suggestions: [],
+      evaluationFailed: true,
+      evaluationError: `RALPH check agent failed: ${msg}`,
+    };
   }
 }
 

--- a/packages/core/src/pipeline/pr-description.ts
+++ b/packages/core/src/pipeline/pr-description.ts
@@ -14,6 +14,18 @@ export interface PRDescriptionOptions {
   ralphSatisfied?: boolean;
   /** List of unmet RALPH gap items (used for count in draft reason). */
   ralphGaps?: unknown[];
+  /**
+   * Set when the RALPH check agent itself failed (threw, hit its turn cap,
+   * or produced no parseable JSON). Distinct from `ralphSatisfied: false`
+   * with a non-empty gap list — that means RALPH ran successfully and found
+   * real gaps. When this is true, the draft reason wording switches from
+   * "RALPH found N unmet acceptance criteria" to "RALPH evaluation failed:
+   * <reason>" so reviewers don't waste time hunting for a non-existent
+   * failed requirement (urateam#108).
+   */
+  ralphEvaluationFailed?: boolean;
+  /** Human-readable reason from `RalphCheckResult.evaluationError`. */
+  ralphEvaluationError?: string;
   /** Blocking review findings that remain unresolved (used for count in draft reason). */
   unresolvedBlockingFindings?: unknown[];
   /** Agent-authored commit messages (not auto-committed fallbacks) to include in a Commits section. */
@@ -40,6 +52,8 @@ export function generatePRDescription(options: PRDescriptionOptions): string {
     shouldDraft = false,
     ralphSatisfied = true,
     ralphGaps = [],
+    ralphEvaluationFailed = false,
+    ralphEvaluationError,
     unresolvedBlockingFindings = [],
     agentCommits = [],
   } = options;
@@ -76,7 +90,20 @@ export function generatePRDescription(options: PRDescriptionOptions): string {
   // Flag draft status with reason
   if (shouldDraft) {
     const reasons: string[] = [];
-    if (!ralphSatisfied) reasons.push(`RALPH found ${ralphGaps.length} unmet acceptance criteria`);
+    if (!ralphSatisfied) {
+      // urateam#108: distinguish "agent ran, found gaps" from "evaluator
+      // crashed". The previous "RALPH found N unmet acceptance criteria"
+      // copy lied when N actually counted "RALPH check agent failed: ..."
+      // strings, sending reviewers hunting for a non-existent requirement
+      // failure.
+      if (ralphEvaluationFailed) {
+        reasons.push(
+          `RALPH evaluation failed (${ralphEvaluationError ?? "no detail"}) — human review required`,
+        );
+      } else {
+        reasons.push(`RALPH found ${ralphGaps.length} unmet acceptance criteria`);
+      }
+    }
     if (unresolvedBlockingFindings.length > 0)
       reasons.push(`${unresolvedBlockingFindings.length} blocking review findings remain`);
     parts.push(`> **Draft PR** — ${reasons.join("; ")}. See PR comments for details.`);

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -759,6 +759,13 @@ export class PipelineRunner {
       let ralphSatisfied = true;
       let ralphGaps: string[] = [];
       let ralphSuggestions: string[] = [];
+      // urateam#108: distinguish "RALPH ran successfully and found N gaps"
+      // (ralphSatisfied=false, ralphGaps populated) from "RALPH check agent
+      // itself failed" (ralphSatisfied=false, ralphEvaluationFailed=true).
+      // These produce different PR-body / comment / notifier copy so reviewers
+      // don't waste time hunting for a non-existent failed requirement.
+      let ralphEvaluationFailed = false;
+      let ralphEvaluationError: string | undefined;
       const effectiveRalphIterations = isFeatureLicensed("deep-review")
         ? config.ralphIterations ?? 2
         : Math.min(config.ralphIterations ?? 1, 1);
@@ -887,10 +894,9 @@ export class PipelineRunner {
                 "RALPH: evaluation failed — drafting PR with eval-failure note instead of re-implementing",
               );
               ralphSatisfied = false;
-              ralphGaps = [
-                check.evaluationError ??
-                  "RALPH evaluation failed (no detail) — human review required",
-              ];
+              ralphEvaluationFailed = true;
+              ralphEvaluationError = check.evaluationError;
+              ralphGaps = [];
               ralphSuggestions = [];
               break;
             }
@@ -1293,16 +1299,19 @@ export class PipelineRunner {
               const rfCheck = await checkRequirements(sanitizedIssue, rfHandoffResult, worktreePath);
               ralphSatisfied = rfCheck.satisfied;
               if (rfCheck.evaluationFailed) {
-                ralphGaps = [
-                  rfCheck.evaluationError ??
-                    "RALPH evaluation failed (no detail) — human review required",
-                ];
+                ralphEvaluationFailed = true;
+                ralphEvaluationError = rfCheck.evaluationError;
+                ralphGaps = [];
                 ralphSuggestions = [];
                 runLog.warn(
                   { rfIteration, evaluationError: rfCheck.evaluationError },
                   "RALPH: re-check evaluation failed — drafting PR with eval-failure note (urateam#108)",
                 );
               } else {
+                // Reset in case a prior iteration's eval failed but this
+                // re-check ran cleanly.
+                ralphEvaluationFailed = false;
+                ralphEvaluationError = undefined;
                 ralphGaps = rfCheck.gaps;
                 ralphSuggestions = rfCheck.suggestions;
                 if (rfCheck.satisfied) {
@@ -1718,6 +1727,8 @@ export class PipelineRunner {
           shouldDraft,
           ralphSatisfied,
           ralphGaps,
+          ralphEvaluationFailed,
+          ralphEvaluationError,
           unresolvedBlockingFindings,
           agentCommits,
         });
@@ -1823,7 +1834,22 @@ export class PipelineRunner {
           runLog.info({ prUrl }, "draft PR: adding review comments with gaps and next steps");
           const commentParts: string[] = [];
 
-          if (!ralphSatisfied && ralphGaps.length > 0) {
+          if (!ralphSatisfied && ralphEvaluationFailed) {
+            // urateam#108: separate header + copy when the evaluator itself
+            // crashed. The previous "Unmet Acceptance Criteria" header was a
+            // lie — there were zero acceptance criteria checked, the agent
+            // broke before it could check anything.
+            commentParts.push("## RALPH Evaluation Error\n");
+            commentParts.push(
+              `The RALPH requirements-check agent failed to evaluate this PR. Human review is required to confirm all acceptance criteria are met.\n`,
+            );
+            commentParts.push(
+              `**Reason:** ${ralphEvaluationError ?? "no detail captured"}\n`,
+            );
+            commentParts.push(
+              "Common causes: agent exhausted its 6-turn cap on a complex spec, transient SDK error, or agent emitted no parseable JSON. Re-running the issue may succeed.",
+            );
+          } else if (!ralphSatisfied && ralphGaps.length > 0) {
             commentParts.push("## Unmet Acceptance Criteria (RALPH)\n");
             commentParts.push(`RALPH checked ${ralphIterations} time(s) and found the following gaps:\n`);
             for (const gap of ralphGaps) {
@@ -1864,11 +1890,15 @@ export class PipelineRunner {
             runLog.warn({ err: commentErr }, "failed to add PR comment for draft — continuing");
           }
 
-          // Notify for human review
+          // Notify for human review (urateam#108: don't claim "N unmet
+          // criteria" when N is actually an evaluator-error count).
+          const ralphSummary = ralphEvaluationFailed
+            ? "RALPH evaluation failed"
+            : `${ralphGaps.length} unmet acceptance criteria`;
           await this.notifier.onHumanReviewNeeded?.(
             run,
             prUrl,
-            `Draft PR created — ${ralphGaps.length} unmet acceptance criteria, ${unresolvedBlockingFindings.length} blocking findings`,
+            `Draft PR created — ${ralphSummary}, ${unresolvedBlockingFindings.length} blocking findings`,
           );
         }
 

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -876,6 +876,25 @@ export class PipelineRunner {
               break;
             }
 
+            // Eval-failure path: the check agent itself broke (no parseable
+            // output, threw, or exhausted turns). We have NO evidence about
+            // gap status; surface that to the human via the PR draft note
+            // and skip re-implement (retry on the same conditions almost
+            // never recovers, and burns tokens). See urateam#108.
+            if (check.evaluationFailed) {
+              runLog.warn(
+                { iteration, evaluationError: check.evaluationError },
+                "RALPH: evaluation failed — drafting PR with eval-failure note instead of re-implementing",
+              );
+              ralphSatisfied = false;
+              ralphGaps = [
+                check.evaluationError ??
+                  "RALPH evaluation failed (no detail) — human review required",
+              ];
+              ralphSuggestions = [];
+              break;
+            }
+
             // Track the latest gaps for PR comments if loop exhausts
             ralphGaps = check.gaps;
             ralphSuggestions = check.suggestions;
@@ -1273,15 +1292,27 @@ export class PipelineRunner {
               runLog.info({ rfIteration }, "RALPH: re-checking requirements after review-fix implement");
               const rfCheck = await checkRequirements(sanitizedIssue, rfHandoffResult, worktreePath);
               ralphSatisfied = rfCheck.satisfied;
-              ralphGaps = rfCheck.gaps;
-              ralphSuggestions = rfCheck.suggestions;
-              if (rfCheck.satisfied) {
-                runLog.info({ rfIteration }, "RALPH: requirements satisfied after review-fix implement");
-              } else {
+              if (rfCheck.evaluationFailed) {
+                ralphGaps = [
+                  rfCheck.evaluationError ??
+                    "RALPH evaluation failed (no detail) — human review required",
+                ];
+                ralphSuggestions = [];
                 runLog.warn(
-                  { rfIteration, gaps: rfCheck.gaps.length },
-                  "RALPH: requirements NOT satisfied after review-fix implement — PR may be created as draft",
+                  { rfIteration, evaluationError: rfCheck.evaluationError },
+                  "RALPH: re-check evaluation failed — drafting PR with eval-failure note (urateam#108)",
                 );
+              } else {
+                ralphGaps = rfCheck.gaps;
+                ralphSuggestions = rfCheck.suggestions;
+                if (rfCheck.satisfied) {
+                  runLog.info({ rfIteration }, "RALPH: requirements satisfied after review-fix implement");
+                } else {
+                  runLog.warn(
+                    { rfIteration, gaps: rfCheck.gaps.length },
+                    "RALPH: requirements NOT satisfied after review-fix implement — PR may be created as draft",
+                  );
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

Closes urateam#108. RALPH's \`checkRequirements\` previously returned \`{ satisfied: true }\` when its sub-agent threw or emitted no parseable JSON. Real eval failures masqueraded as positive signals; broken PRs shipped as ready with no operator warning.

## Reproduction (rotulus#17 OSS validation)

```
"RALPH","err":"Reached maximum number of turns (6)","msg":"requirements check agent failed"
↓ immediately:
"RALPH: all requirements satisfied"
```

## Fix

- Add \`evaluationFailed: true\` + \`evaluationError: string\` to \`RalphCheckResult\`.
- Both failure paths (throw, no-parseable-JSON) now return \`satisfied: false, evaluationFailed: true\`.
- Both runner call sites:
  - Don't claim \`ralphSatisfied = true\` when eval failed
  - Don't re-implement (waste of tokens; same eval conditions = same wall)
  - Set \`ralphGaps\` to a single entry with the evaluation error → surfaces in the PR-body draft note

## Test plan

- [x] \`pnpm --filter @urateam/core build\` (typecheck)
- [x] \`pnpm --filter @urateam/core test\` — 1194 tests pass
- [x] Replaced legacy fail-open test with three new fail-closed tests (SDK throw, no-JSON, negative control)

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)