### PR TITLE
fix(dashboard): trailing-slash 404s on HTMX poll + brand link

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",

--- a/packages/dashboard/src/__tests__/layout.test.ts
+++ b/packages/dashboard/src/__tests__/layout.test.ts
@@ -71,7 +71,9 @@ describe("layout", () => {
       process.env.DASHBOARD_BASE_PATH = "/ateam";
       const html = layout("Test", "");
 
-      expect(html).toContain('<a href="/ateam/">Runs</a>');
+      // Runs href omits trailing slash so it matches Hono's mount-prefix
+      // routing — `/ateam/` 404s but `/ateam` matches the runs router's `/`.
+      expect(html).toContain('<a href="/ateam">Runs</a>');
       expect(html).toContain('<a href="/ateam/tokens">Tokens</a>');
       expect(html).toContain('<a href="/ateam/errors">Errors</a>');
       expect(html).toContain('<a href="/ateam/config">Config</a>');

--- a/packages/dashboard/src/__tests__/server.test.ts
+++ b/packages/dashboard/src/__tests__/server.test.ts
@@ -285,6 +285,53 @@ describe("createDashboard — basePath navigation links", () => {
     expect(resBare.status).toBe(404);
   });
 
+  it("HTMX poll URL has no trailing slash when basePath is set (avoids 404 every 5s)", async () => {
+    // urateam#131 follow-up: run-feed.ts used to emit hx-get="${basePath}/"
+    // which produced "/ateam/" for non-empty basePath — Hono mounts the runs
+    // router at "/ateam" (no trailing slash), so the poll 404s on every tick.
+    // run-feed reads basePath via getBasePath() (env var), so set it here.
+    const previousEnv = process.env.DASHBOARD_BASE_PATH;
+    process.env.DASHBOARD_BASE_PATH = "/ateam";
+    try {
+      const app = createDashboard({
+        db: mockDb,
+        pipelineConfigs: {},
+        repoConfigs: {},
+        auth: AUTH,
+        basePath: "/ateam",
+      });
+      const res = await app.request("/ateam", { headers: authHeader });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('hx-get="/ateam"');
+      expect(html).not.toContain('hx-get="/ateam/"');
+      // Brand link too.
+      expect(html).toContain('class="brand" href="/ateam"');
+    } finally {
+      if (previousEnv === undefined) delete process.env.DASHBOARD_BASE_PATH;
+      else process.env.DASHBOARD_BASE_PATH = previousEnv;
+    }
+  });
+
+  it("HTMX poll URL is / when basePath is empty (root)", async () => {
+    const previousEnv = process.env.DASHBOARD_BASE_PATH;
+    delete process.env.DASHBOARD_BASE_PATH;
+    try {
+      const app = createDashboard({
+        db: mockDb,
+        pipelineConfigs: {},
+        repoConfigs: {},
+        auth: AUTH,
+      });
+      const res = await app.request("/", { headers: authHeader });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('hx-get="/"');
+    } finally {
+      if (previousEnv !== undefined) process.env.DASHBOARD_BASE_PATH = previousEnv;
+    }
+  });
+
   it("static style.css serves at /static/style.css when basePath is empty (root mount)", async () => {
     const app = createDashboard({
       db: mockDb,

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -83,8 +83,8 @@ export function layout(
 </head>
 <body>
   <nav>
-    <a class="brand" href="${bp}/">⚡ urateam</a>
-    <a href="${bp}/">Runs</a>
+    <a class="brand" href="${bp || "/"}">⚡ urateam</a>
+    <a href="${bp || "/"}">Runs</a>
     <a href="${bp}/tokens">Tokens</a>
     <a href="${bp}/errors">Errors</a>
     <a href="${bp}/audit">Audit</a>

--- a/packages/dashboard/src/views/run-feed.ts
+++ b/packages/dashboard/src/views/run-feed.ts
@@ -70,7 +70,12 @@ export function runFeedView(runs: RunRow[]): string {
     )
     .join("\n");
 
-  return `<div id="run-feed" hx-get="${basePath}/" hx-trigger="every 5s" hx-swap="innerHTML" hx-target="#run-feed">
+  // basePath || "/" not basePath + "/" — Hono mounts the runs router at
+  // <basePath> (no trailing slash), so "/ateam/" 404s but "/ateam" matches.
+  // The empty-basePath case still resolves to "/" so root-mounted dashboards
+  // continue to work.
+  const pollUrl = basePath || "/";
+  return `<div id="run-feed" hx-get="${pollUrl}" hx-trigger="every 5s" hx-swap="innerHTML" hx-target="#run-feed">
   <div class="table-wrapper">
     <table>
       <thead>


### PR DESCRIPTION
The visible symptom you saw in the network tab: 7+ \`ateam/\` requests returning 404, repeating every 5 seconds. Source: \`run-feed.ts\` polled \`hx-get="\${basePath}/"\` which produces \`/ateam/\` (trailing slash) when basePath is set. Hono mounts the runs router at \`/ateam\` (no trailing slash), so the trailing-slash variant 404s.

Same pattern in two layout links (brand and Runs nav) — clicking them would also 404, even though the page renders fine when navigating to bare \`/ateam\`.

Fix: \`basePath || "/"\` instead of \`basePath + "/"\`. Resolves to \`/\` when basePath is empty (root mounts unchanged) and to \`/ateam\` when set (matches Hono's prefix mount).

## Tests

Two new regression tests assert hx-get and brand href stay slash-free when basePath is set. One existing layout test updated to match new expected href.

201/201 dashboard tests pass.

## Versioning

- \`@urateam/dashboard\` 0.1.13 → 0.1.14 (the fix)
- \`@urateam/cli\` 0.1.14 → 0.1.15 (cascade re-pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)