### PR TITLE
feat(dashboard): retry confirmation modal + parentRunId linkage (BEC-133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ notes call out when a change affects only a single package.
 - `@urateam/core`: `startTodoIssues` short-circuits when the budget is blocked, so orphaned Todo issues don't bypass the cap.
 - `pipeline_runs` table gains a `linear_team_id` column (nullable for legacy rows), populated from the Linear webhook payload at run creation time and from the parent run for review-feedback runs.
 - New `budget_alerts` table with `UNIQUE(date, scope, threshold)` for persistent alert dedup.
+- `@urateam/dashboard`: retry button on the run-detail view now opens a native `<dialog>` confirmation modal before submitting the POST. CSP-compliant via a small static `dialog.js` (BEC-133).
+- `@urateam/dashboard`: retried runs now link back to their parent via `parentRunId` so the run-feed shows the lineage. Only applies to the `runner.start()` retry branch — `runner.resume()` continues to update the same row in place (BEC-133).
 
 ### Changed
 - `pm/budget.ts`: `checkBudgetGuards` is replaced by `evaluateBudget`, which returns per-scope breakdowns (`ScopeBudget[]`) and a `worstTier` / `promoteBlocked` / `blockReason` verdict. Installs that don't configure `budgets` keep the existing single-global behavior with the addition of threshold alerts on the global scope. The previous silent 80% promotion-block gate is replaced with a 100% hard gate plus explicit 50/80 warnings. `checkBudgetGuards` remains as a thin backward-compat shim.
@@ -30,6 +32,9 @@ notes call out when a change affects only a single package.
 - **Breaking (license)**: tier enum renamed from `free | pro | team | enterprise` to `oss | pro | enterprise`. The `team` tier is removed. Code reading `LicenseStatus.tier` should expect `"oss"` where it previously expected `"free"`.
 - **Breaking (license)**: `URATEAM_LICENSE_KEY` must now be a valid Ed25519-signed JWT issued by urateam. Existing placeholder keys will fail validation; the system falls back to OSS mode and logs a warning at startup.
 - `LicenseStatus` interface gains `features: Set<string>`, `customerId`, `expiresAt`, `seats`, and `invalidReason` fields. The `key` field is removed.
+
+### Fixed
+- `@urateam/dashboard`: retry button is now hidden in unlicensed deployments. The route's 404 enforcement was already correct; the view's `canRetry` flag was inconsistently defaulting to `true` (BEC-133).
 
 ## [0.1.6] - 2026-04-13
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",

--- a/packages/dashboard/src/__tests__/layout.test.ts
+++ b/packages/dashboard/src/__tests__/layout.test.ts
@@ -65,6 +65,9 @@ describe("layout", () => {
     it("should include HTMX script", () => {
       const html = layout("Test", "");
       expect(html).toContain('<script src="https://unpkg.com/htmx.org@2.0.0"></script>');
+      // Companion: the dialog-trigger script must also load (deferred,
+      // same-origin) so retry-confirm modal opens under CSP `script-src 'self'`.
+      expect(html).toContain('/static/dialog.js" defer');
     });
 
     it("should include navigation links with basePath", () => {
@@ -155,18 +158,21 @@ describe("layout", () => {
       delete process.env.DASHBOARD_BASE_PATH;
       const html = layout("Test", "");
       expect(html).toContain('href="/static/style.css"');
+      expect(html).toContain('src="/static/dialog.js"');
     });
 
     it("should use correct path for CSS with basePath /ateam", () => {
       process.env.DASHBOARD_BASE_PATH = "/ateam";
       const html = layout("Test", "");
       expect(html).toContain('href="/ateam/static/style.css"');
+      expect(html).toContain('src="/ateam/static/dialog.js"');
     });
 
     it("should use correct path for CSS with custom basePath", () => {
       process.env.DASHBOARD_BASE_PATH = "/myapp";
       const html = layout("Test", "");
       expect(html).toContain('href="/myapp/static/style.css"');
+      expect(html).toContain('src="/myapp/static/dialog.js"');
     });
   });
 });

--- a/packages/dashboard/src/__tests__/retry-route.test.ts
+++ b/packages/dashboard/src/__tests__/retry-route.test.ts
@@ -129,3 +129,25 @@ describe("POST /runs/:id/retry", () => {
     });
   });
 });
