### PR TITLE
fix(dashboard): static files were 404'ing under all paths

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",

--- a/packages/dashboard/src/__tests__/server.test.ts
+++ b/packages/dashboard/src/__tests__/server.test.ts
@@ -255,7 +255,13 @@ describe("createDashboard — basePath navigation links", () => {
     expect(res.status).toBe(404);
   });
 
-  it("static files served at <basePath>/static/* when basePath is set", async () => {
+  it("static style.css actually serves at <basePath>/static/style.css", async () => {
+    // Strict version — actually fetch the real CSS file (committed to the
+    // repo at packages/dashboard/src/static/style.css; in dev tests the
+    // module dir resolves to src/, where the file lives next to dist/).
+    // Pre-fix: serveStatic joined c.req.path directly with root, so the
+    // lookup fell out as `<root>/ateam/static/style.css` (404). This test
+    // would fail without rewriteRequestPath.
     const app = createDashboard({
       db: mockDb,
       pipelineConfigs: {},
@@ -263,22 +269,33 @@ describe("createDashboard — basePath navigation links", () => {
       auth: AUTH,
       basePath: "/ateam",
     });
-    const res = await app.request("/ateam/static/nonexistent.css", {
+    const res = await app.request("/ateam/static/style.css", {
       headers: authHeader,
     });
-    // Static middleware should respond with 200 (file found) or 404 (file
-    // missing) — both prove the route MATCHED. The miss case must NOT be a
-    // dashboard layout 404 (which would mean the static middleware didn't
-    // match at all). Assert the response isn't HTML to distinguish.
-    expect([200, 404]).toContain(res.status);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body.length).toBeGreaterThan(100); // sanity — it's the real CSS, not an empty file
     const contentType = res.headers.get("content-type") ?? "";
-    expect(contentType).not.toMatch(/text\/html/);
+    expect(contentType).toMatch(/text\/css/);
 
-    // Bare /static/ path must NOT match when basePath is set.
-    const resBare = await app.request("/static/nonexistent.css", {
+    // Bare /static/style.css must NOT match when basePath is set.
+    const resBare = await app.request("/static/style.css", {
       headers: authHeader,
     });
     expect(resBare.status).toBe(404);
+  });
+
+  it("static style.css serves at /static/style.css when basePath is empty (root mount)", async () => {
+    const app = createDashboard({
+      db: mockDb,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: AUTH,
+    });
+    const res = await app.request("/static/style.css", { headers: authHeader });
+    expect(res.status).toBe(200);
+    const contentType = res.headers.get("content-type") ?? "";
+    expect(contentType).toMatch(/text\/css/);
   });
 
   it("nav links have no double slashes when basePath is '/'", async () => {

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -232,11 +232,22 @@ export function createDashboard(config: DashboardConfig): Hono {
   // join lands at dist/static/ — where the build script copies src/static/
   // before publishing.
   const dashboardModuleDir = dirname(fileURLToPath(import.meta.url));
-  // Static middleware needs to see the prefixed path too — operator visiting
-  // /ateam/static/foo.css needs to hit serveStatic. Hono's `app.use` doesn't
-  // share prefix with `app.route`, so we plumb basePath in explicitly here.
-  const staticPath = basePath ? `${basePath}/static/*` : "/static/*";
-  app.use(staticPath, serveStatic({ root: join(dashboardModuleDir, "static") }));
+  // Static middleware needs to see the prefixed path AND strip the URL
+  // prefix before resolving the file under `root`. @hono/node-server's
+  // serveStatic joins `c.req.path` directly with `root` — so a request
+  // for `/ateam/static/style.css` against `root: dist/static` would look
+  // up `dist/static/ateam/static/style.css` (404). The same surprise hit
+  // even without basePath: `/static/style.css` would look up
+  // `dist/static/static/style.css`. Use rewriteRequestPath to strip the
+  // entire URL-side prefix so the lookup lands at `dist/static/<file>`.
+  const staticUrlPrefix = basePath ? `${basePath}/static` : "/static";
+  app.use(
+    `${staticUrlPrefix}/*`,
+    serveStatic({
+      root: join(dashboardModuleDir, "static"),
+      rewriteRequestPath: (path) => path.replace(staticUrlPrefix, ""),
+    }),
+  );
 
   // Mount each sub-router at the basePath prefix. basePath also continues to
   // get passed INTO each router so layout() emits correct hrefs — the two


### PR DESCRIPTION
## TL;DR — the dashboard CSS has been silently broken

Your VPS deploy showed a fully unstyled dashboard. Network tab confirmed style.css wasn't loading. Investigation: \`serveStatic\` from \`@hono/node-server\` does NOT strip the URL prefix before resolving the file path. Combined with how we mounted it, the file lookup always fell out at the wrong path.

Demonstration:

| Mount | URL | File lookup (BUGGY) | File actually at |
|---|---|---|---|
| \`/static/*\` (no basePath) | \`/static/style.css\` | \`<root>/static/style.css\` | \`<root>/style.css\` |
| \`/ateam/static/*\` | \`/ateam/static/style.css\` | \`<root>/ateam/static/style.css\` | \`<root>/style.css\` |

Both 404. The dashboard has been shipping with no CSS since the dashboard package's first publish — only nobody noticed because it was masked by:
1. Layout had inline structure that "worked" without CSS
2. The previous test allowed \`[200, 404]\` for static files (the fuzzy assertion Sonnet flagged on PR #130)

This is why your VPS-deployed dashboard looked far less polished than the pre-split repo's screenshots — it's the same CSS file, but it was never being served.

## Fix

Use \`rewriteRequestPath\` on \`serveStatic\` to strip the URL-side prefix:

\`\`\`ts
const staticUrlPrefix = basePath ? \`\${basePath}/static\` : "/static";
app.use(
  \`\${staticUrlPrefix}/*\`,
  serveStatic({
    root: join(dashboardModuleDir, "static"),
    rewriteRequestPath: (path) => path.replace(staticUrlPrefix, ""),
  }),
);
\`\`\`

Now:
- \`basePath="" \` + URL \`/static/style.css\` → root + \`/style.css\` ✓
- \`basePath="/ateam"\` + URL \`/ateam/static/style.css\` → root + \`/style.css\` ✓

## Tests

Two new STRICT tests (no more fuzzy [200, 404]):
- \`/ateam/static/style.css\` → status 200, content-type text/css, body > 100 bytes (real CSS, not empty)
- \`/static/style.css\` (no basePath) → same assertions

These would have caught this from day one.

199/199 dashboard tests pass.

## Versioning

- \`@urateam/dashboard\` 0.1.12 → 0.1.13 (the fix)
- \`@urateam/cli\` 0.1.13 → 0.1.14 (cascade re-pin)

After tag + publish, your VPS deploy:
\`\`\`bash
docker compose pull
docker compose up -d --build
\`\`\`
…and the dashboard should look the way you remember.

🤖 Generated with [Claude Code](https://claude.com/claude-code)