### PR TITLE
chore(release): cascade dashboard 0.1.10→0.1.11 (re-pin core@0.1.15)

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Why

\`@urateam/dashboard\` declares \`@urateam/core\` as \`workspace:*\`, which pnpm re-pins to the current workspace version at publish time. The last published \`dashboard@0.1.10\` was built against \`core@0.1.14\`. After v0.1.19 (which shipped \`core@0.1.15\` with #121 + #122 fixes), consumers installing \`dashboard@0.1.10\` would get \`core@0.1.14\` transitively — missing the watchdog and retry-visibility fixes.

This bump is a pure cascade re-pin. No dashboard runtime behavior changes.

## Verification

- Dashboard build: clean
- Dashboard tests: 194/194 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)