### PR TITLE
chore(release): bump core 0.1.14 + cascade cli 0.1.11 + dashboard 0.1.10

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Ships PR #118 (TestQuality detector — constant-self-equality stub detection).

| Package | From | To |
|---|---|---|
| \`@urateam/core\` | 0.1.13 | 0.1.14 |
| \`@urateam/cli\` | 0.1.10 | 0.1.11 |
| \`@urateam/dashboard\` | 0.1.9 | 0.1.10 |
| \`create-urateam\` | 0.1.8 | unchanged |

## After merge

Tag \`v0.1.18\` → publish workflow ships all 3 with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)