### PR TITLE
fix(git): worktree-add recovers from 'already used by worktree' error

### DIFF
--- a/packages/core/src/__tests__/worktree-stale-recovery.test.ts
+++ b/packages/core/src/__tests__/worktree-stale-recovery.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createWorktree } from "../repo/git.js";
+
+/**
+ * Fixture that mirrors the runner's clone-then-worktree flow. Returns a
+ * "shared" repo dir that holds the .git data and a baseline commit.
+ */
+async function makeBareIshRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "stale-worktree-test-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, stdio: "pipe" });
+  await writeFile(join(dir, "README.md"), "init\n");
+  execFileSync("git", ["add", "."], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+describe("createWorktree — stale-worktree recovery (urateam#112)", () => {
+  let repoDir: string;
+  let baseDir: string;
+
+  beforeEach(async () => {
+    repoDir = await makeBareIshRepo();
+    baseDir = await mkdtemp(join(tmpdir(), "stale-worktree-runs-"));
+  });
+
+  afterEach(async () => {
+    await rm(repoDir, { recursive: true, force: true });
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("first call creates the worktree cleanly", async () => {
+    const wt = await createWorktree(repoDir, "run-1", "agent/iss-1", baseDir);
+    expect(existsSync(wt)).toBe(true);
+    expect(wt).toContain("run-1");
+  });
+
+  it("recovers from 'already checked out' (worktree still on disk)", async () => {
+    // First run creates the worktree — branch is "currently checked out".
+    const firstWt = await createWorktree(repoDir, "run-1", "agent/iss-1", baseDir);
+    expect(existsSync(firstWt)).toBe(true);
+
+    // Second run on the SAME branch, different runId. Without recovery,
+    // git rejects with "fatal: '<branch>' is already checked out at '<path>'".
+    const secondWt = await createWorktree(repoDir, "run-2", "agent/iss-1", baseDir);
+    expect(existsSync(secondWt)).toBe(true);
+    expect(secondWt).toContain("run-2");
+    // The first worktree should have been removed during recovery.
+    expect(existsSync(firstWt)).toBe(false);
+  });
+
+  it("recovers from 'already used by worktree' (worktree dir deleted out from under git)", async () => {
+    // Reproduces the exact rotulus#17-style failure. First run creates
+    // a worktree, then the worktree directory is rm-rf'd WITHOUT
+    // running `git worktree prune`. This leaves the branch ↔ worktree
+    // association in .git/worktrees/ but no on-disk worktree.
+    //
+    // git's error wording for THIS case:
+    //   "fatal: '<branch>' is already used by worktree at '<path>'"
+    // (different from "already checked out" which fires when the dir
+    // still exists). Pre-#112 the recovery branch missed this wording.
+    const firstWt = await createWorktree(repoDir, "run-1", "agent/iss-1", baseDir);
+    expect(existsSync(firstWt)).toBe(true);
+
+    // Rip the worktree dir without telling git about it.
+    await rm(firstWt, { recursive: true, force: true });
+    expect(existsSync(firstWt)).toBe(false);
+
+    // Sanity check: at this point a bare `git worktree add` produces
+    // the "already used by worktree" error.
+    let bareAddErr: string | null = null;
+    try {
+      execFileSync(
+        "git",
+        ["worktree", "add", "-B", "agent/iss-1", join(baseDir, "sanity", "worktree")],
+        { cwd: repoDir, stdio: "pipe" },
+      );
+    } catch (e) {
+      bareAddErr = (e as { stderr?: Buffer }).stderr?.toString() ?? String(e);
+    }
+    expect(bareAddErr).toContain("already used by worktree");
+
+    // Now the real test: createWorktree should auto-recover.
+    const secondWt = await createWorktree(repoDir, "run-2", "agent/iss-1", baseDir);
+    expect(existsSync(secondWt)).toBe(true);
+    expect(secondWt).toContain("run-2");
+  });
+
+  it("propagates unrelated git errors instead of swallowing them", async () => {
+    // Negative control: a git error that's NOT a stale-worktree case
+    // must still reach the caller. Trigger one by passing an invalid
+    // branch character that the SAFE_BRANCH_RE will accept but git
+    // will reject (e.g., a leading dash to make it look like a flag).
+    // We use an invalid PATH instead — pointing baseDir at a file
+    // (not a directory) which makes `git worktree add` fail with a
+    // distinct error.
+    const filePath = join(baseDir, "not-a-dir");
+    await writeFile(filePath, "blocking file");
+    await expect(
+      createWorktree(repoDir, "run-fail", "agent/blocked", filePath),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/core/src/repo/git.ts
+++ b/packages/core/src/repo/git.ts
@@ -119,8 +119,23 @@ export async function fetchLatest(repoDir: string): Promise<void> {
 }
 
 /**
- * Try to add a git worktree. If it fails with "already checked out",
- * force-remove the stale worktree and retry once.
+ * Try to add a git worktree. If it fails because the branch is already
+ * tied to another worktree, force-remove the stale one and retry once.
+ *
+ * Git emits TWO different error wordings for this case (urateam#112):
+ *   - "fatal: '<branch>' is already checked out at '<path>'"
+ *     — fires when the branch is currently checked out in another live
+ *     worktree.
+ *   - "fatal: '<branch>' is already used by worktree at '<path>'"
+ *     — fires when the branch is associated with a worktree even if the
+ *     worktree directory has been deleted out from under git. Common
+ *     after a previous run completed and the worktree dir was cleaned up
+ *     (or rm -rf'd) without `git worktree prune` running.
+ *
+ * Both are recoverable the same way: remove the stale worktree (force +
+ * fall back to rm + prune), retry. The previous version of this function
+ * only matched the first wording; the second produced "pipeline failed
+ * with unexpected error" on every Linear re-trigger after a completed run.
  */
 async function worktreeAddWithRetry(
   repoDir: string,
@@ -133,11 +148,14 @@ async function worktreeAddWithRetry(
     await gitExec(["worktree", "add", ...args], repoDir);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes("already checked out")) throw err;
+    if (!msg.includes("already checked out") && !msg.includes("already used by worktree")) {
+      throw err;
+    }
 
-    // Extract the stale worktree path from the error message:
-    // "fatal: '<branch>' is already checked out at '<path>'"
-    const match = msg.match(/already checked out at '([^']+)'/);
+    // Extract the stale worktree path from either error wording:
+    //   "fatal: '<branch>' is already checked out at '<path>'"
+    //   "fatal: '<branch>' is already used by worktree at '<path>'"
+    const match = msg.match(/already (?:checked out|used by worktree) at '([^']+)'/);
     const stalePath = match?.[1];
     if (stalePath) {
       log.warn({ stalePath, worktreePath }, "removing stale worktree blocking branch checkout");


### PR DESCRIPTION
## Summary

Closes urateam#112. The runner's \`worktreeAddWithRetry\` caught one git error wording but not the other, leaving a common operator workflow ("close PR, re-trigger Linear issue without manually cleaning \`/tmp/agent-runs/\`") to crash with a raw git error.

## Root cause

Two parallel git error wordings, both recoverable the same way:

```
fatal: '<branch>' is already checked out at '<path>'      ← already handled
fatal: '<branch>' is already used by worktree at '<path>' ← was crashing
```

The latter fires when a branch is associated with a worktree even if the worktree directory has been deleted out from under git (e.g., \`rm -rf /tmp/agent-runs/...\` without \`git worktree prune\` — the rotulus#17 OSS validation rerun reproducer).

## Fix

- Extend the error-pattern check to catch both wordings: \`already checked out\` OR \`already used by worktree\`.
- Update the stale-path extraction regex to match either form.
- Recovery path unchanged (force-remove → fall back to rm + prune → retry).

## Test plan

- [x] \`pnpm --filter @urateam/core build\` (typecheck)
- [x] \`pnpm --filter @urateam/core test\` — 1206 tests pass

New \`worktree-stale-recovery.test.ts\` (4 tests):
- First-time creation
- Recovers from "already checked out" (worktree dir still on disk)
- Recovers from "already used by worktree" (worktree dir deleted) — the exact rotulus#17 reproducer
- Negative control: unrelated git errors propagate

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)