### PR TITLE
chore(release): bump core 0.1.12 + cascade cli 0.1.9 + dashboard 0.1.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Ships PR #113 (urateam #112) — worktree recovery now handles the "already used by worktree" git error wording in addition to "already checked out".

| Package | From | To |
|---|---|---|
| \`@urateam/core\` | 0.1.11 | 0.1.12 |
| \`@urateam/cli\` | 0.1.8 | 0.1.9 |
| \`@urateam/dashboard\` | 0.1.7 | 0.1.8 |
| \`create-urateam\` | 0.1.8 | unchanged |

## After merge

Tag \`v0.1.16\` → publish workflow ships all 3 packages with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)