### PR TITLE
fix(core): retry visibility (#121) + stage progress watchdog (#122)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/__tests__/agent-stream.test.ts
+++ b/packages/core/src/__tests__/agent-stream.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { consumeAgentStream, StageStalledError } from "../executor/agent-stream.js";
+
+async function* fromArray(items: Array<unknown>): AsyncIterable<unknown> {
+  for (const item of items) yield item;
+}
+
+/** Async iterable that yields the given items, then sleeps forever. */
+async function* hangsAfter(items: Array<unknown>): AsyncIterable<unknown> {
+  for (const item of items) yield item;
+  await new Promise(() => {}); // never resolves
+}
+
+/** Async iterable where each yield is delayed by `delayMs` and emits an output_tokens bump. */
+async function* tokenStream(count: number, delayMs: number): AsyncIterable<unknown> {
+  for (let i = 0; i < count; i++) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    yield { type: "assistant", usage: { output_tokens: 5 }, content: [{ type: "text", text: `chunk ${i}` }] };
+  }
+}
+
+describe("consumeAgentStream — basic behavior", () => {
+  it("accumulates token usage across messages", async () => {
+    const result = await consumeAgentStream(
+      fromArray([
+        { usage: { input_tokens: 100, output_tokens: 50 } },
+        { usage: { input_tokens: 20, output_tokens: 30 } },
+      ]),
+    );
+    expect(result.inputTokens).toBe(120);
+    expect(result.outputTokens).toBe(80);
+  });
+
+  it("counts assistant messages as turns and extracts last text", async () => {
+    const result = await consumeAgentStream(
+      fromArray([
+        { type: "assistant", content: [{ type: "text", text: "first" }] },
+        { type: "assistant", content: [{ type: "text", text: "last" }] },
+      ]),
+    );
+    expect(result.turns).toBe(2);
+    expect(result.lastText).toBe("last");
+  });
+});
+
+describe("consumeAgentStream — stall watchdog (urateam#122)", () => {
+  it("throws StageStalledError when the iterator hangs longer than progressTimeoutMs", async () => {
+    await expect(
+      consumeAgentStream(hangsAfter([{ type: "assistant", content: [{ type: "text", text: "ok" }] }]), {
+        progressTimeoutMs: 80,
+      }),
+    ).rejects.toBeInstanceOf(StageStalledError);
+  });
+
+  it("includes last observed stats in the StageStalledError", async () => {
+    try {
+      await consumeAgentStream(
+        hangsAfter([
+          { type: "assistant", usage: { output_tokens: 12 }, content: [{ type: "text", text: "hi" }] },
+        ]),
+        { progressTimeoutMs: 80 },
+      );
+      throw new Error("expected StageStalledError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StageStalledError);
+      const stalled = err as StageStalledError;
+      expect(stalled.lastStats.turns).toBe(1);
+      expect(stalled.lastStats.outputTokens).toBe(12);
+      expect(stalled.stalledForMs).toBeGreaterThanOrEqual(80);
+    }
+  });
+
+  it("does NOT fire when output tokens keep advancing within the window", async () => {
+    // 4 chunks at 30ms each = 120ms total. Window is 100ms but resets on each token bump.
+    const result = await consumeAgentStream(tokenStream(4, 30), { progressTimeoutMs: 100 });
+    expect(result.turns).toBe(4);
+    expect(result.outputTokens).toBe(20);
+  });
+
+  it("fires when messages keep arriving but no output tokens / turns advance", async () => {
+    // Reproduction of the ROT-15 zombie pattern: messageCount advances slowly, but
+    // turns and outputTokens stay flat. Watchdog must catch this.
+    async function* zombieStream(): AsyncIterable<unknown> {
+      // First a real assistant message to seed lastTokenAdvanceAt.
+      yield { type: "assistant", usage: { output_tokens: 5 }, content: [{ type: "text", text: "start" }] };
+      // Then a slow drip of non-progress messages (system events with no tokens, no turns).
+      for (let i = 0; i < 20; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        yield { type: "system" };
+      }
+    }
+    await expect(
+      consumeAgentStream(zombieStream(), { progressTimeoutMs: 60 }),
+    ).rejects.toBeInstanceOf(StageStalledError);
+  });
+});

--- a/packages/core/src/__tests__/agent-stream.test.ts
+++ b/packages/core/src/__tests__/agent-stream.test.ts
@@ -47,7 +47,7 @@ describe("consumeAgentStream — stall watchdog (urateam#122)", () => {
   it("throws StageStalledError when the iterator hangs longer than progressTimeoutMs", async () => {
     await expect(
       consumeAgentStream(hangsAfter([{ type: "assistant", content: [{ type: "text", text: "ok" }] }]), {
-        progressTimeoutMs: 80,
+        progressTimeoutMs: 200,
       }),
     ).rejects.toBeInstanceOf(StageStalledError);
   });
@@ -58,7 +58,7 @@ describe("consumeAgentStream — stall watchdog (urateam#122)", () => {
         hangsAfter([
           { type: "assistant", usage: { output_tokens: 12 }, content: [{ type: "text", text: "hi" }] },
         ]),
-        { progressTimeoutMs: 80 },
+        { progressTimeoutMs: 200 },
       );
       throw new Error("expected StageStalledError");
     } catch (err) {
@@ -66,13 +66,14 @@ describe("consumeAgentStream — stall watchdog (urateam#122)", () => {
       const stalled = err as StageStalledError;
       expect(stalled.lastStats.turns).toBe(1);
       expect(stalled.lastStats.outputTokens).toBe(12);
-      expect(stalled.stalledForMs).toBeGreaterThanOrEqual(80);
+      expect(stalled.stalledForMs).toBeGreaterThanOrEqual(200);
     }
   });
 
   it("does NOT fire when output tokens keep advancing within the window", async () => {
-    // 4 chunks at 30ms each = 120ms total. Window is 100ms but resets on each token bump.
-    const result = await consumeAgentStream(tokenStream(4, 30), { progressTimeoutMs: 100 });
+    // 4 chunks at 30ms each = 120ms total. Window is 250ms but resets on each token bump.
+    // Generous slack (130ms+) keeps this from flaking under loaded CI.
+    const result = await consumeAgentStream(tokenStream(4, 30), { progressTimeoutMs: 250 });
     expect(result.turns).toBe(4);
     expect(result.outputTokens).toBe(20);
   });
@@ -90,7 +91,7 @@ describe("consumeAgentStream — stall watchdog (urateam#122)", () => {
       }
     }
     await expect(
-      consumeAgentStream(zombieStream(), { progressTimeoutMs: 60 }),
+      consumeAgentStream(zombieStream(), { progressTimeoutMs: 200 }),
     ).rejects.toBeInstanceOf(StageStalledError);
   });
 });

