### PR TITLE
chore(release): bump core 0.1.11 + cascade cli 0.1.8 + dashboard 0.1.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Combined release shipping two reputation-fix PRs from the rotulus#17 OSS validation cycle.

| Package | From | To | Includes |
|---|---|---|---|
| \`@urateam/core\` | 0.1.10 | 0.1.11 | #109 (RALPH fail-closed), #110 (handoff sanitization + log demotion) |
| \`@urateam/cli\` | 0.1.7 | 0.1.8 | cascade — workspace:* re-pins on core 0.1.11 |
| \`@urateam/dashboard\` | 0.1.6 | 0.1.7 | cascade — same |
| \`create-urateam\` | 0.1.8 | unchanged | no code changes |

## What ships

- **#109** — RALPH no longer marks broken evaluations as "satisfied". When the requirements-check sub-agent throws or exhausts its turns, the PR drafts with an honest "RALPH evaluation failed" note instead of silently shipping as ready.
- **#110** — Review-finding JSON no longer leaks into PR body \`## Summary\` (rotulus#7 reproducer dead). Misleading error-level handoff logs demoted to debug — operator dashboards stop flagging expected behavior as errors.

## After merge

Tag \`v0.1.15\` → publish workflow ships all 3 wrapper-affected packages with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)