### PR TITLE
chore(release): bump core 0.1.15→0.1.16 + cascade cli 0.1.17→0.1.18 + dashboard 0.1.15→0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ notes call out when a change affects only a single package.
 
 ### Fixed
 - `@urateam/dashboard`: retry button is now hidden in unlicensed deployments. The route's 404 enforcement was already correct; the view's `canRetry` flag was inconsistently defaulting to `true` (BEC-133).
+- `@urateam/core`: PR-comment-triggered review-feedback runs no longer fail with `Reached maximum number of turns (50)`. The runner was passing review comments as a `ralphContext` text suffix while the implement template fell through to the standard "create branch + implement issue from scratch" prompt — agent saw a contradictory prompt and burned all 50 turns. `executeFeedbackPipeline` now builds a structured `ReviewFeedbackContext` (via the new exported `buildReviewFeedbackContext()` helper) and routes it into the implement template's dedicated review-feedback branch (#137).
+- `@urateam/core`: rebase-conflict resolution in the push-queue path no longer reuses the standard implement template. New `MergeConflictContext` type + dedicated template branch — focuses narrowly on `git status` / resolve markers / `git rebase --continue`; strips out issue data, INTEGRATION REQUIREMENT, acceptance-criteria verification, and build/test runs that were burning the agent's turn budget on irrelevant work (#137).
+- `@urateam/core`: `reviewFeedbackBlock` now includes a `WARNING:` preamble inside `<review-feedback>`, matching the convention used by `<issue-data>` and `<previous-stage-context>`. Restores the in-band instruction-isolation defense that the previous text-form path provided (#137).
+- `@urateam/core`: review-feedback implement template no longer instructs the agent to `git checkout` the PR branch. The worktree is already on the right branch via `createWorktreeFromRemote`, and per CLAUDE.md "Worktree Isolation Model", running `git checkout` inside a worktree can corrupt other concurrent runs sharing the same `.git`. Replaced with explicit "stay on current branch — do NOT run `git checkout`" (#137).
 
 ## [0.1.6] - 2026-04-13
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

- Patch-bump `@urateam/core` for the bug fix in #137 (PR-comment review-feedback runs were hitting max turns).
- Cascade-bump `@urateam/cli` and `@urateam/dashboard` so the published tarballs re-pin `@urateam/core@0.1.16`.
- CHANGELOG `[Unreleased] > Fixed` entries describe the four behavior changes from #137.

## Test plan

- [x] `pnpm install` clean (no lockfile churn — `workspace:*` deps)
- [ ] CI green
- [ ] Merge → tag `v0.1.30` → push tag → publish workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)