### PR TITLE
fix(create-urateam): tier→features expansion + license/webhook-secret hardening

### DIFF
--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -503,7 +503,9 @@ describe("scaffold — production options", () => {
     expect(env).not.toMatch(/^PM_AGENT_ENABLED=true/m);
   });
 
-  it("leaves secrets blank when autoGenSecrets is false", () => {
+  it("leaves DASHBOARD/POSTGRES blank when autoGenSecrets is false", () => {
+    // GITHUB_WEBHOOK_SECRET is no longer auto-generated regardless — it's
+    // shared with GitHub's webhook config and prompted explicitly.
     const projectDir = join(tempDir, "manual-secrets");
     const result = scaffold({
       projectDir,
@@ -517,15 +519,46 @@ describe("scaffold — production options", () => {
     const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
     expect(env).toMatch(/^DASHBOARD_PASSWORD=$/m);
     expect(env).toMatch(/^POSTGRES_PASSWORD=$/m);
-    expect(env).toMatch(/^GITHUB_WEBHOOK_SECRET=$/m);
     expect(result.generatedSecrets).toEqual({});
     expect(result.todos).toEqual(
       expect.arrayContaining([
         expect.stringContaining("DASHBOARD_PASSWORD"),
         expect.stringContaining("POSTGRES_PASSWORD"),
-        expect.stringContaining("GITHUB_WEBHOOK_SECRET"),
       ]),
     );
+  });
+
+  it("never auto-generates GITHUB_WEBHOOK_SECRET (must come from GitHub side)", () => {
+    const projectDir = join(tempDir, "no-gh-secret-autogen");
+    const result = scaffold({
+      projectDir,
+      projectName: "x",
+      linearApiKey: "x",
+      linearTeamId: "t",
+      repoUrl: "https://github.com/o/r",
+      defaultBranch: "main",
+      autoGenSecrets: true, // even when on, GitHub secret stays blank
+    });
+    const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+    // Line is commented when blank, not bare assignment.
+    expect(env).toMatch(/^# GITHUB_WEBHOOK_SECRET=/m);
+    expect(env).not.toMatch(/^GITHUB_WEBHOOK_SECRET=\S/m);
+    expect(result.generatedSecrets.githubWebhookSecret).toBeUndefined();
+  });
+
+  it("emits GITHUB_WEBHOOK_SECRET as a real value when explicitly provided", () => {
+    const projectDir = join(tempDir, "gh-secret-set");
+    scaffold({
+      projectDir,
+      projectName: "x",
+      linearApiKey: "x",
+      linearTeamId: "t",
+      repoUrl: "https://github.com/o/r",
+      defaultBranch: "main",
+      githubWebhookSecret: "my-paste-from-github",
+    });
+    const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+    expect(env).toMatch(/^GITHUB_WEBHOOK_SECRET=my-paste-from-github$/m);
   });
 
   it("returns license info in result when licenseKey decodes", () => {

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -382,6 +382,42 @@ describe("decodeLicense", () => {
     const payload = Buffer.from(JSON.stringify({ tier: "rogue" })).toString("base64url");
     expect(decodeLicense(`x.${payload}.y`)?.tier).toBe("oss");
   });
+
+  it("expands Pro tier to all Pro features when JWT has no explicit features", async () => {
+    // A license issued with `ura license issue --tier pro` (no --features flag)
+    // gets a JWT with no `features` field. Runtime grants all Pro features
+    // implicitly via tier — scaffolder must match that or it'll skip
+    // tier-gated prompts (e.g. PM agent setup) for such licenses.
+    const { decodeLicense } = await import("../index.js");
+    const payload = Buffer.from(
+      JSON.stringify({ tier: "pro", sub: "cust", exp: 2_000_000_000 }),
+    ).toString("base64url");
+    const info = decodeLicense(`x.${payload}.y`);
+    expect(info?.tier).toBe("pro");
+    expect(info?.features).toEqual(
+      expect.arrayContaining(["slack-interface", "deep-review", "multi-repo"]),
+    );
+  });
+
+  it("expands Enterprise tier to all Enterprise features when JWT has no explicit features", async () => {
+    const { decodeLicense } = await import("../index.js");
+    const payload = Buffer.from(JSON.stringify({ tier: "enterprise" })).toString("base64url");
+    const info = decodeLicense(`x.${payload}.y`);
+    expect(info?.features).toEqual(
+      expect.arrayContaining(["slack-interface", "sso", "audit-log", "rbac"]),
+    );
+  });
+
+  it("honors an explicit features array even when shorter than the tier default", async () => {
+    // Operators can issue restricted licenses (e.g. Pro tier minus deep-review).
+    // The explicit list wins.
+    const { decodeLicense } = await import("../index.js");
+    const payload = Buffer.from(
+      JSON.stringify({ tier: "pro", features: ["multi-repo"] }),
+    ).toString("base64url");
+    const info = decodeLicense(`x.${payload}.y`);
+    expect(info?.features).toEqual(["multi-repo"]);
+  });
 });
 
 describe("scaffold — production options", () => {

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -277,7 +277,14 @@ function buildEnv(
   push("# GITHUB_APP_ID=");
   push("# GITHUB_PRIVATE_KEY_PATH=/run/gh-app.pem");
   push("# GITHUB_INSTALLATION_ID=");
-  push(`GITHUB_WEBHOOK_SECRET=${options.githubWebhookSecret}`);
+  // GITHUB_WEBHOOK_SECRET is shared with GitHub's webhook config — only emit
+  // when the operator has pasted a real value. Empty/missing means the
+  // PR-comment re-trigger feature is disabled, which is the expected default.
+  if (options.githubWebhookSecret) {
+    push(`GITHUB_WEBHOOK_SECRET=${options.githubWebhookSecret}`);
+  } else {
+    push("# GITHUB_WEBHOOK_SECRET=  # paste from GitHub webhook config (only needed for PR-comment re-runs)");
+  }
   blank();
 
   push("# === Database ===");
@@ -402,7 +409,12 @@ function resolveSecrets(options: ScaffoldOptions): {
 
   let dashboardPassword = options.dashboardPassword ?? "";
   let postgresPassword = options.postgresPassword ?? "";
-  let githubWebhookSecret = options.githubWebhookSecret ?? "";
+  // GITHUB_WEBHOOK_SECRET is NOT auto-generated. The secret is shared with
+  // GitHub's webhook config — operator either pastes the value GitHub generates
+  // in the webhook UI, OR provides their own and pastes that into both sides.
+  // Auto-generating one only here would mismatch GitHub's value and silently
+  // reject every incoming PR comment.
+  const githubWebhookSecret = options.githubWebhookSecret ?? "";
 
   if (autoGen) {
     // base64url avoids `+`, `/`, `=` which can trip strict env-file parsers
@@ -414,10 +426,6 @@ function resolveSecrets(options: ScaffoldOptions): {
     if (!postgresPassword) {
       postgresPassword = randomBytes(24).toString("base64url");
       generated.postgresPassword = postgresPassword;
-    }
-    if (!githubWebhookSecret) {
-      githubWebhookSecret = randomBytes(32).toString("hex");
-      generated.githubWebhookSecret = githubWebhookSecret;
     }
   }
 
@@ -533,10 +541,11 @@ export function scaffold(options: ScaffoldOptions): ScaffoldResult {
     if (!options.autoGenSecrets) {
       if (!options.dashboardPassword) todos.push("DASHBOARD_PASSWORD — fill in .env.");
       if (!options.postgresPassword) todos.push("POSTGRES_PASSWORD — fill in .env.");
-      if (!options.githubWebhookSecret) todos.push("GITHUB_WEBHOOK_SECRET — fill in .env.");
     }
-    // GITHUB_FEEDBACK_* are gated by GITHUB_WEBHOOK_SECRET at runtime — surface
-    // a TODO if feedback config is set but the secret is empty.
+    // GITHUB_WEBHOOK_SECRET is optional (only needed for PR-comment re-runs).
+    // No TODO when blank — operator who didn't paste it in Stage 6 doesn't want
+    // the feature. But if they DID set GITHUB_FEEDBACK_*, the missing secret
+    // makes those values dead — flag that.
     if (options.githubFeedback && !githubWebhookSecret) {
       todos.push(
         "GITHUB_WEBHOOK_SECRET — required for GITHUB_FEEDBACK_* to take effect; " +
@@ -729,7 +738,10 @@ async function main() {
   // --- Stage 5: license + tier-gated PM agent setup ---
   const stage5 = await prompts([
     {
-      type: "text",
+      // password type masks the JWT so it doesn't echo to scrollback / shell history.
+      // Decoded license summary printed below intentionally only shows tier + features,
+      // not the full JWT, so paste-into-terminal stays opaque.
+      type: "password",
       name: "licenseKey",
       message: "URATEAM_LICENSE_KEY (leave blank for OSS):",
     },
@@ -804,8 +816,15 @@ async function main() {
     }
   }
 
-  // --- Stage 6: notification webhooks (Slack / Discord — both optional) ---
+  // --- Stage 6: optional GitHub webhook secret + notification webhooks ---
   const stage6 = await prompts([
+    {
+      // Hidden input — secret is shared with GitHub's webhook config.
+      type: "password",
+      name: "githubWebhookSecret",
+      message:
+        "GITHUB_WEBHOOK_SECRET (paste from GitHub webhook config; leave blank to disable PR-comment re-runs):",
+    },
     {
       type: "text",
       name: "slackWebhookUrl",
@@ -881,11 +900,13 @@ async function main() {
   }
 
   // --- Stage 8: secret generation strategy ---
+  // GITHUB_WEBHOOK_SECRET intentionally NOT in this list — it must match
+  // GitHub's webhook config and is collected explicitly in Stage 6.
   const stage8 = await prompts({
     type: "confirm",
     name: "autoGen",
     message:
-      "Auto-generate POSTGRES_PASSWORD, DASHBOARD_PASSWORD, GITHUB_WEBHOOK_SECRET? (No → leave blank in .env)",
+      "Auto-generate POSTGRES_PASSWORD and DASHBOARD_PASSWORD? (No → leave blank in .env)",
     initial: true,
   });
 
@@ -907,6 +928,7 @@ async function main() {
     anthropicApiKey: stage4.anthropicApiKey,
     licenseKey: stage5.licenseKey,
     pmAgent,
+    githubWebhookSecret: stage6.githubWebhookSecret || undefined,
     slackWebhookUrl: stage6.slackWebhookUrl || undefined,
     discordWebhookUrl: stage6.discordWebhookUrl || undefined,
     agentProfiles,

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -114,6 +114,34 @@ export interface ScaffoldResult {
 }
 
 /**
+ * Tier → implicit feature set, mirroring packages/core/src/license.ts.
+ * The runtime grants Pro tier ALL Pro features regardless of whether the
+ * JWT carries an explicit `features` array — so the scaffolder must do
+ * the same expansion or it'll skip tier-gated prompts for licenses
+ * issued without `--features`.
+ */
+const PRO_FEATURES = [
+  "slack-interface",
+  "conflict-detection",
+  "deep-review",
+  "approval-workflows",
+  "multi-repo",
+  "stage-models",
+  "advanced-automerge",
+];
+const ENTERPRISE_FEATURES = [
+  ...PRO_FEATURES,
+  "sso",
+  "audit-log",
+  "spend-caps",
+  "rbac",
+  "cost-dashboard",
+  "cost-roi",
+  "org-policy",
+  "pm-agent-governance",
+];
+
+/**
  * Decode a urateam license JWT payload WITHOUT verifying the signature.
  *
  * The scaffolder doesn't ship the public key (would bloat the package and
@@ -121,6 +149,11 @@ export interface ScaffoldResult {
  * just produces a wrong prompt flow which is recoverable by editing .env
  * after the fact. Production verification happens at runtime in the agent
  * via packages/core/src/license.ts against the embedded public key.
+ *
+ * If the JWT has no explicit `features` array, this expands by tier to
+ * match runtime semantics. An explicit (possibly trimmed) array in the
+ * JWT takes precedence — operators can ship Pro licenses with a subset
+ * of features and the scaffolder honors that.
  *
  * Returns null on any parse failure.
  */
@@ -142,9 +175,23 @@ export function decodeLicense(jwt: string | undefined | null): LicenseInfo | nul
     };
     const tier =
       payload.tier === "pro" || payload.tier === "enterprise" ? payload.tier : "oss";
+
+    // Honor an explicit features array (operators can issue restricted licenses).
+    // Otherwise expand by tier to match the runtime's tier-implicit feature set.
+    let features: string[];
+    if (Array.isArray(payload.features) && payload.features.length > 0) {
+      features = payload.features;
+    } else if (tier === "pro") {
+      features = [...PRO_FEATURES];
+    } else if (tier === "enterprise") {
+      features = [...ENTERPRISE_FEATURES];
+    } else {
+      features = [];
+    }
+
     return {
       tier,
-      features: payload.features ?? [],
+      features,
       customerId: payload.sub,
       expiresAt: payload.exp ? new Date(payload.exp * 1000) : undefined,
     };


### PR DESCRIPTION
Three related scaffolder correctness fixes, surfaced from real-deploy review.

## Commit 1: tier → features expansion (\`f7a9c92\`)

A Pro license issued via \`ura license issue --tier pro\` (no \`--features\`) carries no \`features\` field in its JWT. The runtime at \`packages/core/src/license.ts:48-52\` resolves features from tier alone — Pro = all 7 Pro features. But \`decodeLicense\` was reading \`payload.features ?? []\`, getting an empty array, and skipping every feature gate in the scaffolder.

Net effect: the PM agent / Slack interface prompt never fired, even for valid Pro licenses.

Fix: when \`features\` is missing/empty, expand by tier (Pro → 7 features, Enterprise → 15). Explicit array still wins so restricted licenses keep working. \`PRO_FEATURES\` and \`ENTERPRISE_FEATURES\` constants kept in sync with \`packages/core/src/license.ts\` via inline comment.

## Commit 2: hide license JWT + don't auto-gen GH webhook secret (\`14bc387\`)

Two fixes:

**(a) URATEAM_LICENSE_KEY input is now \`type: password\`.** Previous \`text\` type echoed the full JWT to terminal scrollback and shell history. Decoded tier+features summary still prints; the raw token is masked.

**(b) GITHUB_WEBHOOK_SECRET no longer auto-generated.** The previous behavior generated a 32-byte hex string and wrote it to \`.env\`, but that value can't match what GitHub stores in its webhook config (GitHub either generates its own or accepts a custom one) — so the runtime would silently reject every incoming webhook with a signature mismatch.

Now collected via dedicated Stage 6 prompt (\`type: password\`, blank to skip the entire PR-comment re-run feature). When blank, \`.env\` writes the line commented out so dotenv doesn't load an empty string.

## Tests

5 new tests, 43/43 pass:
- 3 tier-expansion tests (Pro implicit, Enterprise implicit, explicit-wins)
- 2 GH-secret tests (never auto-generated regardless of autoGenSecrets, and explicit values pass through)

Plus 1 existing test renamed/tightened for the new GITHUB_WEBHOOK_SECRET semantics.

Bumps \`create-urateam\` 0.1.15 → 0.1.17 (2 patch bumps shipping together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)