--- a/packages/core/src/executor/agent-stream.ts
+++ b/packages/core/src/executor/agent-stream.ts
@@ -19,6 +19,25 @@ export interface ConsumeResult {
 }
 
 /**
+ * Thrown when a stage's agent stream makes no observable progress
+ * (no new output tokens or assistant turns) for `progressTimeoutMs`.
+ * See urateam#122 — without this watchdog, an SDK stuck on internal
+ * rate-limit-or-auth retry loops could keep a stage "running" for hours.
+ */
+export class StageStalledError extends Error {
+  constructor(
+    public readonly stalledForMs: number,
+    public readonly lastStats: { messageCount: number; turns: number; inputTokens: number; outputTokens: number },
+  ) {
+    super(
+      `stage stalled — no token/turn progress in ${Math.round(stalledForMs / 1000)}s ` +
+        `(messageCount=${lastStats.messageCount}, turns=${lastStats.turns}, outputTokens=${lastStats.outputTokens})`,
+    );
+    this.name = "StageStalledError";
+  }
+}
+
+/**
  * Consume an Agent SDK message stream, accumulating token usage and
  * extracting the last assistant text content.
  *
@@ -33,6 +52,11 @@ export async function consumeAgentStream(
     /** Called periodically (every progressIntervalMs) with current stats */
     onProgress?: (stats: { messageCount: number; turns: number; inputTokens: number; outputTokens: number }) => void;
     progressIntervalMs?: number;
