### PR TITLE
feat(test-quality): detect constant-self-equality stubs (expect(X).toBe(X))

### DIFF
--- a/packages/core/src/__tests__/test-quality.test.ts
+++ b/packages/core/src/__tests__/test-quality.test.ts
@@ -377,6 +377,101 @@ it("throws on bad input", () => { expect(() => sum(null, 2)).toThrow(); });
     expect(typeof v.fix).toBe("string");
   });
 
+  // ---------------------------------------------------------------------------
+  // urateam#97 / rotulus#17 PR #18: constant-self-equality stub detection
+  // ---------------------------------------------------------------------------
+  it("flags constant-self-equality stubs even when buried among real assertions (rotulus#17 case)", async () => {
+    // Reproduces the PR #18 regression: nav test file had 4 stubs of the
+    // form `expect(BRAND_COLOR).toBe(BRAND_COLOR)` mixed in with many
+    // real behavioral assertions. Pre-fix, the stubs counted as
+    // "behavioral" (toBe matcher), the file's trivialRatio stayed below
+    // the 0.8 threshold, and the file was NOT flagged. Post-fix, the
+    // stubs are reclassified to trivial AND any non-zero stubAssertions
+    // unconditionally flags the file.
+    const content = `
+describe("nav constants", () => {
+  it("uses brand color", () => { expect(BRAND_COLOR).toBe(BRAND_COLOR); });
+  it("uses bg color", () => { expect(TAB_BAR_BG).toBe(TAB_BAR_BG); });
+  it("uses inactive color", () => { expect(TAB_INACTIVE_COLOR).toBe(TAB_INACTIVE_COLOR); });
+  it("uses ac3", () => { expect(AC3).toBe(AC3); });
+  it("real test 1", () => { expect(getValue()).toEqual({ a: 1, b: 2 }); });
+  it("real test 2", () => { expect(items).toHaveLength(3); });
+  it("real test 3", () => { expect(spy).toHaveBeenCalledWith("foo"); });
+  it("real test 4", () => { expect(promise).resolves.toEqual("done"); });
+  it("real test 5", () => { expect(error).toThrow("BadInput"); });
+});`;
+    mockReadFile({ [join("/worktree", "nav.test.tsx")]: content });
+
+    const result = await checkTestQuality(["nav.test.tsx"], "/worktree");
+
+    expect(result.analyses[0].stubAssertions).toBe(4);
+    expect(result.analyses[0].isFlagged).toBe(true);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].description).toContain(
+      "4 constant-self-equality stub(s)",
+    );
+  });
+
+  it("reclassifies expect(X).toEqual(X) and toStrictEqual(X) as trivial too", async () => {
+    const content = `
+it("a", () => { expect(VAR).toEqual(VAR); });
+it("b", () => { expect(VAR2).toStrictEqual(VAR2); });
+it("c", () => { expect(real).toBe(42); });`;
+    mockReadFile({ [join("/worktree", "x.test.ts")]: content });
+
+    const result = await checkTestQuality(["x.test.ts"], "/worktree");
+    const a = result.analyses[0];
+    expect(a.stubAssertions).toBe(2);
+    // Real `toBe(42)` stays behavioral.
+    expect(a.behavioralAssertions).toBe(1);
+    // Trivial pool gains the 2 stubs (despite using behavioral matchers).
+    expect(a.trivialAssertions).toBe(2);
+    expect(a.isFlagged).toBe(true);
+  });
+
+  it("matches member-access identifiers (expect(obj.foo).toBe(obj.foo))", async () => {
+    const content = `it("a", () => { expect(config.brandColor).toBe(config.brandColor); });`;
+    mockReadFile({ [join("/worktree", "y.test.ts")]: content });
+    const result = await checkTestQuality(["y.test.ts"], "/worktree");
+    expect(result.analyses[0].stubAssertions).toBe(1);
+    expect(result.analyses[0].isFlagged).toBe(true);
+  });
+
+  it("does NOT flag expect(X).toBe(Y) when identifiers differ (negative control)", async () => {
+    const content = `
+it("a", () => { expect(actual).toBe(expected); });
+it("b", () => { expect(brandColor).toBe(theme.brandColor); });
+it("c", () => { expect(items).toEqual([1, 2, 3]); });`;
+    mockReadFile({ [join("/worktree", "z.test.ts")]: content });
+
+    const result = await checkTestQuality(["z.test.ts"], "/worktree");
+    expect(result.analyses[0].stubAssertions).toBe(0);
+    expect(result.analyses[0].behavioralAssertions).toBe(3);
+    expect(result.analyses[0].isFlagged).toBe(false);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it("flags a file where ONE test has a constant-self-equality stub (no dilution-grace)", async () => {
+    // The diluted-ratio defense was the rotulus#17 regression. Even one
+    // stub in a file with otherwise-real tests should fire the flag.
+    const content = `
+it("real 1", () => { expect(a).toEqual({ x: 1 }); });
+it("real 2", () => { expect(b).toHaveLength(5); });
+it("stub", () => { expect(THEME).toBe(THEME); });
+it("real 3", () => { expect(spy).toHaveBeenCalledWith("ok"); });`;
+    mockReadFile({ [join("/worktree", "mixed.test.ts")]: content });
+
+    const result = await checkTestQuality(["mixed.test.ts"], "/worktree");
+    const a = result.analyses[0];
+    expect(a.stubAssertions).toBe(1);
+    expect(a.behavioralAssertions).toBe(3); // 3 real, 1 stub reclassified out
+    // Trivial ratio is 1/4 = 25% — way below the 0.8 threshold. Pre-fix
+    // this would NOT have been flagged. Post-fix the unconditional
+    // stub-count flag fires.
+    expect(a.trivialRatio).toBeLessThan(TRIVIAL_THRESHOLD);
+    expect(a.isFlagged).toBe(true);
+  });
+
   it("identifies BEC-52 pattern: 13 tests all with toBeDefined", async () => {
     // Reproduce the problematic BEC-52 dashboard server.test.ts pattern
     const tests = Array.from(

--- a/packages/core/src/executor/test-quality.ts
+++ b/packages/core/src/executor/test-quality.ts
@@ -105,6 +105,26 @@ export const BEHAVIORAL_MATCHERS = [
 export const TRIVIAL_THRESHOLD = 0.8;
 
 /**
+ * Regex for "constant-self-equality" stubs: `expect(X).toBe(X)`,
+ * `expect(X).toEqual(X)`, or `expect(X).toStrictEqual(X)` where the
+ * same identifier (possibly with member access like `obj.foo`) appears on
+ * both sides. These use behavioral matchers but assert a tautology
+ * (X === X) — which is always true and verifies nothing meaningful.
+ *
+ * Reclassified as trivial in countAssertions(). Triggers an unconditional
+ * flag (not just when the file's overall trivial ratio is high) — these
+ * patterns are unambiguous stubs and shouldn't ship even when diluted
+ * by real assertions elsewhere in the file.
+ *
+ * Pattern observed in rotulus#17 PR #18 where the agent left
+ * `expect(BRAND_COLOR).toBe(BRAND_COLOR)` and similar stubs intact —
+ * the previous detector counted them as behavioral and the file passed.
+ * See urateam#97 evidence comment.
+ */
+export const CONSTANT_SELF_EQUALITY_PATTERN =
+  /\bexpect\s*\(\s*([\w$][\w$.]*)\s*\)\s*\.(?:toBe|toEqual|toStrictEqual)\s*\(\s*\1\s*\)/g;
+
+/**
  * Glob-style test file name patterns.
  */
 const TEST_FILE_PATTERNS = [
@@ -121,10 +141,16 @@ export interface TestFileAnalysis {
   file: string;
   /** Total assertions (trivial + behavioral) */
   totalAssertions: number;
-  /** Number of trivial assertions */
+  /** Number of trivial assertions (includes constant-self-equality stubs) */
   trivialAssertions: number;
   /** Number of behavioral assertions */
   behavioralAssertions: number;
+  /**
+   * Number of constant-self-equality stubs (`expect(X).toBe(X)` etc).
+   * Subset of trivialAssertions — already counted there. Tracked
+   * separately so the violation description can call them out specifically.
+   */
+  stubAssertions: number;
   /** Ratio of trivial to total (0–1) */
   trivialRatio: number;
   /** Test function names that contain no behavioral assertion */
@@ -184,9 +210,25 @@ export function extractTestBlocks(content: string): Array<{ name: string; conten
 }
 
 /**
- * Counts how many times each assertion group appears in the given content.
+ * Counts the number of constant-self-equality stubs in the given content.
+ * Resets the regex `lastIndex` defensively since the pattern is /g.
  */
-function countAssertions(content: string): { trivial: number; behavioral: number } {
+function countStubAssertions(content: string): number {
+  CONSTANT_SELF_EQUALITY_PATTERN.lastIndex = 0;
+  return Array.from(content.matchAll(CONSTANT_SELF_EQUALITY_PATTERN)).length;
+}
+
+/**
+ * Counts how many times each assertion group appears in the given content.
+ * Constant-self-equality stubs (e.g. `expect(X).toBe(X)`) are reclassified
+ * from behavioral to trivial — they use behavioral matchers but assert a
+ * tautology and verify nothing.
+ */
+function countAssertions(content: string): {
+  trivial: number;
+  behavioral: number;
+  stubs: number;
+} {
   const trivialPattern = new RegExp(
     `\\.(?:${TRIVIAL_MATCHERS.join("|")})\\s*\\(`,
     "g",
@@ -196,10 +238,19 @@ function countAssertions(content: string): { trivial: number; behavioral: number
     "g",
   );
 
-  const trivial = (content.match(trivialPattern) ?? []).length;
-  const behavioral = (content.match(behavioralPattern) ?? []).length;
+  const rawTrivial = (content.match(trivialPattern) ?? []).length;
+  const rawBehavioral = (content.match(behavioralPattern) ?? []).length;
+  const stubs = countStubAssertions(content);
 
-  return { trivial, behavioral };
+  // Each stub match was originally counted in the behavioral pool (the
+  // matcher is toBe / toEqual / toStrictEqual). Move them to trivial.
+  // Math.max guards against arithmetic surprises if the regex ever picks
+  // up something the behavioral counter doesn't (unlikely but defensive).
+  return {
+    trivial: rawTrivial + stubs,
+    behavioral: Math.max(0, rawBehavioral - stubs),
+    stubs,
+  };
 }
 
 /**
@@ -217,6 +268,7 @@ export async function analyzeTestFile(filePath: string): Promise<TestFileAnalysi
       totalAssertions: 0,
       trivialAssertions: 0,
       behavioralAssertions: 0,
+      stubAssertions: 0,
       trivialRatio: 0,
       testsWithoutBehavioralAssertion: [],
       isFlagged: false,
@@ -224,8 +276,11 @@ export async function analyzeTestFile(filePath: string): Promise<TestFileAnalysi
   }
 
   // File-level counts
-  const { trivial: trivialAssertions, behavioral: behavioralAssertions } =
-    countAssertions(content);
+  const {
+    trivial: trivialAssertions,
+    behavioral: behavioralAssertions,
+    stubs: stubAssertions,
+  } = countAssertions(content);
   const totalAssertions = trivialAssertions + behavioralAssertions;
   const trivialRatio = totalAssertions === 0 ? 0 : trivialAssertions / totalAssertions;
 
@@ -244,13 +299,18 @@ export async function analyzeTestFile(filePath: string): Promise<TestFileAnalysi
 
   const isFlagged =
     (totalAssertions > 0 && trivialRatio > TRIVIAL_THRESHOLD) ||
-    (testBlocks.length > 0 && testsWithoutBehavioralAssertion.length === testBlocks.length);
+    (testBlocks.length > 0 && testsWithoutBehavioralAssertion.length === testBlocks.length) ||
+    // Constant-self-equality stubs are unambiguous regression markers — flag
+    // even one (the rotulus#17 PR #18 case where 4 such stubs slipped through
+    // the diluted-ratio check on a file with otherwise-real assertions).
+    stubAssertions > 0;
 
   return {
     file: filePath,
     totalAssertions,
     trivialAssertions,
     behavioralAssertions,
+    stubAssertions,
     trivialRatio,
     testsWithoutBehavioralAssertion,
     isFlagged,
@@ -299,6 +359,13 @@ export async function checkTestQuality(
       );
     }
 
+    if (analysis.stubAssertions > 0) {
+      details.push(
+        `${analysis.stubAssertions} constant-self-equality stub(s) — ` +
+          `expect(X).toBe(X) / .toEqual(X) tautologies that always pass`,
+      );
+    }
+
     if (analysis.testsWithoutBehavioralAssertion.length > 0) {
       const names = analysis.testsWithoutBehavioralAssertion.slice(0, 3).join(", ");
       const extra =
@@ -330,6 +397,7 @@ export async function checkTestQuality(
         trivialRatio: analysis.trivialRatio,
         trivialAssertions: analysis.trivialAssertions,
         behavioralAssertions: analysis.behavioralAssertions,
+        stubAssertions: analysis.stubAssertions,
         testsWithoutBehavioralAssertion: analysis.testsWithoutBehavioralAssertion.length,
       },
       "test-quality: flagged file with low-quality assertions",


### PR DESCRIPTION
## Summary

Closes the deterministic-detector gap exposed by rotulus#17 PR #18 (per [urateam#97 evidence comment](https://github.com/JonB32/urateam/issues/97#issuecomment-4323869706)). Pre-fix, agent-emitted stubs of the form \`expect(BRAND_COLOR).toBe(BRAND_COLOR)\` counted as behavioral assertions, so when mixed with real ones the file's overall trivial ratio stayed below the 0.8 threshold and the detector silently approved them.

## Fix

- **\`CONSTANT_SELF_EQUALITY_PATTERN\`** regex matches \`expect(X).toBe(X)\`, \`expect(X).toEqual(X)\`, \`expect(X).toStrictEqual(X)\` where the same identifier (with optional member access) appears on both sides — i.e., the assertion is a tautology.
- Stub matches reclassified from behavioral → trivial in \`countAssertions\`.
- New \`stubAssertions\` field on \`TestFileAnalysis\` tracks the count separately so the violation description can call them out specifically.
- \`isFlagged\` now fires unconditionally when \`stubAssertions > 0\` — diluted-ratio defense was the rotulus#17 regression and stubs are unambiguous regardless of file context.

## What this does NOT fix

- \`toBeTruthy()\` on render-result / \`UNSAFE_root\` patterns. Those are already trivial via the existing matcher — distinguishing them from legitimate truthiness checks needs symbol-table analysis the regex-based detector can't do.
- Agent prompt regression itself. Detector is the deterministic guardrail; prompt updates needed to prevent emission. Tracked in #97.

## Test plan

- [x] \`pnpm --filter @urateam/core build\` (typecheck)
- [x] \`pnpm --filter @urateam/core test\` — 1213 tests pass (was 1208; +5)

5 new tests:
- Rotulus#17 exact pattern (4 stubs + 5 real assertions, pre-fix unflagged, post-fix flagged)
- \`toEqual\` + \`toStrictEqual\` reclassification
- Member-access identifiers (\`config.brandColor\`)
- Negative control: different identifiers stay behavioral
- Single-stub in otherwise-real file fires the new unconditional flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)