### PR TITLE
fix(handoff): sanitize JSON-soup summaries + demote noisy parse logs (urateam#97)

### DIFF
--- a/packages/core/src/__tests__/extract-handoff.test.ts
+++ b/packages/core/src/__tests__/extract-handoff.test.ts
@@ -374,6 +374,77 @@ describe("extractHandoff", () => {
     }
   });
 
+  // ---------------------------------------------------------------------------
+  // urateam#97: JSON-soup summary sanitization (slow path)
+  // ---------------------------------------------------------------------------
+  it("replaces JSON-soup summary text with a deterministic placeholder (urateam#97 rotulus#7 case)", async () => {
+    // Reproduces the exact pattern from rotulus PR #7: the review-stage
+    // agent emits review-finding JSON arrays (different schema than
+    // HandoffArtifact). The previous slow-path scraped the last 5 lines
+    // verbatim into `summary`, leaking JSON fragments into the rendered
+    // PR body's "## Summary" section.
+    const dir = await createTestRepo();
+    try {
+      const reviewFindingsLeak = [
+        "Done analyzing.",
+        '"description": "patchMeSchema uses Zod default strip — fields silently dropped.",',
+        '"fix": "Append .strict() to patchMeSchema",',
+        '"severity": "warning"',
+        "}]",
+      ].join("\n");
+
+      const result = await extractHandoff(reviewFindingsLeak, "run-1", "ISS-1", "review", dir);
+      expect(result.structured).toBe(false);
+      // Must NOT contain the leaked JSON fragments
+      expect(result.artifact.summary).not.toContain('"description"');
+      expect(result.artifact.summary).not.toContain('"fix"');
+      expect(result.artifact.summary).not.toContain('"severity"');
+      // Must have the deterministic placeholder
+      expect(result.artifact.summary).toContain("Stage review completed");
+      expect(result.artifact.summary).toContain("see Changes for files modified");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves prose summary when agent output is normal text (no false positive)", async () => {
+    // Negative control: the JSON-soup heuristic should NOT fire on
+    // legitimate prose summaries.
+    const dir = await createTestRepo();
+    try {
+      const prose = [
+        "Completed implementation of the search endpoint.",
+        "Added pagination support and input validation.",
+        "All tests pass.",
+      ].join("\n");
+
+      const result = await extractHandoff(prose, "run-1", "ISS-1", "implement", dir);
+      expect(result.structured).toBe(false);
+      expect(result.artifact.summary).toContain("search endpoint");
+      expect(result.artifact.summary).toContain("All tests pass");
+      // Sanity: not the placeholder
+      expect(result.artifact.summary).not.toContain("not parseable prose");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves prose with incidental quoted phrases (no over-eager pattern match)", async () => {
+    // Edge case: prose that mentions a JSON-shaped phrase by coincidence
+    // (e.g., "the description: field is missing"). The heuristic requires
+    // 2+ `"x":"` patterns OR an opening { / [, neither of which fires here.
+    const dir = await createTestRepo();
+    try {
+      const prose = "Implementation done. The description field on User model now accepts emojis.";
+      const result = await extractHandoff(prose, "run-1", "ISS-1", "implement", dir);
+      expect(result.structured).toBe(false);
+      expect(result.artifact.summary).toContain("emojis");
+      expect(result.artifact.summary).not.toContain("not parseable prose");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns structured: false when git diff fails (not a git repo)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "extract-test-"));
     // Not a git repo — no .git directory

--- a/packages/core/src/__tests__/extract-handoff.test.ts
+++ b/packages/core/src/__tests__/extract-handoff.test.ts
@@ -432,7 +432,8 @@ describe("extractHandoff", () => {
   it("preserves prose with incidental quoted phrases (no over-eager pattern match)", async () => {
     // Edge case: prose that mentions a JSON-shaped phrase by coincidence
     // (e.g., "the description: field is missing"). The heuristic requires
-    // 2+ `"x":"` patterns OR an opening { / [, neither of which fires here.
+    // 3+ `"x":"` patterns OR an opening { / [ followed by JSON structure,
+    // neither of which fires here.
     const dir = await createTestRepo();
     try {
       const prose = "Implementation done. The description field on User model now accepts emojis.";
@@ -440,6 +441,68 @@ describe("extractHandoff", () => {
       expect(result.structured).toBe(false);
       expect(result.artifact.summary).toContain("emojis");
       expect(result.artifact.summary).not.toContain("not parseable prose");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves prose starting with checklist or tag prefixes (no false positive on `[x]`/`[PASS]`)", async () => {
+    // Sonnet review of PR #110 caught: agent output often ends with
+    // checklist items like `[x] tests pass` or tag-prefixed lines like
+    // `[PASS] all checks` / `[fix] update schema`. The previous
+    // `^[\s\[\{]` heuristic fired on these. Tightened to require an
+    // actual JSON opener (`[{` or `{"`) after the bracket.
+    const dir = await createTestRepo();
+    try {
+      const checklistTail = [
+        "[x] feature implemented",
+        "[x] tests pass",
+        "[PASS] lint",
+      ].join("\n");
+      const result = await extractHandoff(checklistTail, "run-1", "ISS-1", "test", dir);
+      expect(result.structured).toBe(false);
+      expect(result.artifact.summary).toContain("[x]");
+      expect(result.artifact.summary).toContain("PASS");
+      expect(result.artifact.summary).not.toContain("not parseable prose");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves config-change prose with two quoted attribute pairs (threshold guard)", async () => {
+    // Sonnet review of PR #110 caught: prose like
+    // `Added "env": "production" and "debug": "false" in config` was
+    // tripping the c3 heuristic when its threshold was 2. Raised to 3.
+    const dir = await createTestRepo();
+    try {
+      const configProse = 'Added "env": "production" and "debug": "false" to the staging config.';
+      const result = await extractHandoff(configProse, "run-1", "ISS-1", "implement", dir);
+      expect(result.structured).toBe(false);
+      expect(result.artifact.summary).toContain("staging config");
+      expect(result.artifact.summary).not.toContain("not parseable prose");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("JSON-soup detection still fires when baseRef is provided (slow-path coverage)", async () => {
+    // Coverage gap from PR #110 — the original 3 tests didn't pass baseRef.
+    // The widened union helper from PR #104 doesn't change the soup
+    // detection path, but the test surface should exercise both args.
+    const dir = await createTestRepo();
+    try {
+      const reviewFindingsLeak = '[{"description": "issue", "fix": "fix it", "severity": "blocking", "category": "Other"}]';
+      const result = await extractHandoff(
+        reviewFindingsLeak,
+        "run-1",
+        "ISS-1",
+        "review",
+        dir,
+        "origin/main",
+      );
+      expect(result.structured).toBe(false);
+      expect(result.artifact.summary).not.toContain('"description"');
+      expect(result.artifact.summary).toContain("Stage review completed");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/pr-description.test.ts
+++ b/packages/core/src/__tests__/pr-description.test.ts
@@ -42,6 +42,30 @@ describe("PR Description Enrichment (BEC-83)", () => {
       expect(body).toContain("No summary available.");
     });
 
+    it("propagates the JSON-soup placeholder summary to ## Summary verbatim (urateam#97)", () => {
+      // Closes the loop on the urateam#97 fix: extract-handoff slow path
+      // produces a deterministic placeholder when the agent emits JSON soup
+      // instead of prose; pr-description must render it as-is. Without this
+      // test, a future change to the summary block could break the chain.
+      const handoff: any = {
+        summary: "Stage review completed — agent output was not parseable prose; see Changes for files modified",
+        filesChanged: ["src/auth.ts"],
+        approach: "test",
+        context: { issueIntent: "test", constraints: [], assumptions: [] },
+        tokenBudget: { contextTokensUsed: 100, recommendedMaxTurns: 5 },
+      };
+
+      const body = generatePRDescription({ handoff, issueId: "BEC-97" });
+
+      expect(body).toContain("## Summary");
+      expect(body).toContain("Stage review completed");
+      expect(body).toContain("see Changes for files modified");
+      // Critical: the body must NOT contain JSON-fragment-shaped strings
+      // that the placeholder is meant to replace.
+      expect(body).not.toContain('"description"');
+      expect(body).not.toContain('"severity"');
+    });
+
     it("renders empty summary when handoff.summary is an empty string", () => {
       const handoff: any = {
         summary: "",

--- a/packages/core/src/executor/extract-handoff.ts
+++ b/packages/core/src/executor/extract-handoff.ts
@@ -169,11 +169,22 @@ export async function extractHandoff(
     const rawTail = lines.length > 0
       ? lines.slice(-5).join(" ").slice(0, 500)
       : "";
+    // Heuristics tuned to avoid false positives on common agent prose:
+    //   - `[x] tests pass`, `[PASS]`, `[fix] ...` — checklist / tag prefixes
+    //   - `Added "env": "production" and "debug": "false"` — config-change prose
+    //   - `{ destructured } = result` — JS destructuring prose
+    // To trip detection, the tail must look STRUCTURALLY like JSON, not just
+    // contain bracket characters. `^\s*[\[{]\s*[{"]` matches `[{...`, `{"...`,
+    // and similar real JSON openers but not `[x]` / `{ destruct }` / etc.
     const looksLikeJsonSoup =
-      /^[\s\[\{]/.test(rawTail) ||
+      /^\s*[[{]\s*["{]/.test(rawTail) ||
       /"(description|fix|severity|category)"\s*:/.test(rawTail) ||
-      // Heuristic: 2+ JSON-property colons in close proximity (e.g. ", "x":")
-      (rawTail.match(/"\s*:\s*"/g)?.length ?? 0) >= 2;
+      // Tighter threshold (3+) for the bare-property-pair heuristic. Two
+      // pairs is too low — operators routinely write prose with two quoted
+      // attribute references (e.g., "Added \"env\": \"production\" and
+      // \"debug\": \"false\""). Three+ is consistent with real review-finding
+      // JSON arrays which always emit many such pairs per tail window.
+      (rawTail.match(/"\s*:\s*"/g)?.length ?? 0) >= 3;
     const summary = !rawTail
       ? `Stage ${stage} completed`
       : looksLikeJsonSoup

--- a/packages/core/src/executor/extract-handoff.ts
+++ b/packages/core/src/executor/extract-handoff.ts
@@ -154,12 +154,31 @@ export async function extractHandoff(
       gitExecSafe(["diff", "--stat", statRange], workdir),
     ]);
 
-    // Best-effort summary from agent output. The last few lines often contain
-    // tool noise rather than meaningful prose. filesChanged is the reliable signal.
+    // Best-effort summary from agent output. Two failure modes are common
+    // here (urateam#97):
+    //   - Review-stage agents emit review-finding JSON arrays (not the
+    //     HandoffArtifact shape) which leak into the rendered PR body
+    //     "## Summary" as `"description": "..."` / `"fix": "..."` fragments.
+    //   - Implement/test stage agents emit nothing structured; the last few
+    //     lines often contain tool noise rather than prose.
+    // Detect JSON-fragment-shaped content and replace with a deterministic
+    // placeholder. Reviewers got bitten on rotulus#7 by JSON-soup summaries
+    // that looked like a structured review (and even flagged a real bug)
+    // that nobody acted on.
     const lines = agentOutput.split("\n").filter((l) => l.trim().length > 0);
-    const summary = lines.length > 0
+    const rawTail = lines.length > 0
       ? lines.slice(-5).join(" ").slice(0, 500)
-      : `Stage ${stage} completed`;
+      : "";
+    const looksLikeJsonSoup =
+      /^[\s\[\{]/.test(rawTail) ||
+      /"(description|fix|severity|category)"\s*:/.test(rawTail) ||
+      // Heuristic: 2+ JSON-property colons in close proximity (e.g. ", "x":")
+      (rawTail.match(/"\s*:\s*"/g)?.length ?? 0) >= 2;
+    const summary = !rawTail
+      ? `Stage ${stage} completed`
+      : looksLikeJsonSoup
+        ? `Stage ${stage} completed — agent output was not parseable prose; see Changes for files modified`
+        : rawTail;
 
     const approach = diffStat
       ? `Modified ${filesChanged.length} file(s): ${diffStat.split("\n").pop() || ""}`

--- a/packages/core/src/executor/handoff.ts
+++ b/packages/core/src/executor/handoff.ts
@@ -15,12 +15,18 @@ export function buildFallback(
   metadata: { runId: string; issueId: string; stage: string; timestamp: string },
   summary: string,
 ): HandoffArtifact {
-  // Note (urateam#35 Bug 1): if `summary` here is the agent's raw output
-  // truncated to 500 chars, it may contain JSON fragments from a self-
-  // critique block the agent leaked instead of structured prose. The fix
-  // for that is upstream prompt engineering (constraining the agent's
-  // structured-output instructions) — not summary sanitization here, which
-  // would be fragile regex hacks.
+  // Note (urateam#97): callers should NOT use this raw `summary` string
+  // for end-user surfaces. The slow path in extract-handoff.ts applies
+  // a JSON-soup heuristic before assigning to artifact.summary so the
+  // PR body's "## Summary" section doesn't render review-finding JSON
+  // fragments verbatim (rotulus#7 reproduction). buildFallback itself is
+  // schema-required to populate `summary` to satisfy HandoffArtifact;
+  // the sanitization logically belongs at the call site, not here.
+  //
+  // The deeper root cause — per-stage prompts in templates.ts never
+  // instruct the agent to emit a HandoffArtifact JSON block — is tracked
+  // in urateam#97 as the long-term fix. When that lands, the fast path
+  // becomes load-bearing and this fallback is rarely hit.
   return {
     ...metadata,
     summary: summary || `Stage ${metadata.stage} completed without structured output`,
@@ -64,14 +70,18 @@ export function parseHandoffArtifact(
   const parsed = parseJsonBlock(agentOutput);
   if (!parsed) {
     // Demoted from error → debug: this fires on EVERY implement/test stage
-    // because per-stage prompts (templates.ts) never instruct the agent to
-    // emit a HandoffArtifact-shaped JSON block. The slow path in
-    // extractHandoff reconstructs filesChanged from git diff and provides a
-    // sanitized summary, so this isn't an actionable error — it's expected
-    // operation. Logging at error level falsely flagged it as a problem in
-    // every operator dashboard. See urateam#97. (When prompt engineering
-    // catches up and the fast path actually runs, this log becomes useful
-    // again — flip back to warn at that point.)
+    // because per-stage prompts in `packages/core/src/executor/prompt/templates.ts`
+    // never instruct the agent to emit a HandoffArtifact-shaped JSON block.
+    // The slow path in extractHandoff reconstructs filesChanged from git diff
+    // and provides a sanitized summary, so this isn't an actionable error —
+    // it's expected operation. Logging at error level falsely flagged it as
+    // a problem in every operator dashboard (and triggered Slack alerts via
+    // notifier/slack-alerts.ts which fires on level >= 50). See urateam#97.
+    //
+    // CONTRACT FOR FLIP-BACK: when (a) the per-stage prompts in templates.ts
+    // are updated to request a HandoffArtifact JSON block, AND (b) the fast
+    // path actually reaches `structured: true` on a meaningful fraction of
+    // runs, this log should flip back to warn. Track via urateam#97.
     log.debug({ stage }, "no valid JSON block in agent output, using slow-path reconstruction");
     return {
       artifact: buildFallback(metadata, agentOutput.slice(0, 500)),
@@ -88,9 +98,11 @@ export function parseHandoffArtifact(
 
   const result = HandoffArtifactSchema.safeParse(fullArtifact);
   if (!result.success) {
-    // Same demotion as the no-block case above (urateam#97). The review
-    // stage routinely emits review-findings JSON (severity/file/line shape)
-    // which fails this validation. That's expected, not an error.
+    // Same demotion as the no-block case above (urateam#97); same
+    // flip-back contract. The review stage routinely emits review-findings
+    // JSON (severity/file/line shape, see security/review-checklist.ts
+    // REVIEW_OUTPUT_FORMAT) which fails this validation. That's expected
+    // operation, not an error.
     log.debug(
       { stage, validationErrors: result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ") },
       "JSON block did not match HandoffArtifact schema, using slow-path reconstruction",

--- a/packages/core/src/executor/handoff.ts
+++ b/packages/core/src/executor/handoff.ts
@@ -63,7 +63,16 @@ export function parseHandoffArtifact(
 
   const parsed = parseJsonBlock(agentOutput);
   if (!parsed) {
-    log.error({ stage }, "no valid JSON block in agent output, using fallback");
+    // Demoted from error → debug: this fires on EVERY implement/test stage
+    // because per-stage prompts (templates.ts) never instruct the agent to
+    // emit a HandoffArtifact-shaped JSON block. The slow path in
+    // extractHandoff reconstructs filesChanged from git diff and provides a
+    // sanitized summary, so this isn't an actionable error — it's expected
+    // operation. Logging at error level falsely flagged it as a problem in
+    // every operator dashboard. See urateam#97. (When prompt engineering
+    // catches up and the fast path actually runs, this log becomes useful
+    // again — flip back to warn at that point.)
+    log.debug({ stage }, "no valid JSON block in agent output, using slow-path reconstruction");
     return {
       artifact: buildFallback(metadata, agentOutput.slice(0, 500)),
       structured: false,
@@ -79,9 +88,12 @@ export function parseHandoffArtifact(
 
   const result = HandoffArtifactSchema.safeParse(fullArtifact);
   if (!result.success) {
-    log.error(
+    // Same demotion as the no-block case above (urateam#97). The review
+    // stage routinely emits review-findings JSON (severity/file/line shape)
+    // which fails this validation. That's expected, not an error.
+    log.debug(
       { stage, validationErrors: result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ") },
-      "invalid HandoffArtifact, using fallback",
+      "JSON block did not match HandoffArtifact schema, using slow-path reconstruction",
     );
     return {
       artifact: buildFallback(metadata, agentOutput.slice(0, 500)),


### PR DESCRIPTION
## Summary

Closes the second-pass concern from urateam#97 surfaced by rotulus#17 OSS validation. Two compounding production-quality issues:

### 1. Slow-path summary leaks JSON fragments

The slow-path \`extractHandoff\` scrapes the agent's last 5 stdout lines into \`summary\`. When the review-stage agent emits a review-finding JSON array (which it does **by design** — see \`REVIEW_OUTPUT_FORMAT\` in the review template), those JSON fragments end up rendered verbatim in the PR body's \`## Summary\` section. Rotulus PR #7 was the canonical reproducer.

**Fix:** detect JSON-soup-shaped content (leading \`{\` / \`[\`, presence of \`"description"\` / \`"fix"\` / \`"severity"\` / \`"category"\` property keys, or 2+ JSON property colons) → replace with a deterministic placeholder.

### 2. Misleading error-level log spam

\`handoff.ts\` emitted level=50 (error) logs on **every** implement/test stage saying \"no valid JSON block in agent output\". Per-stage prompts in \`templates.ts\` never instruct agents to emit HandoffArtifact JSON, so this fires every pipeline run — operator dashboards saw error-level logs on every successful run.

**Fix:** demote both no-block and schema-mismatch logs from \`error\` → \`debug\`. The slow path is the load-bearing path; these are expected operation, not errors.

## Test plan

- [x] \`pnpm --filter @urateam/core build\` (typecheck)
- [x] \`pnpm --filter @urateam/core test\` — 1195 tests pass (was 1192; +3)

3 new extract-handoff tests:
- JSON-soup detection on rotulus#7's exact pattern
- Plain prose preserved (no false positive)
- Edge case: prose with incidental quoted phrases

## Long-term scope note

The fix doesn't address the actual root cause: per-stage prompts (\`templates.ts\`) never ask agents for a HandoffArtifact JSON block. That's a prompt-engineering effort gap analysis from #97 already tracks. When that lands, the fast path becomes load-bearing again and these debug logs should flip back to warn level — comment in code notes the contract.

Closes #97 (Bug 1, the JSON-leak symptom). The deeper architectural mismatch (agents not asked for handoff JSON) remains tracked in the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)