+    /**
+     * Throw StageStalledError if no new outputTokens or turns arrive in this window.
+     * Default 30 minutes. See urateam#122.
+     */
+    progressTimeoutMs?: number;
   },
 ): Promise<ConsumeResult> {
   let inputTokens = 0;
@@ -41,10 +65,41 @@ export async function consumeAgentStream(
   let lastText = "";
   let messageCount = 0;
   let lastProgressTime = Date.now();
+  let lastTokenAdvanceAt = Date.now();
   const progressInterval = options?.progressIntervalMs ?? 30_000;
+  const stallTimeoutMs = options?.progressTimeoutMs ?? 30 * 60_000;
 
-  for await (const rawMessage of messages) {
-    const message = rawMessage as StreamMessage;
+  const iterator = (messages as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+  while (true) {
+    const remainingUntilStall = stallTimeoutMs - (Date.now() - lastTokenAdvanceAt);
+    let stallTimer: ReturnType<typeof setTimeout> | undefined;
+    const stallSentinel: unique symbol = Symbol("stall") as unknown as never;
+    const next = iterator.next();
+    const stallPromise = new Promise<typeof stallSentinel>((resolve) => {
+      stallTimer = setTimeout(() => resolve(stallSentinel), Math.max(remainingUntilStall, 0));
+    });
+
+    const raced = await Promise.race([next, stallPromise]);
+    if (stallTimer) clearTimeout(stallTimer);
+
+    if (raced === stallSentinel) {
+      // Fire-and-forget cleanup — when the agent generator is paused on a
+      // never-resolving await (the exact zombie pattern from urateam#122),
+      // awaiting iterator.return() would hang forever waiting for that
+      // await to settle. Best-effort signal; let the GC handle the rest.
+      iterator.return?.().catch(() => {});
+      throw new StageStalledError(Date.now() - lastTokenAdvanceAt, {
+        messageCount,
+        turns,
+        inputTokens,
+        outputTokens,
+      });
+    }
+
+    const result = raced as IteratorResult<unknown>;
+    if (result.done) break;
+
+    const message = result.value as StreamMessage;
     messageCount++;
 
     if (options?.onProgress && Date.now() - lastProgressTime >= progressInterval) {
@@ -52,6 +107,7 @@ export async function consumeAgentStream(
       lastProgressTime = Date.now();
     }
 
+    const prevOutputTokens = outputTokens;
     if (message.usage) {
       inputTokens += message.usage.input_tokens ?? 0;
       outputTokens += message.usage.output_tokens ?? 0;
@@ -82,6 +138,13 @@ export async function consumeAgentStream(
 
     if (message.type === "assistant") {
       turns++;
+    }
+
+    // Reset stall watchdog on real progress (output tokens advance OR a turn was added).
+    // messageCount alone is NOT enough — see urateam#122 reproduction where
+    // messageCount kept advancing but turns/outputTokens stayed flat for 8h.
+    if (outputTokens > prevOutputTokens || message.type === "assistant") {
+      lastTokenAdvanceAt = Date.now();
     }
   }
 

--- a/packages/core/src/executor/agent-stream.ts
+++ b/packages/core/src/executor/agent-stream.ts
@@ -53,8 +53,14 @@ export async function consumeAgentStream(
     onProgress?: (stats: { messageCount: number; turns: number; inputTokens: number; outputTokens: number }) => void;
     progressIntervalMs?: number;
     /**
-     * Throw StageStalledError if no new outputTokens or turns arrive in this window.
-     * Default 30 minutes. See urateam#122.
+     * Throw StageStalledError if no new outputTokens or assistant turns arrive
+     * in this window. Default 30 minutes. See urateam#122.
+     *
+     * NOTE: tool_use / tool_result messages do NOT reset this timer. The
+     * ROT-15 zombie pattern emitted system messages while stuck, but a
+     * legitimate long-running tool call (e.g. a 30+ min build) also produces
+     * no assistant turns until the tool returns. If your stage runs slow
+     * tool calls, raise this value (or chunk the work).
      */
     progressTimeoutMs?: number;
   },
@@ -70,33 +76,46 @@ export async function consumeAgentStream(
   const stallTimeoutMs = options?.progressTimeoutMs ?? 30 * 60_000;
 
   const iterator = (messages as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+  const STALLED = { __stalled: true } as const;
+  type StallSentinel = typeof STALLED;
   while (true) {
     const remainingUntilStall = stallTimeoutMs - (Date.now() - lastTokenAdvanceAt);
     let stallTimer: ReturnType<typeof setTimeout> | undefined;
-    const stallSentinel: unique symbol = Symbol("stall") as unknown as never;
-    const next = iterator.next();
-    const stallPromise = new Promise<typeof stallSentinel>((resolve) => {
-      stallTimer = setTimeout(() => resolve(stallSentinel), Math.max(remainingUntilStall, 0));
+    let nextSettled = false;
+    let nextValue: IteratorResult<unknown> | undefined;
+    const next = iterator.next().then((v) => {
+      nextSettled = true;
+      nextValue = v;
+      return v;
+    });
+    const stallPromise = new Promise<StallSentinel>((resolve) => {
+      stallTimer = setTimeout(() => resolve(STALLED), Math.max(remainingUntilStall, 0));
     });
 
     const raced = await Promise.race([next, stallPromise]);
     if (stallTimer) clearTimeout(stallTimer);
 
-    if (raced === stallSentinel) {
-      // Fire-and-forget cleanup — when the agent generator is paused on a
-      // never-resolving await (the exact zombie pattern from urateam#122),
-      // awaiting iterator.return() would hang forever waiting for that
-      // await to settle. Best-effort signal; let the GC handle the rest.
-      iterator.return?.().catch(() => {});
-      throw new StageStalledError(Date.now() - lastTokenAdvanceAt, {
-        messageCount,
-        turns,
-        inputTokens,
-        outputTokens,
-      });
+    if (raced === STALLED) {
+      // Defensive race-loss check: if the iterator settled in the same tick
+      // as the timer fired, prefer the message we already have. The
+      // microtask vs macrotask ordering in V8 makes this near-impossible
+      // in practice, but the cost is one boolean check.
+      if (!(nextSettled && nextValue && !nextValue.done)) {
+        // Fire-and-forget cleanup — when the agent generator is paused on a
+        // never-resolving await (the exact zombie pattern from urateam#122),
+        // awaiting iterator.return() would hang forever waiting for that
+        // await to settle. Best-effort signal; let the GC handle the rest.
+        iterator.return?.().catch(() => {});
+        throw new StageStalledError(Date.now() - lastTokenAdvanceAt, {
+          messageCount,
+          turns,
+          inputTokens,
+          outputTokens,
+        });
+      }
     }
 
-    const result = raced as IteratorResult<unknown>;
+    const result = (raced === STALLED ? nextValue! : raced) as IteratorResult<unknown>;
     if (result.done) break;
 
     const message = result.value as StreamMessage;

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -965,6 +965,17 @@ export class PipelineRunner {
         ) {
           for (let attempt = 0; attempt < config.retry.maxAttempts; attempt++) {
             if (config.retry.strategy === "fix-and-retry") {
+              runLog.warn(
+                {
+                  stage: stageType,
+                  attempt: attempt + 1,
+                  maxAttempts: config.retry.maxAttempts,
+                  prevError: result.errorMessage ?? "stage failed",
+                },
+                "stage failed — restarting (urateam#121)",
+              );
+              run.stageRetries ??= {};
+              run.stageRetries[stageType] = (run.stageRetries[stageType] ?? 0) + 1;
               result = await executeStage({
                 runId,
                 issueId: sanitizedIssue.id,
@@ -2032,6 +2043,9 @@ export class PipelineRunner {
         .where(eq(pipelineRuns.id, runId));
       run.status = "completed";
 
+      const totalStageRetries = run.stageRetries
+        ? Object.values(run.stageRetries).reduce((a, b) => a + b, 0)
+        : 0;
       runLog.info(
         {
           prUrl: prUrl || undefined,
@@ -2039,6 +2053,9 @@ export class PipelineRunner {
           autoCommitted: run.autoCommitted ?? false,
           totalInputTokens: run.totalInputTokens,
           totalOutputTokens: run.totalOutputTokens,
+          ...(totalStageRetries > 0
+            ? { stageRetries: run.stageRetries, totalStageRetries }
+            : {}),
         },
         "pipeline completed",
       );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -338,7 +338,14 @@ export interface PipelineRun {
   autoMergeReason?: string;
   /** True when auto-commit was triggered because the agent did not commit its work. Quality metric. */
   autoCommitted?: boolean;
-  /** In-memory only: count of retries per stage. Surfaces silent retry attempts in logs. */
+  /**
+   * In-memory only: count of retries per stage. Surfaces silent retry attempts
+   * in the "pipeline completed" log when non-zero.
+   *
+   * TODO(urateam#121): persist to DB so the dashboard can show retry counts on
+   * completed runs, and so transient-retry resumes (which reload the run from
+   * DB) carry the count forward.
+   */
   stageRetries?: Record<string, number>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -338,6 +338,8 @@ export interface PipelineRun {
   autoMergeReason?: string;
   /** True when auto-commit was triggered because the agent did not commit its work. Quality metric. */
   autoCommitted?: boolean;
+  /** In-memory only: count of retries per stage. Surfaces silent retry attempts in logs. */
+  stageRetries?: Record<string, number>;
 }
 
 // --- Pipeline Result / Error ---


### PR DESCRIPTION
Fixes urateam#121 and urateam#122. Found while running rotulus ROT-15 against published packages — see the issues for the reproduction logs.

## Two atomic commits

### `3747a37` — Retry visibility (#121)

The runner.ts `fix-and-retry` loop was silent. When a stage failed and was retried, the log just showed a fresh "importing Agent SDK" / "starting agent query" with no signal that anything had failed. On ROT-15 the review stage silently restarted **three times**, burning 3× tokens for the same work — operators had no way to see this.

**Change:** every retry emits a warn log `"stage failed — restarting (urateam#121)"` with `attempt N/M` and the previous error message. PipelineRun tracks per-stage retries in memory (`stageRetries: Record<string, number>`), and the final `"pipeline completed"` log includes the breakdown when any were non-zero.

### `6b5fa3b` — Stage progress watchdog (#122)

The executor had no kill-on-stall. On ROT-15 the implement stage ran for **8 hours** with messageCount slowly advancing (122→153) but turns staying flat at 73 — classic SDK-stuck-on-retry-loop pattern. The heartbeat happily reported "stage still in progress" the whole time.

**Change:** `consumeAgentStream` now races each `iterator.next()` against a stall timer. The timer only resets on real progress signals (output tokens advance OR an assistant turn arrives) — messageCount alone is *not* enough, because the ROT-15 reproduction had messageCount creeping up while no real work happened. When the timer wins, throws a new `StageStalledError` with last-observed stats. The error bubbles into the existing retry loop, which now logs the restart visibly thanks to commit 1.

Default 30 min, configurable via `progressTimeoutMs`. Bumps core 0.1.14 → 0.1.15.

## Test coverage

**New: `agent-stream.test.ts` — 6 tests**
- Existing behavior: token accumulation, turn counting, lastText extraction
- Watchdog: throws StageStalledError when iterator hangs
- Watchdog: error includes last-observed stats (turns, outputTokens)
- Watchdog: does NOT fire when output tokens advance within window
- Watchdog: **fires when messages keep arriving but tokens/turns stay flat** — exact ROT-15 zombie pattern

**Not added: integration test for the runner.ts retry-log path.** The change is purely additive (one warn log + one increment) and the runner's full dependency tree (notifier, gh CLI, git, DB) is heavy to mock cleanly. Open to adding one if reviewer flags it as a blocker — please push back if so.

## Verification

- core: 1219/1219 tests pass (1213 prior + 6 new)
- TS build: clean
- Reproduces from ROT-15 logs would now show: silent retries surfaced as warn logs + 8h zombie killed at 30min with StageStalledError → which itself triggers the visible retry log

🤖 Generated with [Claude Code](https://claude.com/claude-code)