+
+describe("GET /runs/:id retry button visibility", () => {
+  it("hides retry control when rbac is unlicensed", async () => {
+    // No license installed (afterEach in this file already calls restoreLicense)
+    const app = appWith("operator");
+    const res = await app.request("/runs/run_1");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain("/runs/run_1/retry");
+    expect(html).not.toContain("<dialog");
+  });
+
+  it("shows retry control when rbac is licensed and role permits", async () => {
+    await installTestProLicense("enterprise");
+    const app = appWith("operator");
+    const res = await app.request("/runs/run_1");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("/runs/run_1/retry");
+    expect(html).toContain("<dialog");
+  });
+});

--- a/packages/dashboard/src/__tests__/retry-route.test.ts
+++ b/packages/dashboard/src/__tests__/retry-route.test.ts
@@ -95,6 +95,26 @@ describe("POST /runs/:id/retry", () => {
       expect(retry).toBeDefined();
     });
 
+    it("operator retrying a failed run with no resumePayload → runner.start called with parentRunId", async () => {
+      // run_1 has no resumePayload (default fixture in beforeEach)
+      const runner = {
+        resume: vi.fn(),
+        start: vi.fn().mockResolvedValue(undefined),
+      };
+      const app = appWith("operator", runner);
+      const res = await app.request("/runs/run_1/retry", { method: "POST" });
+      expect(res.status).toBe(302);
+      expect(runner.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issueId: "BEC-42",
+          issueTitle: "fix bug",
+          repoUrl: "https://github.com/acme/api",
+          parentRunId: "run_1",
+        }),
+      );
+      expect(runner.resume).not.toHaveBeenCalled();
+    });
+
     it("admin → 302, runner.resume called (with resumePayload)", async () => {
       await db
         .update(pipelineRuns)

--- a/packages/dashboard/src/__tests__/run-detail-view.test.ts
+++ b/packages/dashboard/src/__tests__/run-detail-view.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { runDetailView, type RunInfo } from "../views/run-detail.js";
+
+const baseRun = (overrides: Partial<RunInfo> = {}): RunInfo => ({
+  id: "run_abc",
+  issueId: "BEC-1",
+  issueTitle: "Test issue",
+  pipelineKey: "auto-implement",
+  repoUrl: "https://github.com/acme/repo",
+  branch: null,
+  status: "failed",
+  startedAt: new Date("2026-04-29T00:00:00Z"),
+  completedAt: new Date("2026-04-29T00:01:00Z"),
+  prUrl: null,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  errorMessage: null,
+  ...overrides,
+});
+
+describe("runDetailView retry control", () => {
+  it("renders a <dialog> confirmation modal when run is failed and canRetry", () => {
+    const html = runDetailView(baseRun({ status: "failed" }), [], [], 1, 0, true);
+    expect(html).toContain("<dialog");
+    expect(html).toContain('id="retry-confirm-run_abc"');
+    // Trigger button opens dialog via data-attribute (no inline JS — CSP)
+    expect(html).toContain('data-open-dialog="retry-confirm-run_abc"');
+    // Modal contains the POST form action and a Cancel button
+    expect(html).toContain("/runs/run_abc/retry");
+    expect(html).toMatch(/Cancel/);
+    expect(html).toMatch(/Confirm retry/i);
+  });
+
+  it("renders modal for retriable status too", () => {
+    const html = runDetailView(baseRun({ status: "retriable" }), [], [], 1, 0, true);
+    expect(html).toContain("<dialog");
+  });
+
+  it("does not render retry control for succeeded run", () => {
+    const html = runDetailView(baseRun({ status: "succeeded" }), [], [], 1, 0, true);
+    expect(html).not.toContain("<dialog");
+    expect(html).not.toContain("/runs/run_abc/retry");
+  });
+
+  it("does not render retry control when canRetry=false even on failed run", () => {
+    const html = runDetailView(baseRun({ status: "failed" }), [], [], 1, 0, false);
+    expect(html).not.toContain("<dialog");
+    expect(html).not.toContain("/runs/run_abc/retry");
+  });
+
+  it("escapes run id in dialog id and form action", () => {
+    const html = runDetailView(
+      baseRun({ id: "run with spaces" }),
+      [],
+      [],
+      1,
+      0,
+      true,
+    );
+    // form action uses encodeURIComponent
+    expect(html).toContain("/runs/run%20with%20spaces/retry");
+  });
+});

--- a/packages/dashboard/src/__tests__/server.test.ts
+++ b/packages/dashboard/src/__tests__/server.test.ts
@@ -285,6 +285,32 @@ describe("createDashboard — basePath navigation links", () => {
     expect(resBare.status).toBe(404);
   });
 
+  it("static dialog.js actually serves at <basePath>/static/dialog.js", async () => {
+    // Mirrors the style.css test: ensures the dialog-trigger script is
+    // reachable under a non-empty basePath. Without it the retry-confirm
+    // modal silently fails to open in production.
+    const app = createDashboard({
+      db: mockDb,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: AUTH,
+      basePath: "/ateam",
+    });
+    const res = await app.request("/ateam/static/dialog.js", {
+      headers: authHeader,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).toContain("data-open-dialog");
+
+    // Bare /static/dialog.js must NOT match when basePath is set.
+    const resBare = await app.request("/static/dialog.js", {
+      headers: authHeader,
+    });
+    expect(resBare.status).toBe(404);
+  });
+
   it("HTMX poll URL has no trailing slash when basePath is set (avoids 404 every 5s)", async () => {
     // urateam#131 follow-up: run-feed.ts used to emit hx-get="${basePath}/"
     // which produced "/ateam/" for non-empty basePath — Hono mounts the runs
@@ -343,6 +369,20 @@ describe("createDashboard — basePath navigation links", () => {
     expect(res.status).toBe(200);
     const contentType = res.headers.get("content-type") ?? "";
     expect(contentType).toMatch(/text\/css/);
+  });
+
+  it("static dialog.js serves at /static/dialog.js when basePath is empty (root mount)", async () => {
+    const app = createDashboard({
+      db: mockDb,
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: AUTH,
+    });
+    const res = await app.request("/static/dialog.js", { headers: authHeader });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).toContain("data-open-dialog");
   });
 
   it("nav links have no double slashes when basePath is '/'", async () => {

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -171,6 +171,7 @@ export function createRunsRouter(
             issueId: run.issueId,
             issueTitle: run.issueTitle,
             repoUrl: run.repoUrl,
+            parentRunId: id,
           });
         }
       } catch (err) {

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -129,7 +129,7 @@ export function createRunsRouter(
 
     const canRetry = isFeatureLicensed("rbac")
       ? canAccess((user?.role ?? "viewer") as Role, "runs.retry")
-      : true;
+      : false;
     const content = runDetailView(run, stages, logs, page, totalLogs, canRetry);
     return c.html(layout(`Run ${id}`, content, effectiveBasePath, { userEmail: user?.email }));
   });

--- a/packages/dashboard/src/static/dialog.js
+++ b/packages/dashboard/src/static/dialog.js
@@ -1,12 +1,20 @@
 // Wires up `data-open-dialog="<id>"` triggers to open the matching <dialog>.
 // CSP-compliant: served from same origin via `script-src 'self'`.
 document.addEventListener("click", function (e) {
-  var trigger = e.target.closest("[data-open-dialog]");
+  var t = e.target;
+  // `e.target` can be a non-Element (Text node) in rare engines — guard.
+  if (!t || typeof t.closest !== "function") return;
+  var trigger = t.closest("[data-open-dialog]");
   if (!trigger) return;
   var id = trigger.getAttribute("data-open-dialog");
   if (!id) return;
   var dialog = document.getElementById(id);
-  if (dialog && typeof dialog.showModal === "function") {
+  // showModal() throws InvalidStateError if the dialog is already open.
+  if (
+    dialog &&
+    typeof dialog.showModal === "function" &&
+    !dialog.open
+  ) {
     dialog.showModal();
   }
 });

--- a/packages/dashboard/src/static/dialog.js
+++ b/packages/dashboard/src/static/dialog.js
@@ -1,0 +1,12 @@
+// Wires up `data-open-dialog="<id>"` triggers to open the matching <dialog>.
+// CSP-compliant: served from same origin via `script-src 'self'`.
+document.addEventListener("click", function (e) {
+  var trigger = e.target.closest("[data-open-dialog]");
+  if (!trigger) return;
+  var id = trigger.getAttribute("data-open-dialog");
+  if (!id) return;
+  var dialog = document.getElementById(id);
+  if (dialog && typeof dialog.showModal === "function") {
+    dialog.showModal();
+  }
+});

--- a/packages/dashboard/src/static/style.css
+++ b/packages/dashboard/src/static/style.css
@@ -646,3 +646,17 @@ a:focus-visible {
     display: none;
   }
 }
+
+/* ── Retry confirmation dialog ────────────────────────────────── */
+.retry-confirm-dialog {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 1.25rem;
+  min-width: 320px;
+  max-width: 480px;
+  background: var(--color-bg-elevated, #fff);
+  color: var(--color-text);
+}
+.retry-confirm-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -80,6 +80,7 @@ export function layout(
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
   <link rel="stylesheet" href="${bp}/static/style.css">
   <script src="https://unpkg.com/htmx.org@2.0.0"></script>
+  <script src="${bp}/static/dialog.js" defer></script>
 </head>
 <body>
   <nav>

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -102,9 +102,29 @@ export function runDetailView(
       ${run.prUrl ? `<a href="${escapeHtml(run.prUrl)}" target="_blank" rel="noopener" style="font-size:0.875rem;">↗ Pull Request</a>` : ""}
       ${
         canRetry && (run.status === "failed" || run.status === "retriable")
-          ? `<form method="post" action="${basePath}/runs/${encodeURIComponent(run.id)}/retry" hx-post="${basePath}/runs/${encodeURIComponent(run.id)}/retry" hx-headers='{"HX-Request":"true"}' style="display:inline;margin:0;">
-          <button type="submit" class="button-primary">Retry</button>
-        </form>`
+          ? (() => {
+              const dialogId = `retry-confirm-${run.id}`;
+              const action = `${basePath}/runs/${encodeURIComponent(run.id)}/retry`;
+              return `<button
+                type="button"
+                class="button-primary"
+                data-open-dialog="${escapeHtml(dialogId)}"
+              >Retry</button>
+              <dialog id="${escapeHtml(dialogId)}" class="retry-confirm-dialog">
+                <h3 style="margin-top:0;">Retry this run?</h3>
+                <p style="margin:0.5rem 0 1rem;color:var(--color-text-muted);">
+                  A new pipeline run will be queued, linked to this run as its parent.
+                </p>
+                <div style="display:flex;gap:0.5rem;justify-content:flex-end;">
+                  <form method="dialog" style="margin:0;">
+                    <button type="submit" class="button-secondary">Cancel</button>
+                  </form>
+                  <form method="post" action="${action}" hx-post="${action}" hx-headers='{"HX-Request":"true"}' style="margin:0;">
+                    <button type="submit" class="button-primary">Confirm retry</button>
+                  </form>
+                </div>
+              </dialog>`;
+            })()
           : ""
       }
     </div>


### PR DESCRIPTION
Closes BEC-133.

## Summary
- Wrap the existing dashboard Retry button in a native `<dialog>` confirmation modal so operators get a deliberate Confirm/Cancel step before re-enqueuing.
- Pass `parentRunId` to `runner.start()` on retry so the new run is linked to its parent in the run feed (one of BEC-133's acceptance criteria). Only the start branch needs this — `runner.resume()` updates the same row in place, so no new run is created.
- Hide the Retry button in unlicensed deployments. The route already 404'd on click; the view's `canRetry` flag was inconsistently defaulting to `true`. Now consistent.

## Notes
- BEC-133 wording mentions ``completed-with-warnings`` as a status — that status doesn't exist in the run state machine. The code uses `failed | retriable`, which I confirmed with @JonB32 is the intended set. Treated as loose wording in the issue.
- CSP-compliance: the dashboard's CSP is `script-src 'self' https://unpkg.com` — no `'unsafe-inline'`. So the trigger is a `data-open-dialog` attribute and a small same-origin `static/dialog.js` delegates clicks to `.showModal()`. No inline `onclick`.
- The retry endpoint (POST /runs/<id>/retry) was already in place from PR #115; this PR threads `parentRunId` into the existing `runner.start({...})` call but does not change the route's auth or status validation.

## Files
- New: `packages/dashboard/src/static/dialog.js` (12 lines + a few defensive guards from review feedback)
- New tests: `packages/dashboard/src/__tests__/run-detail-view.test.ts` (5 view tests)
- Modified: `packages/dashboard/src/views/{layout,run-detail}.ts`, `packages/dashboard/src/routes/runs.ts`, `packages/dashboard/src/static/style.css`
- Modified tests: `__tests__/{retry-route,layout,server}.test.ts` (assert button visibility under license, retry parentRunId linkage, layout includes new script, /static/dialog.js serves)
- `@urateam/dashboard 0.1.14 → 0.1.15`, `@urateam/cli 0.1.16 → 0.1.17` (workspace cascade)
- `CHANGELOG.md` Unreleased section updated

## Test plan
- [x] `pnpm --filter @urateam/dashboard test` — 211 tests across 15 files green
- [x] `pnpm -w build` clean
- [x] `pnpm -w test` — 1550 tests across all packages green
- [x] `tsc --noEmit` clean for dashboard package
- [ ] Manual UI smoke: NOT performed in this session (no browser available). Recommended manual check on review:
  - Failed run → Retry button → dialog opens → Cancel closes → Confirm posts → redirects to run-detail with new run linked via parentRunId in the feed
  - Succeeded run → no Retry button visible
  - Unlicensed deployment → no Retry button visible (matches the route's existing 404 behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)