### PR TITLE
feat(create-urateam): GH webhook auto-gen + GITHUB_FEEDBACK_* wizard + AGENT_BYPASS_PERMISSIONS

### DIFF
--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -528,8 +528,8 @@ describe("scaffold — production options", () => {
     );
   });
 
-  it("never auto-generates GITHUB_WEBHOOK_SECRET (must come from GitHub side)", () => {
-    const projectDir = join(tempDir, "no-gh-secret-autogen");
+  it("auto-generates GITHUB_WEBHOOK_SECRET when autoGenSecrets is true and none provided", () => {
+    const projectDir = join(tempDir, "gh-secret-autogen");
     const result = scaffold({
       projectDir,
       projectName: "x",
@@ -537,29 +537,48 @@ describe("scaffold — production options", () => {
       linearTeamId: "t",
       repoUrl: "https://github.com/o/r",
       defaultBranch: "main",
-      autoGenSecrets: true, // even when on, GitHub secret stays blank
+      autoGenSecrets: true,
     });
     const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
-    // Line is commented when blank, not bare assignment.
-    expect(env).toMatch(/^# GITHUB_WEBHOOK_SECRET=/m);
-    expect(env).not.toMatch(/^GITHUB_WEBHOOK_SECRET=\S/m);
-    expect(result.generatedSecrets.githubWebhookSecret).toBeUndefined();
+    expect(env).toMatch(/^GITHUB_WEBHOOK_SECRET=[a-f0-9]{64}$/m);
+    expect(result.generatedSecrets.githubWebhookSecret).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it("emits GITHUB_WEBHOOK_SECRET as a real value when explicitly provided", () => {
-    const projectDir = join(tempDir, "gh-secret-set");
-    scaffold({
+  it("explicit GITHUB_WEBHOOK_SECRET wins over auto-gen", () => {
+    const projectDir = join(tempDir, "gh-secret-explicit-wins");
+    const result = scaffold({
       projectDir,
       projectName: "x",
       linearApiKey: "x",
       linearTeamId: "t",
       repoUrl: "https://github.com/o/r",
       defaultBranch: "main",
-      githubWebhookSecret: "my-paste-from-github",
+      autoGenSecrets: true,
+      githubWebhookSecret: "operator-paste-from-github",
     });
     const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
-    expect(env).toMatch(/^GITHUB_WEBHOOK_SECRET=my-paste-from-github$/m);
+    expect(env).toMatch(/^GITHUB_WEBHOOK_SECRET=operator-paste-from-github$/m);
+    // Not in generated set since it came from the operator.
+    expect(result.generatedSecrets.githubWebhookSecret).toBeUndefined();
   });
+
+  it("leaves GITHUB_WEBHOOK_SECRET commented when autoGenSecrets is false and none provided", () => {
+    const projectDir = join(tempDir, "gh-secret-blank");
+    const result = scaffold({
+      projectDir,
+      projectName: "x",
+      linearApiKey: "x",
+      linearTeamId: "t",
+      repoUrl: "https://github.com/o/r",
+      defaultBranch: "main",
+      autoGenSecrets: false,
+    });
+    const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+    expect(env).toMatch(/^# GITHUB_WEBHOOK_SECRET=/m);
+    expect(env).not.toMatch(/^GITHUB_WEBHOOK_SECRET=\S/m);
+    expect(result.generatedSecrets.githubWebhookSecret).toBeUndefined();
+  });
+
 
   it("returns license info in result when licenseKey decodes", () => {
     const payload = Buffer.from(

--- a/packages/create-urateam/src/__tests__/scaffold.test.ts
+++ b/packages/create-urateam/src/__tests__/scaffold.test.ts
@@ -598,6 +598,39 @@ describe("scaffold — production options", () => {
     expect(result.license?.features).toContain("slack-interface");
   });
 
+  it("AGENT_BYPASS_PERMISSIONS=true uncommented in local mode", () => {
+    const projectDir = join(tempDir, "perm-local");
+    scaffold({
+      projectDir,
+      projectName: "perm-local",
+      linearApiKey: "x",
+      linearTeamId: "t",
+      repoUrl: "https://github.com/o/r",
+      defaultBranch: "main",
+      deployMode: "local",
+    });
+    const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+    expect(env).toMatch(/^AGENT_BYPASS_PERMISSIONS=true$/m);
+  });
+
+  it("AGENT_BYPASS_PERMISSIONS commented out in production mode", () => {
+    const projectDir = join(tempDir, "perm-prod");
+    scaffold({
+      projectDir,
+      projectName: "perm-prod",
+      linearApiKey: "x",
+      linearTeamId: "t",
+      repoUrl: "https://github.com/o/r",
+      defaultBranch: "main",
+      deployMode: "production",
+      domain: "x.example.com",
+      caddyEmail: "x@x.com",
+    });
+    const env = readFileSync(join(projectDir, ".urateam", ".env"), "utf-8");
+    expect(env).toMatch(/^# AGENT_BYPASS_PERMISSIONS=true/m);
+    expect(env).not.toMatch(/^AGENT_BYPASS_PERMISSIONS=true$/m);
+  });
+
   it("writes DASHBOARD_BASE_PATH when provided, comments out otherwise", () => {
     const projectDir = join(tempDir, "base-path");
     scaffold({

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -312,6 +312,23 @@ function buildEnv(
   push(`MAX_CONCURRENT_RUNS=${options.maxConcurrentRuns}`);
   blank();
 
+  // AGENT_BYPASS_PERMISSIONS — Claude Code permission-mode override. Runtime
+  // logic at packages/core/src/executor/permissions.ts:
+  //   - root user (UID 0): all permission flags ignored (Claude Code refuses)
+  //   - else, env var unset: implement/reproduce=acceptEdits, test/review=default
+  //   - else, env var =true: bypassPermissions for all stages
+  // The hardened compose template runs the container as root, so this var is
+  // a no-op for production VPS deploys. For local `pnpm dev` (non-root), the
+  // test/review stages would hang on interactive prompts without this — local
+  // mode therefore defaults to true.
+  push("# === Agent permissions (Claude Code) ===");
+  if (options.deployMode === "local") {
+    push("AGENT_BYPASS_PERMISSIONS=true");
+  } else {
+    push("# AGENT_BYPASS_PERMISSIONS=true  # no-op in root containers; uncomment if running container as a non-root user");
+  }
+  blank();
+
   if (options.pmAgent) {
     push("# === PM Agent (Pro: slack-interface) ===");
     push("PM_AGENT_ENABLED=true");

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -277,13 +277,13 @@ function buildEnv(
   push("# GITHUB_APP_ID=");
   push("# GITHUB_PRIVATE_KEY_PATH=/run/gh-app.pem");
   push("# GITHUB_INSTALLATION_ID=");
-  // GITHUB_WEBHOOK_SECRET is shared with GitHub's webhook config — only emit
-  // when the operator has pasted a real value. Empty/missing means the
-  // PR-comment re-trigger feature is disabled, which is the expected default.
+  // GITHUB_WEBHOOK_SECRET is shared with GitHub's webhook config. Auto-genned
+  // by default (operator pastes the value INTO GitHub when creating the
+  // webhook). Blank means PR-comment re-trigger feature stays disabled.
   if (options.githubWebhookSecret) {
     push(`GITHUB_WEBHOOK_SECRET=${options.githubWebhookSecret}`);
   } else {
-    push("# GITHUB_WEBHOOK_SECRET=  # paste from GitHub webhook config (only needed for PR-comment re-runs)");
+    push("# GITHUB_WEBHOOK_SECRET=  # paste here AND into GitHub webhook config to enable PR-comment re-runs");
   }
   blank();
 
@@ -409,12 +409,7 @@ function resolveSecrets(options: ScaffoldOptions): {
 
   let dashboardPassword = options.dashboardPassword ?? "";
   let postgresPassword = options.postgresPassword ?? "";
-  // GITHUB_WEBHOOK_SECRET is NOT auto-generated. The secret is shared with
-  // GitHub's webhook config — operator either pastes the value GitHub generates
-  // in the webhook UI, OR provides their own and pastes that into both sides.
-  // Auto-generating one only here would mismatch GitHub's value and silently
-  // reject every incoming PR comment.
-  const githubWebhookSecret = options.githubWebhookSecret ?? "";
+  let githubWebhookSecret = options.githubWebhookSecret ?? "";
 
   if (autoGen) {
     // base64url avoids `+`, `/`, `=` which can trip strict env-file parsers
@@ -426,6 +421,13 @@ function resolveSecrets(options: ScaffoldOptions): {
     if (!postgresPassword) {
       postgresPassword = randomBytes(24).toString("base64url");
       generated.postgresPassword = postgresPassword;
+    }
+    if (!githubWebhookSecret) {
+      // hex (not base64url) for compatibility with the broadest set of HMAC
+      // validators that operators paste this into. Operator pastes the same
+      // value into GitHub's webhook config so signatures match.
+      githubWebhookSecret = randomBytes(32).toString("hex");
+      generated.githubWebhookSecret = githubWebhookSecret;
     }
   }
 
@@ -819,11 +821,13 @@ async function main() {
   // --- Stage 6: optional GitHub webhook secret + notification webhooks ---
   const stage6 = await prompts([
     {
-      // Hidden input — secret is shared with GitHub's webhook config.
+      // Hidden input — secret is shared with GitHub's webhook config. If the
+      // operator already has a secret in GitHub, paste it here. Otherwise leave
+      // blank and the auto-gen step at Stage 8 will mint one for both sides.
       type: "password",
       name: "githubWebhookSecret",
       message:
-        "GITHUB_WEBHOOK_SECRET (paste from GitHub webhook config; leave blank to disable PR-comment re-runs):",
+        "GITHUB_WEBHOOK_SECRET (paste from GitHub if you already set one, or leave blank to auto-generate):",
     },
     {
       type: "text",
@@ -900,13 +904,15 @@ async function main() {
   }
 
   // --- Stage 8: secret generation strategy ---
-  // GITHUB_WEBHOOK_SECRET intentionally NOT in this list — it must match
-  // GitHub's webhook config and is collected explicitly in Stage 6.
+  // GITHUB_WEBHOOK_SECRET is in this set with one twist: if the operator
+  // explicitly pasted a value in Stage 6, it wins; otherwise it's auto-genned
+  // here. Either way the operator gets a value they can paste into GitHub's
+  // webhook config so HMAC signatures match.
   const stage8 = await prompts({
     type: "confirm",
     name: "autoGen",
     message:
-      "Auto-generate POSTGRES_PASSWORD and DASHBOARD_PASSWORD? (No → leave blank in .env)",
+      "Auto-generate POSTGRES_PASSWORD, DASHBOARD_PASSWORD, GITHUB_WEBHOOK_SECRET? (No → leave blank in .env for any not provided above)",
     initial: true,
   });
 
@@ -949,9 +955,10 @@ async function main() {
       console.log(`    POSTGRES_PASSWORD: ${result.generatedSecrets.postgresPassword}`);
     }
     if (result.generatedSecrets.githubWebhookSecret) {
-      console.log(
-        `    GITHUB_WEBHOOK_SECRET: ${result.generatedSecrets.githubWebhookSecret.slice(0, 12)}…`,
-      );
+      // Show the full secret — the operator needs it to paste into GitHub's
+      // webhook UI for HMAC signatures to match.
+      console.log(`    GITHUB_WEBHOOK_SECRET: ${result.generatedSecrets.githubWebhookSecret}`);
+      console.log(`    ↑ paste this into the webhook's "Secret" field at github.com/<repo>/settings/hooks/new`);
     }
     console.log("");
   }

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -916,6 +916,59 @@ async function main() {
     initial: true,
   });
 
+  // --- Stage 9: GitHub PR-comment re-trigger config (gated) ---
+  // Only prompt when both signals are present:
+  //   - URATEAM_LICENSE_KEY pasted (operator is engaged with the product enough
+  //     to want advanced workflows)
+  //   - A GITHUB_WEBHOOK_SECRET will exist in .env (either pasted in Stage 6
+  //     or auto-genned in Stage 8) — without it the runtime won't even mount
+  //     the feedback handler.
+  let githubFeedback: GithubFeedbackOptions | undefined;
+  const willHaveGhSecret = !!stage6.githubWebhookSecret || stage8.autoGen;
+  if (stage5.licenseKey && willHaveGhSecret) {
+    const setupFeedback = await prompts({
+      type: "confirm",
+      name: "setup",
+      message:
+        "Configure GitHub PR-comment re-triggers (GITHUB_FEEDBACK_*) now? You can skip and add later.",
+      initial: false,
+    });
+    if (setupFeedback.setup) {
+      const fb = await prompts([
+        {
+          type: "text",
+          name: "triggerKeyword",
+          message:
+            "  GITHUB_FEEDBACK_TRIGGER_KEYWORD (require this string in PR comment to fire; blank = any review/comment):",
+        },
+        {
+          type: "text",
+          name: "allowedReviewers",
+          message:
+            "  GITHUB_FEEDBACK_ALLOWED_REVIEWERS (csv of GitHub usernames whose comments fire it; blank = all):",
+        },
+        {
+          type: "text",
+          name: "botLogins",
+          message:
+            "  GITHUB_FEEDBACK_BOT_LOGINS (csv of bot logins like github-actions[bot]; blank = none):",
+        },
+        {
+          type: "confirm",
+          name: "autoTrigger",
+          message: "  GITHUB_FEEDBACK_AUTO_TRIGGER — fire automatically on qualifying comments?",
+          initial: true,
+        },
+      ]);
+      githubFeedback = {
+        triggerKeyword: fb.triggerKeyword || undefined,
+        allowedReviewers: fb.allowedReviewers || undefined,
+        botLogins: fb.botLogins || undefined,
+        autoTrigger: fb.autoTrigger,
+      };
+    }
+  }
+
   const projectDir = arg === "." ? process.cwd() : join(process.cwd(), arg);
   const projectName = arg === "." ? basename(projectDir) || "my-project" : arg;
 
@@ -935,6 +988,7 @@ async function main() {
     licenseKey: stage5.licenseKey,
     pmAgent,
     githubWebhookSecret: stage6.githubWebhookSecret || undefined,
+    githubFeedback,
     slackWebhookUrl: stage6.slackWebhookUrl || undefined,
     discordWebhookUrl: stage6.discordWebhookUrl || undefined,
     agentProfiles,

--- a/packages/create-urateam/template/.urateam/.env.example
+++ b/packages/create-urateam/template/.urateam/.env.example
@@ -72,6 +72,15 @@ DASHBOARD_PASSWORD=
 # === Concurrency ===
 # MAX_CONCURRENT_RUNS=3
 
+# === Agent permissions (Claude Code) ===
+# Bypass all Claude Code permission prompts (treat agent as fully trusted in
+# the workspace). Required when running `pnpm dev` locally on a laptop that
+# isn't root, where the test/review stages would otherwise hang waiting for
+# interactive permission grants. NO-OP in containers running as root (the
+# default Dockerfile setup) — Claude Code rejects permission flags as root
+# anyway, so leaving this unset is fine for production VPS deploys.
+# AGENT_BYPASS_PERMISSIONS=true
+
 # =============================================================================
 # Optional features below
 # =============================================================================


### PR DESCRIPTION
Three stacked commits.

## Commit 1: re-enable GITHUB_WEBHOOK_SECRET auto-generation (\`0f1afbd\`)

Reverses v0.1.17. GitHub doesn't auto-generate webhook secrets — the operator sets the value when creating the webhook. Auto-genning urateam-side and pasting into GitHub is the more common UX. Operator-provided value still wins. Next-steps printout shows the FULL secret untruncated with explicit guidance to paste into GitHub's webhook config.

## Commit 2: GITHUB_FEEDBACK_* wizard (\`f13f2e6\`)

Mirrors PM-agent prompt UX. Gated when both signals are present:
- \`URATEAM_LICENSE_KEY\` pasted (operator engaged with advanced workflow intent)
- \`GITHUB_WEBHOOK_SECRET\` will exist (Stage 6 paste OR Stage 8 auto-gen)

Sub-prompts: trigger keyword, allowed reviewers, bot logins, auto-trigger toggle.

Note: GitHub feedback is NOT license-gated at runtime. The license check is a UX heuristic per spec, not a correctness requirement.

## Commit 3: AGENT_BYPASS_PERMISSIONS per deploy mode (\`288012f\`)

Runtime path at \`packages/core/src/executor/permissions.ts\`:
- root user: all permission flags ignored
- non-root + env unset: implement/reproduce=acceptEdits, others=default
- non-root + env=true: bypassPermissions for all stages

Hardened compose template runs as root → env var is a no-op for VPS deploys. Local \`pnpm dev\` runs as operator's user → test/review stages would hang on interactive prompts without it.

- Local mode: emits \`AGENT_BYPASS_PERMISSIONS=true\` uncommented
- Production mode: emits commented-out with a "no-op in root containers" note so power users hardening with USER directive know the knob exists
- \`.env.example\` gets long-form comment for discoverability

## Tests

- 5 new tests across the three commits (auto-gen paths, AGENT_BYPASS_PERMISSIONS local/prod)
- 46/46 pass

Bumps \`create-urateam\` 0.1.17 → 0.1.20 (three patch bumps shipping together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)