### PR TITLE
feat(core): OpenRouter multi-model review fanout (BEC-134)

### DIFF
--- a/docs/superpowers/plans/2026-04-30-bec-134-openrouter-fanout.md
+++ b/docs/superpowers/plans/2026-04-30-bec-134-openrouter-fanout.md
@@ -1,0 +1,2310 @@
+# BEC-134 OpenRouter Multi-Model Fanout — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send the review stage to N models in parallel via OpenRouter. Findings post as labeled PR comments; existing agentic deep-review remains the merge gate.
+
+**Architecture:** New `ReviewProvider` interface with two implementations: `AgenticDeepReviewProvider` (thin wrapper around the existing single-pass `runDeepReview`) and `OpenRouterFanoutProvider` (N parallel single-shot chat-completions). Fanout runs **once** outside the existing multi-pass convergence loop; agentic continues per-pass via its wrapper. Per-model results persist to a new `review_model_runs` table.
+
+**Tech Stack:** TypeScript, Node 20+, drizzle-orm (SQLite + Postgres), vitest, fetch (Node native), Octokit. Existing patterns: `process.env` direct reads, vitest mocks for `fetch`.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-bec-134-openrouter-fanout-design.md`
+
+---
+
+## File Structure
+
+```
+packages/core/src/executor/review/
+  review-provider.ts             # interface + ReviewModelRun type + registry
+  agentic-deep-review.ts         # AgenticDeepReviewProvider — wraps runDeepReview()
+  openrouter-client.ts           # low-level fetch wrapper for /chat/completions
+  review-prompt.ts               # buildReviewPrompt() + parseReviewFindings()
+  openrouter-fanout.ts           # OpenRouterFanoutProvider — Promise.allSettled fanout
+  post-fanout-comments.ts        # render markdown + addPRComment per run
+
+packages/core/src/db/
+  schema.ts                      # ADD reviewModelRuns table
+  migrations/sqlite/008_review_model_runs.sql
+  migrations/postgres/009_review_model_runs.sql
+  review-model-runs.ts           # NEW — insertReviewModelRuns(stageRunId, runs[])
+
+packages/core/src/cost/
+  per-run.ts                     # JOIN review_model_runs in rollup
+
+packages/core/src/pipeline/
+  runner.ts                      # MODIFY — replace runDeepReview call site
+
+packages/core/src/__tests__/
+  review-provider-registry.test.ts
+  agentic-deep-review-provider.test.ts
+  openrouter-client.test.ts
+  review-prompt.test.ts
+  openrouter-fanout.test.ts
+  post-fanout-comments.test.ts
+  db-review-model-runs.test.ts
+  cost/per-run-multi-model.test.ts
+  e2e-pipeline.test.ts            # EXTEND existing
+
+packages/create-urateam/
+  src/index.ts                   # MODIFY — optional ScaffoldOptions + buildEnv
+  template/.urateam/.env.example # MODIFY — add commented fanout block
+```
+
+Order rationale: types & schema first (Task 1, 3), pure helpers next (Task 4–6), assembly (Task 7–9), wire-up last (Task 10–13). Each task is independently committable; tests pass after every commit.
+
+---
+
+## Task 1: ReviewProvider interface and ReviewModelRun type
+
+**Files:**
+- Create: `packages/core/src/executor/review/review-provider.ts`
+- Test: `packages/core/src/__tests__/review-provider-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/review-provider-registry.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  getEnabledProviders,
+  type ReviewProvider,
+  type ReviewModelRun,
+  type ReviewContext,
+} from "../executor/review/review-provider.js";
+
+describe("review-provider registry", () => {
+  it("exports the ReviewProvider interface and ReviewModelRun type", () => {
+    // Compile-time existence check via type assignment
+    const _checkRun: ReviewModelRun = {
+      modelId: "x",
+      providerId: "agentic",
+      status: "completed",
+      findings: [],
+      inputTokens: 0,
+      outputTokens: 0,
+      durationMs: 0,
+    };
+    expect(_checkRun.modelId).toBe("x");
+  });
+
+  it("returns at least the agentic provider when env is empty", () => {
+    const providers = getEnabledProviders({});
+    expect(providers.length).toBeGreaterThanOrEqual(1);
+    expect(providers.some((p) => p.id === "agentic")).toBe(true);
+  });
+
+  it("ReviewProvider has runReview signature", () => {
+    const providers = getEnabledProviders({});
+    const p: ReviewProvider = providers[0];
+    expect(typeof p.runReview).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- review-provider-registry`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the interface and a stub registry**
+
+```ts
+// packages/core/src/executor/review/review-provider.ts
+import type { HandoffArtifact, ReviewFinding } from "../../types.js";
+
+export type ReviewProviderId = "agentic" | "openrouter";
+
+export interface ReviewContext {
+  runId: string;
+  stageRunId: string;
+  workdir: string;
+  handoff: HandoffArtifact;
+  baseRef: string;
+  prNumber: number | null;
+}
+
+export interface ReviewModelRun {
+  modelId: string;
+  providerId: ReviewProviderId;
+  status: "completed" | "failed";
+  findings: ReviewFinding[];
+  inputTokens: number;
+  outputTokens: number;
+  durationMs: number;
+  errorMessage?: string;
+  truncatedFiles?: number;
+}
+
+export interface ReviewProvider {
+  readonly id: ReviewProviderId;
+  runReview(ctx: ReviewContext): Promise<ReviewModelRun[]>;
+}
+
+// Stub registry — Task 7 fills in real selection logic.
+// For now, returns only a placeholder that satisfies the interface, so callers
+// in later tasks can typecheck. AgenticDeepReviewProvider arrives in Task 2;
+// we wire it in here at that point.
+const placeholderAgentic: ReviewProvider = {
+  id: "agentic",
+  async runReview(_ctx) {
+    return [];
+  },
+};
+
+export function getEnabledProviders(_env: NodeJS.ProcessEnv): ReviewProvider[] {
+  return [placeholderAgentic];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- review-provider-registry`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/executor/review/review-provider.ts \
+        packages/core/src/__tests__/review-provider-registry.test.ts
+git commit -m "feat(core): ReviewProvider interface and registry stub (BEC-134)"
+```
+
+---
+
+## Task 2: AgenticDeepReviewProvider — thin wrapper around runDeepReview
+
+**Files:**
+- Create: `packages/core/src/executor/review/agentic-deep-review.ts`
+- Test: `packages/core/src/__tests__/agentic-deep-review-provider.test.ts`
+- Modify: `packages/core/src/executor/review/review-provider.ts` (replace placeholder)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/agentic-deep-review-provider.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HandoffArtifact } from "../types.js";
+
+const runDeepReviewMock = vi.fn();
+vi.mock("../executor/deep-review.js", () => ({
+  runDeepReview: (...args: unknown[]) => runDeepReviewMock(...args),
+  deepFindingsToReviewFindings: (findings: unknown[]) => findings,
+}));
+
+const makeHandoff = (): HandoffArtifact => ({
+  runId: "r1",
+  issueId: "i1",
+  stage: "review",
+  timestamp: new Date().toISOString(),
+  summary: "",
+  filesChanged: [],
+  approach: "",
+  context: { issueIntent: "do x", constraints: [], assumptions: [] },
+  tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 },
+});
+
+describe("AgenticDeepReviewProvider", () => {
+  beforeEach(() => runDeepReviewMock.mockReset());
+
+  it("returns a single ReviewModelRun with completed status on success", async () => {
+    runDeepReviewMock.mockResolvedValue({
+      findings: [
+        { severity: "warning", file: "a.ts", line: 1, category: "x", description: "d", fix: "f" },
+      ],
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+
+    const { AgenticDeepReviewProvider } = await import(
+      "../executor/review/agentic-deep-review.js"
+    );
+    const provider = new AgenticDeepReviewProvider();
+
+    const runs = await provider.runReview({
+      runId: "r1",
+      stageRunId: "s1",
+      workdir: "/tmp/x",
+      handoff: makeHandoff(),
+      baseRef: "main",
+      prNumber: null,
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].providerId).toBe("agentic");
+    expect(runs[0].status).toBe("completed");
+    expect(runs[0].modelId).toBe("claude-haiku-4-5-20251001");
+    expect(runs[0].findings).toHaveLength(1);
+    expect(runs[0].inputTokens).toBe(100);
+    expect(runs[0].outputTokens).toBe(50);
+    expect(runDeepReviewMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns failed run with errorMessage when runDeepReview throws", async () => {
+    runDeepReviewMock.mockRejectedValue(new Error("agent sdk down"));
+    const { AgenticDeepReviewProvider } = await import(
+      "../executor/review/agentic-deep-review.js"
+    );
+    const provider = new AgenticDeepReviewProvider();
+
+    const runs = await provider.runReview({
+      runId: "r1",
+      stageRunId: "s1",
+      workdir: "/tmp/x",
+      handoff: makeHandoff(),
+      baseRef: "main",
+      prNumber: null,
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("failed");
+    expect(runs[0].errorMessage).toContain("agent sdk down");
+    expect(runs[0].findings).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- agentic-deep-review-provider`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the wrapper**
+
+```ts
+// packages/core/src/executor/review/agentic-deep-review.ts
+import { runDeepReview, deepFindingsToReviewFindings } from "../deep-review.js";
+import type { ReviewProvider, ReviewModelRun, ReviewContext } from "./review-provider.js";
+
+const DEEP_REVIEW_MODEL = "claude-haiku-4-5-20251001";
+
+export class AgenticDeepReviewProvider implements ReviewProvider {
+  readonly id = "agentic" as const;
+
+  async runReview(ctx: ReviewContext): Promise<ReviewModelRun[]> {
+    const startedAt = Date.now();
+    try {
+      const result = await runDeepReview(ctx.handoff, ctx.workdir);
+      return [
+        {
+          modelId: DEEP_REVIEW_MODEL,
+          providerId: "agentic",
+          status: "completed",
+          findings: deepFindingsToReviewFindings(result.findings),
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+          durationMs: Date.now() - startedAt,
+        },
+      ];
+    } catch (err) {
+      return [
+        {
+          modelId: DEEP_REVIEW_MODEL,
+          providerId: "agentic",
+          status: "failed",
+          findings: [],
+          inputTokens: 0,
+          outputTokens: 0,
+          durationMs: Date.now() - startedAt,
+          errorMessage: err instanceof Error ? err.message : String(err),
+        },
+      ];
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Wire into the registry (replace placeholder)**
+
+```ts
+// packages/core/src/executor/review/review-provider.ts
+// Replace the placeholderAgentic block + getEnabledProviders body with:
+
+import { AgenticDeepReviewProvider } from "./agentic-deep-review.js";
+
+export function getEnabledProviders(_env: NodeJS.ProcessEnv): ReviewProvider[] {
+  return [new AgenticDeepReviewProvider()];
+}
+```
+
+(Keep the interface and types above untouched. Delete the `placeholderAgentic` constant.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm --filter @urateam/core test -- agentic-deep-review-provider review-provider-registry`
+Expected: PASS (5 tests total).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/executor/review/agentic-deep-review.ts \
+        packages/core/src/executor/review/review-provider.ts \
+        packages/core/src/__tests__/agentic-deep-review-provider.test.ts
+git commit -m "feat(core): AgenticDeepReviewProvider wraps runDeepReview (BEC-134)"
+```
+
+---
+
+## Task 3: Schema migration — review_model_runs table
+
+**Files:**
+- Create: `packages/core/src/db/migrations/sqlite/008_review_model_runs.sql`
+- Create: `packages/core/src/db/migrations/postgres/009_review_model_runs.sql`
+- Modify: `packages/core/src/db/schema.ts` (add table at end)
+- Test: `packages/core/src/__tests__/db-review-model-runs.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/db-review-model-runs.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrationsSqlite } from "../db/migrator.js";
+
+describe("review_model_runs migration (sqlite)", () => {
+  it("creates the table with expected columns", () => {
+    const db = new Database(":memory:");
+    runMigrationsSqlite(db);
+
+    const cols = db
+      .prepare("PRAGMA table_info(review_model_runs)")
+      .all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual(
+      [
+        "completed_at",
+        "duration_ms",
+        "error_message",
+        "id",
+        "input_tokens",
+        "model_id",
+        "output_tokens",
+        "provider_id",
+        "stage_run_id",
+        "started_at",
+        "status",
+        "truncated_files",
+      ].sort(),
+    );
+  });
+
+  it("creates an index on stage_run_id", () => {
+    const db = new Database(":memory:");
+    runMigrationsSqlite(db);
+    const indexes = db
+      .prepare("PRAGMA index_list(review_model_runs)")
+      .all() as Array<{ name: string }>;
+    expect(indexes.some((i) => i.name.includes("stage_run_id"))).toBe(true);
+  });
+
+  it("inserts and reads rows", () => {
+    const db = new Database(":memory:");
+    runMigrationsSqlite(db);
+
+    // Need a stage_run row first (FK)
+    db.prepare(
+      "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run("p1", "i1", "t", "k", "u", "running", Math.floor(Date.now() / 1000));
+    db.prepare(
+      "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "p1", "review", "completed", Math.floor(Date.now() / 1000));
+
+    db.prepare(
+      "INSERT INTO review_model_runs (id, stage_run_id, provider_id, model_id, status, input_tokens, output_tokens, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("r1", "s1", "openrouter", "anthropic/claude-3.5-sonnet", "completed", 100, 50, 1000);
+
+    const rows = db
+      .prepare("SELECT * FROM review_model_runs WHERE stage_run_id = ?")
+      .all("s1");
+    expect(rows).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- db-review-model-runs`
+Expected: FAIL — `no such table: review_model_runs`.
+
+- [ ] **Step 3: Add the SQLite migration**
+
+```sql
+-- packages/core/src/db/migrations/sqlite/008_review_model_runs.sql
+-- BEC-134: per-model results from review-stage fanout.
+CREATE TABLE IF NOT EXISTS review_model_runs (
+  id TEXT PRIMARY KEY,
+  stage_run_id TEXT NOT NULL REFERENCES stage_runs(id),
+  provider_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  truncated_files INTEGER NOT NULL DEFAULT 0,
+  started_at INTEGER,
+  completed_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_model_runs_stage_run_id
+  ON review_model_runs(stage_run_id);
+```
+
+- [ ] **Step 4: Add the Postgres migration**
+
+```sql
+-- packages/core/src/db/migrations/postgres/009_review_model_runs.sql
+-- BEC-134: per-model results from review-stage fanout.
+CREATE TABLE IF NOT EXISTS review_model_runs (
+  id TEXT PRIMARY KEY,
+  stage_run_id TEXT NOT NULL REFERENCES stage_runs(id),
+  provider_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  truncated_files INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_model_runs_stage_run_id
+  ON review_model_runs(stage_run_id);
+```
+
+- [ ] **Step 5: Add the drizzle table definition**
+
+Append to `packages/core/src/db/schema.ts` (after the existing tables):
+
+```ts
+export const reviewModelRuns = sqliteTable("review_model_runs", {
+  id: text("id").primaryKey(),
+  stageRunId: text("stage_run_id")
+    .notNull()
+    .references(() => stageRuns.id),
+  providerId: text("provider_id").notNull(),
+  modelId: text("model_id").notNull(),
+  status: text("status").notNull(),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  durationMs: integer("duration_ms").notNull().default(0),
+  errorMessage: text("error_message"),
+  truncatedFiles: integer("truncated_files").notNull().default(0),
+  startedAt: crossTimestamp("started_at"),
+  completedAt: crossTimestamp("completed_at"),
+});
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pnpm --filter @urateam/core test -- db-review-model-runs db.test`
+Expected: PASS. Existing migrator tests still pass (no regression).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/db/migrations/sqlite/008_review_model_runs.sql \
+        packages/core/src/db/migrations/postgres/009_review_model_runs.sql \
+        packages/core/src/db/schema.ts \
+        packages/core/src/__tests__/db-review-model-runs.test.ts
+git commit -m "feat(core): review_model_runs schema + migrations (BEC-134)"
+```
+
+---
+
+## Task 4: OpenRouterClient — low-level chat-completion wrapper
+
+**Files:**
+- Create: `packages/core/src/executor/review/openrouter-client.ts`
+- Test: `packages/core/src/__tests__/openrouter-client.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/openrouter-client.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("OpenRouterClient", () => {
+  const fetchMock = vi.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("posts to /chat/completions with auth header and returns content + tokens", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "hello" } }],
+          usage: { prompt_tokens: 12, completion_tokens: 7 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({
+      apiKey: "sk-or-test",
+      baseUrl: "https://example.test/api/v1",
+    });
+    const result = await client.chatCompletion(
+      "anthropic/claude-3.5-sonnet",
+      [{ role: "user", content: "hi" }],
+      { signal: new AbortController().signal },
+    );
+    expect(result).toEqual({ content: "hello", inputTokens: 12, outputTokens: 7 });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.test/api/v1/chat/completions");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer sk-or-test");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("throws on non-2xx with status and snippet of body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("rate limited bro", { status: 429 }),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    await expect(
+      client.chatCompletion("m", [{ role: "user", content: "x" }], {
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/openrouter 429/);
+  });
+
+  it("propagates AbortController abort as a rejection", async () => {
+    const ac = new AbortController();
+    fetchMock.mockImplementation((_url, init: RequestInit) => {
+      return new Promise((_, reject) => {
+        init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    const p = client.chatCompletion("m", [{ role: "user", content: "x" }], { signal: ac.signal });
+    ac.abort();
+    await expect(p).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- openrouter-client`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the client**
+
+```ts
+// packages/core/src/executor/review/openrouter-client.ts
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface OpenRouterClientConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+export interface ChatCompletionResult {
+  content: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ChatCompletionOpts {
+  signal: AbortSignal;
+  maxTokens?: number;
+}
+
+export class OpenRouterClient {
+  constructor(private readonly cfg: OpenRouterClientConfig) {}
+
+  async chatCompletion(
+    modelId: string,
+    messages: ChatMessage[],
+    opts: ChatCompletionOpts,
+  ): Promise<ChatCompletionResult> {
+    const res = await fetch(`${this.cfg.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${this.cfg.apiKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://urateams.com",
+        "X-Title": "urateam",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        messages,
+        max_tokens: opts.maxTokens,
+      }),
+      signal: opts.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`openrouter ${res.status} ${body.slice(0, 200)}`);
+    }
+    const json = (await res.json()) as {
+      choices: Array<{ message: { content: string } }>;
+      usage: { prompt_tokens: number; completion_tokens: number };
+    };
+    return {
+      content: json.choices[0]?.message?.content ?? "",
+      inputTokens: json.usage?.prompt_tokens ?? 0,
+      outputTokens: json.usage?.completion_tokens ?? 0,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- openrouter-client`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/executor/review/openrouter-client.ts \
+        packages/core/src/__tests__/openrouter-client.test.ts
+git commit -m "feat(core): OpenRouterClient chat-completion wrapper (BEC-134)"
+```
+
+---
+
+## Task 5: review-prompt — build prompt and parse model output
+
+**Files:**
+- Create: `packages/core/src/executor/review/review-prompt.ts`
+- Test: `packages/core/src/__tests__/review-prompt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/review-prompt.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  buildReviewPrompt,
+  parseReviewFindings,
+  estimateTokens,
+} from "../executor/review/review-prompt.js";
+import type { HandoffArtifact } from "../types.js";
+
+const handoff: HandoffArtifact = {
+  runId: "r1",
+  issueId: "i1",
+  stage: "review",
+  timestamp: "2026-04-30T00:00:00Z",
+  summary: "",
+  filesChanged: ["src/foo.ts"],
+  approach: "",
+  context: {
+    issueIntent: "Fix bug X",
+    constraints: ["no new deps"],
+    assumptions: ["node 20"],
+  },
+  tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 },
+};
+
+describe("buildReviewPrompt", () => {
+  it("includes intent, constraints, diff, and JSON-output instruction", () => {
+    const prompt = buildReviewPrompt({
+      handoff,
+      diff: "diff --git a/src/foo.ts b/src/foo.ts\n+++ b/src/foo.ts\n@@\n+x",
+      files: [{ path: "src/foo.ts", body: "export const x = 1;" }],
+      maxInputTokens: 100_000,
+    });
+    expect(prompt.messages).toHaveLength(2);
+    expect(prompt.messages[0].role).toBe("system");
+    expect(prompt.messages[1].role).toBe("user");
+    expect(prompt.messages[1].content).toContain("Fix bug X");
+    expect(prompt.messages[1].content).toContain("no new deps");
+    expect(prompt.messages[1].content).toContain("diff --git");
+    expect(prompt.messages[1].content).toContain("export const x = 1;");
+    expect(prompt.messages[0].content).toContain("findings");  // schema instruction
+    expect(prompt.truncatedFiles).toBe(0);
+  });
+
+  it("drops file bodies tail-first when over budget but keeps the diff", () => {
+    const big = "x".repeat(20_000);
+    const out = buildReviewPrompt({
+      handoff,
+      diff: "diff --git a/foo b/foo\n+y",
+      files: [
+        { path: "a.ts", body: big },
+        { path: "b.ts", body: big },
+        { path: "c.ts", body: big },
+      ],
+      maxInputTokens: 6_000, // forces truncation
+    });
+    expect(out.truncatedFiles).toBeGreaterThan(0);
+    expect(out.messages[1].content).toContain("diff --git");
+  });
+});
+
+describe("parseReviewFindings", () => {
+  it("extracts the first balanced JSON object and validates against schema", () => {
+    const raw = `Sure, here is the review:
+\`\`\`json
+{ "findings": [
+  { "severity": "warning", "file": "a.ts", "line": 1, "category": "x", "description": "d", "fix": "f" }
+] }
+\`\`\`
+End.`;
+    const findings = parseReviewFindings(raw);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warning");
+  });
+
+  it("throws on malformed JSON", () => {
+    expect(() => parseReviewFindings("not json at all")).toThrow();
+  });
+
+  it("throws when schema validation fails", () => {
+    expect(() => parseReviewFindings('{"findings":[{"bad":true}]}')).toThrow();
+  });
+});
+
+describe("estimateTokens", () => {
+  it("returns a roughly char/4 estimate", () => {
+    expect(estimateTokens("a".repeat(40))).toBe(10);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- review-prompt`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the prompt builder + parser**
+
+```ts
+// packages/core/src/executor/review/review-prompt.ts
+import { z } from "zod";
+import { ReviewFindingSchema, type ReviewFinding, type HandoffArtifact } from "../../types.js";
+import type { ChatMessage } from "./openrouter-client.js";
+
+const SYSTEM_PROMPT = `You are a careful code reviewer. Review the diff and changed files for issues in three dimensions:
+- reuse: duplication of existing code
+- quality: bugs, error-handling, type misuse, edge cases
+- efficiency: needless work, N+1 queries, hot-loop allocations
+
+Output exactly one JSON object and nothing else, matching this shape:
+{ "findings": [
+    { "severity": "blocking" | "warning" | "suggestion",
+      "file": "path/to/file.ext",
+      "line": <integer>,
+      "category": "reuse" | "quality" | "efficiency",
+      "description": "<concise>",
+      "fix": "<concrete suggestion>" }
+  ]
+}
+Return an empty findings array if you find nothing.`;
+
+export interface BuildPromptInput {
+  handoff: HandoffArtifact;
+  diff: string;
+  files: Array<{ path: string; body: string }>;
+  maxInputTokens: number;
+}
+
+export interface BuiltPrompt {
+  messages: ChatMessage[];
+  estimatedInputTokens: number;
+  truncatedFiles: number;
+}
+
+/** Cheap heuristic: ~4 chars/token. Good enough to gate truncation. */
+export function estimateTokens(s: string): number {
+  return Math.ceil(s.length / 4);
+}
+
+export function buildReviewPrompt(input: BuildPromptInput): BuiltPrompt {
+  const { handoff, diff, files, maxInputTokens } = input;
+  const intentBlock = [
+    "## Intent",
+    handoff.context.issueIntent,
+    "",
+    "## Constraints",
+    ...handoff.context.constraints.map((c) => `- ${c}`),
+    "",
+    "## Assumptions",
+    ...handoff.context.assumptions.map((a) => `- ${a}`),
+    "",
+  ].join("\n");
+
+  const diffBlock = ["## Diff", "```diff", diff, "```", ""].join("\n");
+
+  // Token-budget tail-truncate file bodies. Keep diff and intent always.
+  const fixedTokens = estimateTokens(SYSTEM_PROMPT) + estimateTokens(intentBlock) + estimateTokens(diffBlock);
+  let remaining = maxInputTokens - fixedTokens;
+  const includedFiles: typeof files = [];
+  let truncatedFiles = 0;
+  for (const f of files) {
+    const block = `\n## File: ${f.path}\n\`\`\`\n${f.body}\n\`\`\`\n`;
+    const cost = estimateTokens(block);
+    if (cost <= remaining) {
+      includedFiles.push(f);
+      remaining -= cost;
+    } else {
+      truncatedFiles += 1;
+    }
+  }
+
+  const filesBlock = includedFiles
+    .map((f) => `\n## File: ${f.path}\n\`\`\`\n${f.body}\n\`\`\`\n`)
+    .join("");
+
+  const userContent = `${intentBlock}\n${diffBlock}\n${filesBlock}`;
+
+  return {
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userContent },
+    ],
+    estimatedInputTokens: fixedTokens + estimateTokens(filesBlock),
+    truncatedFiles,
+  };
+}
+
+const FindingsEnvelopeSchema = z.object({
+  findings: z.array(ReviewFindingSchema),
+});
+
+/** Extract the first balanced top-level JSON object from a string. */
+function extractFirstJsonObject(s: string): string | null {
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === "\\") {
+        escape = true;
+      } else if (c === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "{") {
+      if (depth === 0) start = i;
+      depth += 1;
+    } else if (c === "}") {
+      depth -= 1;
+      if (depth === 0 && start >= 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+export function parseReviewFindings(raw: string): ReviewFinding[] {
+  const objStr = extractFirstJsonObject(raw);
+  if (!objStr) throw new Error("model output not parseable as ReviewFinding[]: no JSON object found");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(objStr);
+  } catch (e) {
+    throw new Error(`model output not parseable as ReviewFinding[]: ${(e as Error).message}`);
+  }
+  const result = FindingsEnvelopeSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`model output not parseable as ReviewFinding[]: ${result.error.message}`);
+  }
+  return result.data.findings;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- review-prompt`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/executor/review/review-prompt.ts \
+        packages/core/src/__tests__/review-prompt.test.ts
+git commit -m "feat(core): review-prompt builder + parser with token-cap truncation (BEC-134)"
+```
+
+---
+
+## Task 6: OpenRouterFanoutProvider — N parallel single-shot reviews
+
+**Files:**
+- Create: `packages/core/src/executor/review/openrouter-fanout.ts`
+- Test: `packages/core/src/__tests__/openrouter-fanout.test.ts`
+
+This task introduces the per-model fanout. It uses `OpenRouterClient` (Task 4) and `buildReviewPrompt`/`parseReviewFindings` (Task 5). It depends on a small helper that gathers diff + changed-file bodies from the workdir; we keep that helper inline in this file (no separate task).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/openrouter-fanout.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HandoffArtifact } from "../types.js";
+
+const chatCompletion = vi.fn();
+vi.mock("../executor/review/openrouter-client.js", () => ({
+  OpenRouterClient: class {
+    chatCompletion = chatCompletion;
+  },
+}));
+// Stub git diff + file collection so test does not need a real workdir
+vi.mock("../executor/review/workdir-snapshot.js", () => ({
+  collectWorkdirSnapshot: async () => ({
+    diff: "diff --git a/x b/x\n+y",
+    files: [{ path: "x", body: "y" }],
+  }),
+}));
+
+const handoff: HandoffArtifact = {
+  runId: "r1",
+  issueId: "i1",
+  stage: "review",
+  timestamp: "2026-04-30T00:00:00Z",
+  summary: "",
+  filesChanged: ["x"],
+  approach: "",
+  context: { issueIntent: "do x", constraints: [], assumptions: [] },
+  tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 },
+};
+
+const ctx = () => ({
+  runId: "r1",
+  stageRunId: "s1",
+  workdir: "/tmp/wd",
+  handoff,
+  baseRef: "main",
+  prNumber: 42,
+});
+
+describe("OpenRouterFanoutProvider", () => {
+  beforeEach(() => chatCompletion.mockReset());
+
+  const validJson = `{"findings":[{"severity":"warning","file":"a","line":1,"category":"quality","description":"d","fix":"f"}]}`;
+
+  it("runs N parallel calls and returns one ReviewModelRun per model", async () => {
+    chatCompletion.mockResolvedValue({ content: validJson, inputTokens: 10, outputTokens: 5 });
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k",
+      baseUrl: "https://x/api/v1",
+      models: ["m1", "m2", "m3"],
+      timeoutMs: 1000,
+      maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    expect(runs).toHaveLength(3);
+    expect(runs.map((r) => r.modelId).sort()).toEqual(["m1", "m2", "m3"]);
+    expect(runs.every((r) => r.status === "completed")).toBe(true);
+    expect(chatCompletion).toHaveBeenCalledTimes(3);
+  });
+
+  it("partial failure: one model rejects, others complete", async () => {
+    chatCompletion
+      .mockResolvedValueOnce({ content: validJson, inputTokens: 1, outputTokens: 1 })
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ content: validJson, inputTokens: 1, outputTokens: 1 });
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k", baseUrl: "https://x/api/v1",
+      models: ["m1", "m2", "m3"], timeoutMs: 1000, maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    const failed = runs.filter((r) => r.status === "failed");
+    const ok = runs.filter((r) => r.status === "completed");
+    expect(failed).toHaveLength(1);
+    expect(failed[0].errorMessage).toContain("boom");
+    expect(ok).toHaveLength(2);
+  });
+
+  it("malformed JSON output → run failed with parser error", async () => {
+    chatCompletion.mockResolvedValue({ content: "not json", inputTokens: 1, outputTokens: 1 });
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k", baseUrl: "https://x/api/v1",
+      models: ["m1"], timeoutMs: 1000, maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    expect(runs[0].status).toBe("failed");
+    expect(runs[0].errorMessage).toContain("not parseable");
+  });
+
+  it("all models fail → returns N failed runs (does not throw)", async () => {
+    chatCompletion.mockRejectedValue(new Error("dead"));
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k", baseUrl: "https://x/api/v1",
+      models: ["m1", "m2"], timeoutMs: 1000, maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    expect(runs).toHaveLength(2);
+    expect(runs.every((r) => r.status === "failed")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- openrouter-fanout`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the workdir snapshot helper**
+
+```ts
+// packages/core/src/executor/review/workdir-snapshot.ts
+import { gitExecSafe } from "../../repo/git.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface WorkdirSnapshot {
+  diff: string;
+  files: Array<{ path: string; body: string }>;
+}
+
+/**
+ * Collect the diff against baseRef and the body of every changed file.
+ * Used as input to the single-shot review prompt.
+ */
+export async function collectWorkdirSnapshot(
+  workdir: string,
+  baseRef: string,
+): Promise<WorkdirSnapshot> {
+  const diffOut = await gitExecSafe(["diff", `${baseRef}...HEAD`], { cwd: workdir });
+  const namesOut = await gitExecSafe(
+    ["diff", "--name-only", `${baseRef}...HEAD`],
+    { cwd: workdir },
+  );
+  const paths = namesOut.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  const files: Array<{ path: string; body: string }> = [];
+  for (const p of paths) {
+    try {
+      const body = await readFile(join(workdir, p), "utf8");
+      files.push({ path: p, body });
+    } catch {
+      // file deleted in HEAD — skip
+    }
+  }
+  return { diff: diffOut.stdout, files };
+}
+```
+
+- [ ] **Step 4: Implement the fanout provider**
+
+```ts
+// packages/core/src/executor/review/openrouter-fanout.ts
+import type { ReviewProvider, ReviewModelRun, ReviewContext } from "./review-provider.js";
+import { OpenRouterClient } from "./openrouter-client.js";
+import { buildReviewPrompt, parseReviewFindings } from "./review-prompt.js";
+import { collectWorkdirSnapshot } from "./workdir-snapshot.js";
+import { createLogger } from "../../logger.js";
+
+const log = createLogger({ component: "OpenRouterFanout" });
+
+export interface OpenRouterFanoutConfig {
+  apiKey: string;
+  baseUrl: string;
+  models: string[];
+  timeoutMs: number;
+  maxInputTokens: number;
+}
+
+export class OpenRouterFanoutProvider implements ReviewProvider {
+  readonly id = "openrouter" as const;
+  private readonly client: OpenRouterClient;
+
+  constructor(private readonly cfg: OpenRouterFanoutConfig) {
+    this.client = new OpenRouterClient({ apiKey: cfg.apiKey, baseUrl: cfg.baseUrl });
+  }
+
+  async runReview(ctx: ReviewContext): Promise<ReviewModelRun[]> {
+    const snapshot = await collectWorkdirSnapshot(ctx.workdir, ctx.baseRef);
+    const prompt = buildReviewPrompt({
+      handoff: ctx.handoff,
+      diff: snapshot.diff,
+      files: snapshot.files,
+      maxInputTokens: this.cfg.maxInputTokens,
+    });
+
+    const settled = await Promise.allSettled(
+      this.cfg.models.map((modelId) => this.runOne(modelId, prompt)),
+    );
+
+    return settled.map((res, i) => {
+      const modelId = this.cfg.models[i];
+      if (res.status === "fulfilled") {
+        return { ...res.value, truncatedFiles: prompt.truncatedFiles || undefined };
+      }
+      const err = res.reason as Error;
+      log.warn({ modelId, err: err.message }, "fanout model failed");
+      return {
+        modelId,
+        providerId: "openrouter",
+        status: "failed",
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: 0,
+        errorMessage: err.message,
+        truncatedFiles: prompt.truncatedFiles || undefined,
+      };
+    });
+  }
+
+  private async runOne(
+    modelId: string,
+    prompt: ReturnType<typeof buildReviewPrompt>,
+  ): Promise<ReviewModelRun> {
+    const startedAt = Date.now();
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.cfg.timeoutMs);
+    try {
+      const result = await this.client.chatCompletion(modelId, prompt.messages, {
+        signal: ac.signal,
+      });
+      const findings = parseReviewFindings(result.content);
+      return {
+        modelId,
+        providerId: "openrouter",
+        status: "completed",
+        findings,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        durationMs: Date.now() - startedAt,
+      };
+    } catch (err) {
+      const msg =
+        ac.signal.aborted
+          ? `timed out after ${this.cfg.timeoutMs}ms`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return {
+        modelId,
+        providerId: "openrouter",
+        status: "failed",
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: Date.now() - startedAt,
+        errorMessage: msg,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- openrouter-fanout`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/executor/review/openrouter-fanout.ts \
+        packages/core/src/executor/review/workdir-snapshot.ts \
+        packages/core/src/__tests__/openrouter-fanout.test.ts
+git commit -m "feat(core): OpenRouterFanoutProvider with allSettled best-effort fanout (BEC-134)"
+```
+
+---
+
+## Task 7: Registry env validation and fanout selection
+
+**Files:**
+- Modify: `packages/core/src/executor/review/review-provider.ts`
+- Modify: `packages/core/src/__tests__/review-provider-registry.test.ts`
+
+- [ ] **Step 1: Extend the failing test**
+
+Append to `packages/core/src/__tests__/review-provider-registry.test.ts`:
+
+```ts
+describe("review-provider registry — fanout selection", () => {
+  it("returns only agentic when REVIEW_MODELS unset", () => {
+    const ps = getEnabledProviders({});
+    expect(ps.map((p) => p.id)).toEqual(["agentic"]);
+  });
+
+  it("adds openrouter when both vars set", () => {
+    const ps = getEnabledProviders({
+      REVIEW_MODELS: "anthropic/claude-3.5-sonnet,openai/gpt-4o",
+      OPENROUTER_API_KEY: "sk-or-x",
+    });
+    expect(ps.map((p) => p.id).sort()).toEqual(["agentic", "openrouter"]);
+  });
+
+  it("throws when REVIEW_MODELS set but OPENROUTER_API_KEY missing", () => {
+    expect(() => getEnabledProviders({ REVIEW_MODELS: "x/y" })).toThrow(
+      /OPENROUTER_API_KEY/,
+    );
+  });
+
+  it("throws when OPENROUTER_API_KEY set but REVIEW_MODELS missing", () => {
+    expect(() => getEnabledProviders({ OPENROUTER_API_KEY: "sk" })).toThrow(
+      /REVIEW_MODELS/,
+    );
+  });
+
+  it("treats whitespace-only REVIEW_MODELS as unset", () => {
+    const ps = getEnabledProviders({ REVIEW_MODELS: " , , ", OPENROUTER_API_KEY: "sk" });
+    // Both unset semantically → no fanout; but OPENROUTER_API_KEY is set without
+    // any models → that's a misconfig: throw.
+    // Spec: empty after trim → treated as unset → so the "set without other" rule fires.
+    expect(() =>
+      getEnabledProviders({ REVIEW_MODELS: " , , ", OPENROUTER_API_KEY: "sk" }),
+    ).toThrow(/REVIEW_MODELS/);
+  });
+
+  it("trims whitespace and drops empty entries from REVIEW_MODELS", async () => {
+    const ps = getEnabledProviders({
+      REVIEW_MODELS: " m1 , , m2 ,",
+      OPENROUTER_API_KEY: "sk",
+    });
+    const fanout = ps.find((p) => p.id === "openrouter");
+    expect(fanout).toBeDefined();
+    // White-box: read the configured models off the provider.
+    // Cast through unknown to keep the test strict-typed.
+    const models = (fanout as unknown as { cfg: { models: string[] } }).cfg.models;
+    expect(models).toEqual(["m1", "m2"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- review-provider-registry`
+Expected: FAIL on the new fanout-selection cases.
+
+- [ ] **Step 3: Implement registry env logic**
+
+Replace the body of `getEnabledProviders` in `packages/core/src/executor/review/review-provider.ts`:
+
+```ts
+import { AgenticDeepReviewProvider } from "./agentic-deep-review.js";
+import { OpenRouterFanoutProvider } from "./openrouter-fanout.js";
+
+const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_TIMEOUT_MS = 300_000;
+const DEFAULT_MAX_INPUT_TOKENS = 150_000;
+
+export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[] {
+  const providers: ReviewProvider[] = [new AgenticDeepReviewProvider()];
+
+  const rawModels = env.REVIEW_MODELS ?? "";
+  const models = rawModels.split(",").map((s) => s.trim()).filter(Boolean);
+  const apiKey = env.OPENROUTER_API_KEY ?? "";
+  const fanoutDesired = models.length > 0;
+  const keyPresent = apiKey.length > 0;
+
+  if (fanoutDesired && !keyPresent) {
+    throw new Error(
+      "REVIEW_MODELS is set but OPENROUTER_API_KEY is missing — both must be set or both unset.",
+    );
+  }
+  if (keyPresent && !fanoutDesired) {
+    throw new Error(
+      "OPENROUTER_API_KEY is set but REVIEW_MODELS is missing or empty — both must be set or both unset.",
+    );
+  }
+  if (!fanoutDesired) return providers;
+
+  providers.push(
+    new OpenRouterFanoutProvider({
+      apiKey,
+      baseUrl: env.OPENROUTER_BASE_URL ?? DEFAULT_BASE_URL,
+      models,
+      timeoutMs: parseIntOr(env.REVIEW_MODELS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+      maxInputTokens: parseIntOr(env.REVIEW_MODELS_MAX_INPUT_TOKENS, DEFAULT_MAX_INPUT_TOKENS),
+    }),
+  );
+  return providers;
+}
+
+function parseIntOr(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- review-provider-registry`
+Expected: PASS (all cases including the new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/executor/review/review-provider.ts \
+        packages/core/src/__tests__/review-provider-registry.test.ts
+git commit -m "feat(core): registry env validation + OpenRouter fanout selection (BEC-134)"
+```
+
+---
+
+## Task 8: post-fanout-comments — render markdown and post via addPRComment
+
+**Files:**
+- Create: `packages/core/src/executor/review/post-fanout-comments.ts`
+- Test: `packages/core/src/__tests__/post-fanout-comments.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/post-fanout-comments.test.ts
+import { describe, it, expect, vi } from "vitest";
+import type { ReviewModelRun } from "../executor/review/review-provider.js";
+
+const addPRComment = vi.fn();
+vi.mock("../repo/github.js", () => ({ addPRComment }));
+
+const completedRun: ReviewModelRun = {
+  modelId: "anthropic/claude-3.5-sonnet",
+  providerId: "openrouter",
+  status: "completed",
+  findings: [
+    { severity: "warning", file: "a.ts", line: 1, category: "quality", description: "d", fix: "f" },
+  ],
+  inputTokens: 100,
+  outputTokens: 50,
+  durationMs: 1000,
+};
+
+const failedRun: ReviewModelRun = {
+  modelId: "openai/gpt-4o",
+  providerId: "openrouter",
+  status: "failed",
+  findings: [],
+  inputTokens: 0,
+  outputTokens: 0,
+  durationMs: 200,
+  errorMessage: "rate limited",
+};
+
+describe("postFanoutCommentsToPR", () => {
+  it("posts one comment per run with model id and findings table", async () => {
+    addPRComment.mockResolvedValue(undefined);
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    await postFanoutCommentsToPR({} as never, "owner", "repo", 42, [completedRun]);
+    expect(addPRComment).toHaveBeenCalledOnce();
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).toContain("anthropic/claude-3.5-sonnet");
+    expect(body).toContain("Status: completed");
+    expect(body).toContain("warning");
+    expect(body).toContain("a.ts");
+    expect(body).toContain("Advisory only");
+  });
+
+  it("posts a 'failed' comment with errorMessage", async () => {
+    addPRComment.mockResolvedValue(undefined);
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    await postFanoutCommentsToPR({} as never, "o", "r", 1, [failedRun]);
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).toContain("Status: failed");
+    expect(body).toContain("rate limited");
+  });
+
+  it("notes truncated input when truncatedFiles > 0", async () => {
+    addPRComment.mockResolvedValue(undefined);
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    await postFanoutCommentsToPR({} as never, "o", "r", 1, [
+      { ...completedRun, truncatedFiles: 3 },
+    ]);
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).toContain("input truncated");
+    expect(body).toContain("3");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- post-fanout-comments`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the renderer**
+
+```ts
+// packages/core/src/executor/review/post-fanout-comments.ts
+import type { Octokit } from "@octokit/rest";
+import { addPRComment } from "../../repo/github.js";
+import type { ReviewModelRun } from "./review-provider.js";
+
+export async function postFanoutCommentsToPR(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  runs: ReviewModelRun[],
+): Promise<void> {
+  for (const run of runs) {
+    await addPRComment(octokit, owner, repo, prNumber, renderRunMarkdown(run));
+  }
+}
+
+function renderRunMarkdown(run: ReviewModelRun): string {
+  const tokens = `${run.inputTokens.toLocaleString()} in / ${run.outputTokens.toLocaleString()} out tokens`;
+  const seconds = (run.durationMs / 1000).toFixed(1);
+  const header = `🔎 Review by \`${run.modelId}\` (via OpenRouter)\n\n`;
+  if (run.status === "failed") {
+    return [
+      header,
+      `Status: failed · ${run.errorMessage ?? "unknown error"} · ${seconds}s\n\n`,
+      "_Advisory only — does not block merge._\n",
+    ].join("");
+  }
+  const table =
+    run.findings.length === 0
+      ? "_No findings._\n"
+      : [
+          "| Severity | File | Line | Category | Description |",
+          "|---|---|---|---|---|",
+          ...run.findings.map(
+            (f) =>
+              `| ${f.severity} | ${escapePipe(f.file)} | ${f.line} | ${escapePipe(f.category)} | ${escapePipe(f.description)} |`,
+          ),
+        ].join("\n");
+  const truncationNote =
+    run.truncatedFiles && run.truncatedFiles > 0
+      ? `\n\n_Note: input truncated; ${run.truncatedFiles} file ${run.truncatedFiles === 1 ? "body" : "bodies"} dropped to fit context window._`
+      : "";
+  return [
+    header,
+    `Status: completed · ${tokens} · ${seconds}s\n\n`,
+    table,
+    truncationNote,
+    "\n\n_Advisory only — does not block merge. See deep-review for blocking findings._\n",
+  ].join("");
+}
+
+function escapePipe(s: string): string {
+  return s.replace(/\|/g, "\\|");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- post-fanout-comments`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/executor/review/post-fanout-comments.ts \
+        packages/core/src/__tests__/post-fanout-comments.test.ts
+git commit -m "feat(core): post-fanout-comments markdown renderer (BEC-134)"
+```
+
+---
+
+## Task 9: insertReviewModelRuns DB writer
+
+**Files:**
+- Create: `packages/core/src/db/review-model-runs.ts`
+- Test: `packages/core/src/__tests__/db-review-model-runs.test.ts` (extend Task 3 file)
+
+- [ ] **Step 1: Extend the failing test**
+
+Append to `packages/core/src/__tests__/db-review-model-runs.test.ts`:
+
+```ts
+import { insertReviewModelRuns } from "../db/review-model-runs.js";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+
+describe("insertReviewModelRuns", () => {
+  it("writes one row per ReviewModelRun", () => {
+    const sqliteDb = new Database(":memory:");
+    runMigrationsSqlite(sqliteDb);
+    sqliteDb.prepare(
+      "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run("p1", "i1", "t", "k", "u", "running", Math.floor(Date.now() / 1000));
+    sqliteDb.prepare(
+      "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "p1", "review", "completed", Math.floor(Date.now() / 1000));
+
+    const db = drizzleSqlite(sqliteDb);
+    insertReviewModelRuns(db, "s1", [
+      {
+        modelId: "anthropic/claude-3.5-sonnet",
+        providerId: "openrouter",
+        status: "completed",
+        findings: [],
+        inputTokens: 100,
+        outputTokens: 50,
+        durationMs: 1000,
+      },
+      {
+        modelId: "openai/gpt-4o",
+        providerId: "openrouter",
+        status: "failed",
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: 200,
+        errorMessage: "rate limited",
+        truncatedFiles: 2,
+      },
+    ]);
+
+    const rows = sqliteDb
+      .prepare("SELECT * FROM review_model_runs WHERE stage_run_id = ? ORDER BY model_id")
+      .all("s1") as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].model_id).toBe("anthropic/claude-3.5-sonnet");
+    expect(rows[0].input_tokens).toBe(100);
+    expect(rows[1].status).toBe("failed");
+    expect(rows[1].error_message).toBe("rate limited");
+    expect(rows[1].truncated_files).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- db-review-model-runs`
+Expected: FAIL on the `insertReviewModelRuns` import.
+
+- [ ] **Step 3: Implement the writer**
+
+```ts
+// packages/core/src/db/review-model-runs.ts
+import { reviewModelRuns } from "./schema.js";
+import type { ReviewModelRun } from "../executor/review/review-provider.js";
+import { randomUUID } from "node:crypto";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+export type Db = BetterSQLite3Database | PostgresJsDatabase;
+
+export function insertReviewModelRuns(
+  db: Db,
+  stageRunId: string,
+  runs: ReviewModelRun[],
+): void {
+  if (runs.length === 0) return;
+  const now = new Date();
+  const rows = runs.map((r) => ({
+    id: randomUUID(),
+    stageRunId,
+    providerId: r.providerId,
+    modelId: r.modelId,
+    status: r.status,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    durationMs: r.durationMs,
+    errorMessage: r.errorMessage,
+    truncatedFiles: r.truncatedFiles ?? 0,
+    startedAt: now,
+    completedAt: now,
+  }));
+  // Drizzle's insert is sync on better-sqlite3, async on postgres-js. Both
+  // accept this shape via type-narrowing: cast through unknown.
+  (db as BetterSQLite3Database).insert(reviewModelRuns).values(rows).run();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- db-review-model-runs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/review-model-runs.ts \
+        packages/core/src/__tests__/db-review-model-runs.test.ts
+git commit -m "feat(core): insertReviewModelRuns DB writer (BEC-134)"
+```
+
+---
+
+## Task 10: Wire fanout into runner.ts
+
+This is the integration step. Fanout runs **once before** the existing convergence loop; the loop continues to call the agentic provider per-pass via its wrapper. Fanout findings persist via `insertReviewModelRuns` and post via `postFanoutCommentsToPR`. Agentic findings persist the same way (so the run record has rows for both).
+
+**Files:**
+- Modify: `packages/core/src/pipeline/runner.ts`
+- Test: a new minimal integration test in `packages/core/src/__tests__/runner-fanout-integration.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+// packages/core/src/__tests__/runner-fanout-integration.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fanoutRunReview = vi.fn();
+const agenticRunReview = vi.fn();
+const insertReviewModelRunsMock = vi.fn();
+const postFanoutCommentsToPRMock = vi.fn();
+
+vi.mock("../executor/review/review-provider.js", async (orig) => {
+  const real = await orig<typeof import("../executor/review/review-provider.js")>();
+  return {
+    ...real,
+    getEnabledProviders: () => [
+      { id: "agentic", runReview: agenticRunReview },
+      { id: "openrouter", runReview: fanoutRunReview },
+    ],
+  };
+});
+vi.mock("../db/review-model-runs.js", () => ({
+  insertReviewModelRuns: insertReviewModelRunsMock,
+}));
+vi.mock("../executor/review/post-fanout-comments.js", () => ({
+  postFanoutCommentsToPR: postFanoutCommentsToPRMock,
+}));
+
+describe("runner fanout integration", () => {
+  beforeEach(() => {
+    fanoutRunReview.mockReset();
+    agenticRunReview.mockReset();
+    insertReviewModelRunsMock.mockReset();
+    postFanoutCommentsToPRMock.mockReset();
+  });
+
+  it("runs fanout once per stage execution and posts comments", async () => {
+    fanoutRunReview.mockResolvedValue([
+      {
+        modelId: "anthropic/claude-3.5-sonnet",
+        providerId: "openrouter",
+        status: "completed",
+        findings: [],
+        inputTokens: 1, outputTokens: 1, durationMs: 1,
+      },
+    ]);
+    agenticRunReview.mockResolvedValue([
+      {
+        modelId: "claude-haiku-4-5-20251001",
+        providerId: "agentic",
+        status: "completed",
+        findings: [],
+        inputTokens: 1, outputTokens: 1, durationMs: 1,
+      },
+    ]);
+
+    // Import the runner helper that we extract in Step 3 below; the test calls
+    // it directly to avoid spinning up a full pipeline.
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+    const ctx = {
+      runId: "r1", stageRunId: "s1", workdir: "/tmp/x",
+      handoff: { runId: "r1", issueId: "i1", stage: "review", timestamp: "",
+        summary: "", filesChanged: [], approach: "",
+        context: { issueIntent: "x", constraints: [], assumptions: [] },
+        tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
+      baseRef: "main", prNumber: 42,
+    };
+    const result = await runReviewProviders(ctx, {
+      env: { REVIEW_MODELS: "anthropic/claude-3.5-sonnet", OPENROUTER_API_KEY: "sk-or" },
+      db: {} as never,
+      octokit: {} as never,
+      owner: "o",
+      repo: "r",
+    });
+
+    expect(agenticRunReview).toHaveBeenCalledOnce();
+    expect(fanoutRunReview).toHaveBeenCalledOnce();
+    expect(insertReviewModelRunsMock).toHaveBeenCalledOnce();
+    const persisted = insertReviewModelRunsMock.mock.calls[0][2] as Array<{ providerId: string }>;
+    expect(persisted).toHaveLength(2);
+    expect(postFanoutCommentsToPRMock).toHaveBeenCalledOnce();
+    const postedRuns = postFanoutCommentsToPRMock.mock.calls[0][4] as Array<{ providerId: string }>;
+    expect(postedRuns.every((r) => r.providerId === "openrouter")).toBe(true);
+    expect(result.agenticFindings).toHaveLength(0);
+    expect(result.totalInputTokens).toBe(2);
+    expect(result.totalOutputTokens).toBe(2);
+  });
+
+  it("does not post comments when prNumber is null", async () => {
+    fanoutRunReview.mockResolvedValue([]);
+    agenticRunReview.mockResolvedValue([]);
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+    await runReviewProviders(
+      { runId: "r1", stageRunId: "s1", workdir: "/tmp/x",
+        handoff: { runId: "r1", issueId: "i1", stage: "review", timestamp: "",
+          summary: "", filesChanged: [], approach: "",
+          context: { issueIntent: "x", constraints: [], assumptions: [] },
+          tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
+        baseRef: "main", prNumber: null },
+      { env: {}, db: {} as never, octokit: {} as never, owner: "o", repo: "r" },
+    );
+    expect(postFanoutCommentsToPRMock).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if fanout provider rejects (best-effort)", async () => {
+    agenticRunReview.mockResolvedValue([
+      { modelId: "claude-haiku-4-5-20251001", providerId: "agentic", status: "completed",
+        findings: [], inputTokens: 0, outputTokens: 0, durationMs: 0 },
+    ]);
+    fanoutRunReview.mockRejectedValue(new Error("network gone"));
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+    const result = await runReviewProviders(
+      { runId: "r1", stageRunId: "s1", workdir: "/tmp/x",
+        handoff: { runId: "r1", issueId: "i1", stage: "review", timestamp: "",
+          summary: "", filesChanged: [], approach: "",
+          context: { issueIntent: "x", constraints: [], assumptions: [] },
+          tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
+        baseRef: "main", prNumber: 1 },
+      { env: { REVIEW_MODELS: "x", OPENROUTER_API_KEY: "k" },
+        db: {} as never, octokit: {} as never, owner: "o", repo: "r" },
+    );
+    expect(result.agenticFindings).toEqual([]); // no findings; agentic ok
+    // fanout error logged, not thrown
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- runner-fanout-integration`
+Expected: FAIL — module `pipeline/review-providers-runner.js` not found.
+
+- [ ] **Step 3: Extract the helper into a new module**
+
+```ts
+// packages/core/src/pipeline/review-providers-runner.ts
+import type { Octokit } from "@octokit/rest";
+import {
+  getEnabledProviders,
+  type ReviewContext,
+  type ReviewModelRun,
+} from "../executor/review/review-provider.js";
+import { insertReviewModelRuns, type Db } from "../db/review-model-runs.js";
+import { postFanoutCommentsToPR } from "../executor/review/post-fanout-comments.js";
+import type { ReviewFinding } from "../types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "ReviewProvidersRunner" });
+
+export interface RunReviewProvidersOpts {
+  env: NodeJS.ProcessEnv;
+  db: Db;
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+}
+
+export interface RunReviewProvidersResult {
+  agenticFindings: ReviewFinding[];
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  allRuns: ReviewModelRun[];
+}
+
+export async function runReviewProviders(
+  ctx: ReviewContext,
+  opts: RunReviewProvidersOpts,
+): Promise<RunReviewProvidersResult> {
+  const providers = getEnabledProviders(opts.env);
+  const allRuns: ReviewModelRun[] = [];
+
+  for (const p of providers) {
+    try {
+      const runs = await p.runReview(ctx);
+      allRuns.push(...runs);
+    } catch (err) {
+      log.warn(
+        { providerId: p.id, err: err instanceof Error ? err.message : String(err) },
+        "review provider threw — recording as advisory failure",
+      );
+      // best-effort: agentic failure is still treated as a failed run for visibility
+      allRuns.push({
+        modelId: p.id,
+        providerId: p.id,
+        status: "failed",
+        findings: [],
+        inputTokens: 0, outputTokens: 0, durationMs: 0,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  insertReviewModelRuns(opts.db, ctx.stageRunId, allRuns);
+
+  const fanoutRuns = allRuns.filter((r) => r.providerId !== "agentic");
+  if (ctx.prNumber !== null && fanoutRuns.length > 0) {
+    try {
+      await postFanoutCommentsToPR(opts.octokit, opts.owner, opts.repo, ctx.prNumber, fanoutRuns);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "post-fanout-comments failed — continuing",
+      );
+    }
+  }
+
+  const agenticFindings = allRuns
+    .filter((r) => r.providerId === "agentic")
+    .flatMap((r) => r.findings);
+
+  return {
+    agenticFindings,
+    totalInputTokens: allRuns.reduce((s, r) => s + r.inputTokens, 0),
+    totalOutputTokens: allRuns.reduce((s, r) => s + r.outputTokens, 0),
+    allRuns,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- runner-fanout-integration`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Modify runner.ts to call the helper**
+
+In `packages/core/src/pipeline/runner.ts`, replace the line ~1398 deep-review call site:
+
+**Before:**
+```ts
+runLog.info({ drPass, passLimit }, "deep review: running parallel sub-agents");
+const deepResult = await runDeepReview(handoff, worktreePath);
+
+run.totalInputTokens += deepResult.inputTokens;
+run.totalOutputTokens += deepResult.outputTokens;
+```
+
+**After:**
+```ts
+// On the FIRST pass only, run all enabled review providers (agentic + optional fanout).
+// On subsequent passes, only the agentic provider runs (fanout is one-shot, advisory).
+runLog.info({ drPass, passLimit }, "deep review: running review providers");
+const reviewCtx = {
+  runId,
+  stageRunId: drReviewResult?.stageRunId ?? "", // populated by executeStage on review pass
+  workdir: worktreePath,
+  handoff,
+  baseRef: repoConfig.defaultBranch ?? "main",
+  prNumber: prNumber ?? null,
+};
+const reviewResult =
+  drPass === 1
+    ? await runReviewProviders(reviewCtx, {
+        env: process.env,
+        db: this.db,
+        octokit: this.octokit,
+        owner: repoOwner,
+        repo: repoName,
+      })
+    : await runReviewProviders(reviewCtx, {
+        env: { /* fanout disabled on retries */ },
+        db: this.db,
+        octokit: this.octokit,
+        owner: repoOwner,
+        repo: repoName,
+      });
+const deepResult = {
+  findings: reviewResult.agenticFindings,
+  inputTokens: reviewResult.totalInputTokens,
+  outputTokens: reviewResult.totalOutputTokens,
+};
+
+run.totalInputTokens += deepResult.inputTokens;
+run.totalOutputTokens += deepResult.outputTokens;
+```
+
+Add the import at the top of `runner.ts`:
+
+```ts
+import { runReviewProviders } from "./review-providers-runner.js";
+```
+
+If `repoOwner`, `repoName`, or `prNumber` are not already in scope at this point in `runner.ts`, derive them from `repoConfig.repoUrl` and the existing PR state (search the file for an existing usage of `octokit.pulls` to find the local variables already in scope; reuse them by name).
+
+**Critical follow-up edit in the same file:** The agentic findings returned by the new wrapper are already `ReviewFinding[]` (the wrapper calls `deepFindingsToReviewFindings` internally). The existing line ~1515 reads:
+
+```ts
+const asReviewFindings = deepFindingsToReviewFindings(deepResult.findings);
+const existingFindings = handoff.context.reviewFindings ?? [];
+handoff = {
+  ...handoff,
+  context: { ...handoff.context, reviewFindings: [...existingFindings, ...asReviewFindings] },
+};
+```
+
+Replace with (no double-conversion):
+
+```ts
+const existingFindings = handoff.context.reviewFindings ?? [];
+handoff = {
+  ...handoff,
+  context: { ...handoff.context, reviewFindings: [...existingFindings, ...deepResult.findings] },
+};
+```
+
+Also remove the now-unused `deepFindingsToReviewFindings` import at the top of `runner.ts` if no other usages remain.
+
+- [ ] **Step 6: Run all tests in the runner area**
+
+Run: `pnpm --filter @urateam/core test -- pipeline-runner runner-fanout-integration deep-review review-feedback`
+Expected: PASS — no regressions in the existing pipeline-runner suite.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/pipeline/review-providers-runner.ts \
+        packages/core/src/pipeline/runner.ts \
+        packages/core/src/__tests__/runner-fanout-integration.test.ts
+git commit -m "feat(core): wire fanout into runner.ts review stage (BEC-134)"
+```
+
+---
+
+## Task 11: Cost rollup — JOIN review_model_runs
+
+**Files:**
+- Modify: `packages/core/src/cost/per-run.ts`
+- Test: `packages/core/src/__tests__/cost/per-run-multi-model.test.ts`
+
+- [ ] **Step 1: Read existing per-run.ts to identify the rollup function**
+
+Run: `grep -n "export function\|export const" packages/core/src/cost/per-run.ts`
+
+Find the function that aggregates per-stage tokens by model. The new test asserts that when `review_model_runs` has rows for a stage_run, the rollup uses per-row model pricing (not the aggregated stage_runs.input_tokens × stage-level pricing).
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// packages/core/src/__tests__/cost/per-run-multi-model.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrationsSqlite } from "../../db/migrator.js";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { computeRunCost } from "../../cost/per-run.js";
+
+describe("computeRunCost — multi-model rollup", () => {
+  it("uses review_model_runs rows when present", () => {
+    const sqliteDb = new Database(":memory:");
+    runMigrationsSqlite(sqliteDb);
+    const db = drizzle(sqliteDb);
+
+    const now = Math.floor(Date.now() / 1000);
+    sqliteDb.prepare(
+      "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at, total_input_tokens, total_output_tokens) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("p1", "i1", "t", "k", "u", "completed", now, 0, 0);
+    sqliteDb.prepare(
+      "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at, input_tokens, output_tokens) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run("s1", "p1", "review", "completed", now, 1000, 500);
+
+    sqliteDb.prepare(
+      "INSERT INTO review_model_runs (id, stage_run_id, provider_id, model_id, status, input_tokens, output_tokens, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("rm1", "s1", "agentic", "claude-haiku-4-5-20251001", "completed", 600, 300, 1000);
+    sqliteDb.prepare(
+      "INSERT INTO review_model_runs (id, stage_run_id, provider_id, model_id, status, input_tokens, output_tokens, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("rm2", "s1", "openrouter", "anthropic/claude-3.5-sonnet", "completed", 400, 200, 2000);
+
+    const cost = computeRunCost(db, "p1", {
+      modelPricing: {
+        "claude-haiku-4-5-20251001": { inputPer1k: 0.001, outputPer1k: 0.005 },
+        "anthropic/claude-3.5-sonnet": { inputPer1k: 0.003, outputPer1k: 0.015 },
+      },
+    });
+    // 600/1000 * 0.001 + 300/1000 * 0.005 = 0.0006 + 0.0015 = 0.0021
+    // 400/1000 * 0.003 + 200/1000 * 0.015 = 0.0012 + 0.003  = 0.0042
+    // total: 0.0063
+    expect(cost.totalDollars).toBeCloseTo(0.0063, 5);
+  });
+
+  it("falls back to stage-level rollup when review_model_runs is empty", () => {
+    const sqliteDb = new Database(":memory:");
+    runMigrationsSqlite(sqliteDb);
+    const db = drizzle(sqliteDb);
+    const now = Math.floor(Date.now() / 1000);
+    sqliteDb.prepare(
+      "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at, total_input_tokens, total_output_tokens) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("p1", "i1", "t", "k", "u", "completed", now, 0, 0);
+    sqliteDb.prepare(
+      "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at, input_tokens, output_tokens) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run("s1", "p1", "review", "completed", now, 1000, 500);
+
+    const cost = computeRunCost(db, "p1", {
+      modelPricing: { "default": { inputPer1k: 0.001, outputPer1k: 0.005 } },
+      defaultModel: "default",
+    });
+    // 1000/1000 * 0.001 + 500/1000 * 0.005 = 0.001 + 0.0025 = 0.0035
+    expect(cost.totalDollars).toBeCloseTo(0.0035, 5);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @urateam/core test -- per-run-multi-model`
+Expected: FAIL — current `computeRunCost` does not consult `review_model_runs`.
+
+- [ ] **Step 4: Update computeRunCost**
+
+Open `packages/core/src/cost/per-run.ts`. Find the section that loops over `stageRuns` to compute cost. For each `stageRun`, query `reviewModelRuns` filtered by `stage_run_id`. If rows exist, compute cost as the sum of per-model `(input_tokens/1000) × pricing.inputPer1k + (output_tokens/1000) × pricing.outputPer1k`. If no rows exist, fall back to the existing stage-level computation.
+
+Pseudocode patch (adapt the actual function name and shape from the existing file):
+
+```ts
+import { reviewModelRuns } from "../db/schema.js";
+// ...
+
+for (const sr of stageRunsForRun) {
+  const modelRuns = await db
+    .select()
+    .from(reviewModelRuns)
+    .where(eq(reviewModelRuns.stageRunId, sr.id));
+  if (modelRuns.length > 0) {
+    for (const mr of modelRuns) {
+      const pricing = opts.modelPricing[mr.modelId] ?? opts.modelPricing[opts.defaultModel ?? ""];
+      if (!pricing) continue;
+      total += (mr.inputTokens / 1000) * pricing.inputPer1k;
+      total += (mr.outputTokens / 1000) * pricing.outputPer1k;
+    }
+  } else {
+    // existing stage-level fallback
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @urateam/core test -- per-run-multi-model cost`
+Expected: PASS — both new tests + existing cost tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/cost/per-run.ts \
+        packages/core/src/__tests__/cost/per-run-multi-model.test.ts
+git commit -m "feat(core): cost rollup uses review_model_runs per-model pricing (BEC-134)"
+```
+
+---
+
+## Task 12: .env.example documentation in template
+
+**Files:**
+- Modify: `packages/create-urateam/template/.urateam/.env.example`
+
+- [ ] **Step 1: Read current file**
+
+Run: `cat packages/create-urateam/template/.urateam/.env.example`
+
+- [ ] **Step 2: Append the fanout block**
+
+Append:
+
+```bash
+
+# OpenRouter multi-model review fanout (BEC-134, OSS, optional)
+# When both vars are set, each comma-separated model produces a single-shot
+# advisory review in addition to the default Claude Agent SDK deep-review.
+# Findings post as labeled PR comments; they do NOT block auto-merge.
+# OPENROUTER_API_KEY=sk-or-...
+# REVIEW_MODELS=anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-2.5-pro
+# Optional knobs (defaults shown):
+# REVIEW_MODELS_TIMEOUT_MS=300000
+# REVIEW_MODELS_MAX_INPUT_TOKENS=150000
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/create-urateam/template/.urateam/.env.example
+git commit -m "docs(create-urateam): document OpenRouter fanout env vars (BEC-134)"
+```
+
+---
+
+## Task 13: ScaffoldOptions in create-urateam
+
+**Files:**
+- Modify: `packages/create-urateam/src/index.ts`
+- Test: existing scaffolder test (or extend if a fanout-specific test is needed)
+
+- [ ] **Step 1: Read the ScaffoldOptions and buildEnv function**
+
+Run: `grep -n "ScaffoldOptions\|buildEnv\|interface " packages/create-urateam/src/index.ts | head`
+
+- [ ] **Step 2: Extend ScaffoldOptions**
+
+Add fields:
+
+```ts
+openrouterApiKey?: string;
+reviewModels?: string[];
+```
+
+- [ ] **Step 3: Update buildEnv to write the new vars (uncommented) when present**
+
+Inside the `buildEnv()` function, append a conditional block:
+
+```ts
+if (opts.openrouterApiKey && opts.reviewModels && opts.reviewModels.length > 0) {
+  lines.push("");
+  lines.push("# OpenRouter multi-model review fanout (BEC-134)");
+  lines.push(`OPENROUTER_API_KEY=${opts.openrouterApiKey}`);
+  lines.push(`REVIEW_MODELS=${opts.reviewModels.join(",")}`);
+}
+```
+
+- [ ] **Step 4: Run scaffolder tests**
+
+Run: `pnpm --filter create-urateam test`
+Expected: PASS — no regressions. (Add a new test only if existing tests assert on `buildEnv` content; otherwise the docs change is enough for v1.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/create-urateam/src/index.ts
+git commit -m "feat(create-urateam): optional OPENROUTER + REVIEW_MODELS scaffold fields (BEC-134)"
+```
+
+---
+
+## Task 14: E2E pipeline test extension
+
+**Files:**
+- Modify: `packages/core/src/__tests__/e2e-pipeline.test.ts`
+
+- [ ] **Step 1: Add a new `it()` block at the end of the file**
+
+```ts
+it("BEC-134: fanout providers run when REVIEW_MODELS+OPENROUTER_API_KEY set, advisory only", async () => {
+  // Set env for the duration of this test
+  process.env.REVIEW_MODELS = "anthropic/claude-3.5-sonnet";
+  process.env.OPENROUTER_API_KEY = "sk-or-test";
+  try {
+    // Use existing harness fixture for a minimal pipeline run with mocked
+    // OpenRouter HTTP and mocked Claude Agent SDK (already set up in this test
+    // file). Assert:
+    //   1. review_model_runs has rows for both providers
+    //   2. handoff.context.reviewFindings contains agentic findings only
+    //   3. addPRComment called once per fanout model
+    // The existing test scaffold in this file shows how to run a minimal
+    // pipeline; reuse that helper.
+  } finally {
+    delete process.env.REVIEW_MODELS;
+    delete process.env.OPENROUTER_API_KEY;
+  }
+});
+```
+
+(Body intentionally light — adapt to whatever fixture the existing e2e-pipeline test uses. The acceptance is: assertions 1–3 above.)
+
+- [ ] **Step 2: Run e2e tests**
+
+Run: `pnpm --filter @urateam/core test -- e2e-pipeline`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/__tests__/e2e-pipeline.test.ts
+git commit -m "test(core): e2e pipeline coverage for fanout (BEC-134)"
+```
+
+---
+
+## Task 15: Final full-suite + lint + typecheck
+
+- [ ] **Step 1: Run the full test matrix**
+
+```bash
+pnpm -r test
+pnpm -r typecheck   # or whatever the project uses (tsc --noEmit)
+```
+
+Expected: PASS across all packages.
+
+- [ ] **Step 2: Spot-check the diff**
+
+```bash
+git log --oneline origin/main..HEAD
+git diff --stat origin/main..HEAD
+```
+
+Expected: ~14 commits, all under `packages/core/src/executor/review/`, `packages/core/src/db/`, `packages/core/src/pipeline/`, `packages/core/src/cost/`, and `packages/create-urateam/`.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin jonb3232/bec-134-v10-26-openrouter-multi-model-fanout-on-review-stage
+gh pr create --title "feat(core): OpenRouter multi-model review fanout (BEC-134)" \
+  --body "$(cat docs/superpowers/specs/2026-04-30-bec-134-openrouter-fanout-design.md | head -60)
+
+Closes BEC-134."
+```
+
+---
+
+## Spec coverage check (self-review)
+
+| Spec section | Plan task |
+|---|---|
+| §3 architecture file map | Task 1, 2, 4–9 |
+| §4 ReviewProvider interface | Task 1 |
+| §4.1 ReviewModelRun shape | Task 1 |
+| §4.2 registry env validation | Task 7 |
+| §4.3 OpenRouter client | Task 4 |
+| §5 data flow / runner integration | Task 10 |
+| §5.1 prompt input + truncation | Task 5 |
+| §5.2 PR comment shape | Task 8 |
+| §6 env vars | Task 7 (parsing), Task 12 (.env.example), Task 13 (scaffolder) |
+| §7 schema migration | Task 3 |
+| §7 review_model_runs DB writer | Task 9 |
+| §7 cost rollup JOIN | Task 11 |
+| §8 error handling — partial failure | Task 6 (allSettled) |
+| §8 error handling — startup validation | Task 7 |
+| §8 error handling — timeout | Task 6 (AbortController) |
+| §8 error handling — token cap | Task 5 (truncation) |
+| §9 testing matrix | Tasks 1–11 each include unit tests; Task 14 e2e |
+| §11 acceptance criteria | covered by Tasks 5–11 |
+| §12 release & cascade | post-merge (out of plan scope) |
+
+No gaps.
+
+---
+
+## Notes for the executor
+
+- **TDD discipline**: every task starts with the failing test. Don't write implementation before the test fails for the right reason.
+- **Commits**: one commit per task, message format `feat(core)|test(core)|docs(...): subject (BEC-134)`.
+- **No license-tier check**: BEC-134 is OSS; do not add license gates.
+- **Existing tests must pass**: after every task, run `pnpm --filter @urateam/core test` (full unit suite) and confirm green before committing.
+- **Don't refactor `deep-review.ts`** — the wrapper exists so we don't have to.
+- **`runner.ts` integration (Task 10)** is the trickiest task; if the diff against the existing convergence loop becomes unwieldy, prefer extracting `runReviewProviders` cleanly and keeping the loop body short. The wrapper-thin-call pattern preserves convergence behavior unchanged.

--- a/docs/superpowers/specs/2026-04-30-bec-134-openrouter-fanout-design.md
+++ b/docs/superpowers/specs/2026-04-30-bec-134-openrouter-fanout-design.md
@@ -1,0 +1,286 @@
+# BEC-134 — OpenRouter multi-model fanout on review stage
+
+**Issue:** [BEC-134](https://linear.app/beckerspace/issue/BEC-134/v10-26-openrouter-multi-model-fanout-on-review-stage)
+**Tier:** OSS
+**Estimate:** 2–3 weeks
+**v1.0 gate:** 2 of 6 (sequence after BEC-133)
+**Date:** 2026-04-30
+
+---
+
+## 1. Goal
+
+Send the review stage to N models in parallel via OpenRouter and emit each model's findings as a labeled PR comment. Existing 3-sub-agent agentic deep-review (Claude Agent SDK) keeps running and remains the sole merge-blocking authority; OpenRouter findings are advisory only in v1.
+
+The provider abstraction is designed so direct-key providers (Anthropic, OpenAI, etc.) can plug in post-v1 without touching the review stage caller.
+
+## 2. Decisions (locked 2026-04-30)
+
+| # | Decision | Reason |
+|---|---|---|
+| D1 | Single-shot chat-completion per model | OpenRouter does not host the Claude Agent SDK; matches claude-octopus pattern. |
+| D2 | Default behavior unchanged when env unset | Zero-regression upgrade for existing OSS installs. |
+| D3 | Fanout runs IN ADDITION to agentic deep-review when env set | Agentic stays the merge gate; fanout is broad-coverage advice. |
+| D4 | Fanout findings are advisory in v1 (do not gate merge) | Avoids one rogue model vetoing the PR before consensus-vote (v2). |
+| D5 | `ReviewProvider` interface + registry | Smallest seam to add direct-key providers later. |
+| D6 | New `review_model_runs` table | Per-model cost rollup needs 1:N rows; existing `stage_runs` can't carry it. |
+| D7 | One PR comment per fanout model | Preserves "model X said Y" diagnostic; aggregation/synthesis is v2. |
+
+## 3. Architecture
+
+```
+packages/core/src/executor/
+  deep-review.ts                 (UNCHANGED)
+  review/
+    review-provider.ts           NEW — interface + registry
+    agentic-deep-review.ts       NEW — thin wrapper around runDeepReview()
+    openrouter-fanout.ts         NEW — N parallel single-shot reviews
+    openrouter-client.ts         NEW — HTTP client for OpenRouter chat-completions
+    review-prompt.ts             NEW — single-shot prompt builder + findings parser
+    post-fanout-comments.ts      NEW — renders ReviewModelRun → markdown, calls addPRComment
+
+packages/core/src/db/
+  schema.ts                      ADD reviewModelRuns table
+  migrations/sqlite/008_review_model_runs.sql   NEW
+  migrations/postgres/009_review_model_runs.sql NEW
+
+packages/core/src/pipeline/
+  runner.ts                      MODIFY — call providers via registry, persist runs, post comments
+
+packages/create-urateam/
+  src/index.ts                   MODIFY — optional ScaffoldOptions fields
+  template/.urateam/.env.example MODIFY — document new env vars
+```
+
+## 4. Interfaces
+
+### 4.1 `ReviewProvider`
+
+```ts
+export interface ReviewProvider {
+  readonly id: "agentic" | "openrouter"
+  runReview(ctx: ReviewContext): Promise<ReviewModelRun[]>
+}
+
+export interface ReviewContext {
+  runId: string
+  stageRunId: string
+  workdir: string
+  handoff: HandoffArtifact
+  baseRef: string                  // git ref to diff against; runner sets to PR base branch, or repo default branch when running outside PR context
+  prNumber: number | null          // null when running outside PR context
+}
+
+export interface ReviewModelRun {
+  modelId: string                  // "claude-haiku-4-5-20251001" | "anthropic/claude-3.5-sonnet"
+  providerId: "agentic" | "openrouter"
+  status: "completed" | "failed"
+  findings: ReviewFinding[]        // existing schema, reused as-is
+  inputTokens: number
+  outputTokens: number
+  durationMs: number
+  errorMessage?: string
+  truncatedFiles?: number          // populated when input was capped
+}
+```
+
+### 4.2 Registry
+
+```ts
+export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[]
+```
+
+Always returns `[AgenticDeepReviewProvider]`. Appends `OpenRouterFanoutProvider` iff:
+
+- `REVIEW_MODELS` is set and non-empty after trimming
+- `OPENROUTER_API_KEY` is set
+
+If exactly one is set, throw `Error("REVIEW_MODELS and OPENROUTER_API_KEY must both be set or both be unset")`. The runner catches at startup so users see the message before any pipeline work.
+
+### 4.3 OpenRouter client
+
+```ts
+interface OpenRouterClient {
+  chatCompletion(
+    modelId: string,
+    messages: ChatMessage[],
+    opts: { signal: AbortSignal; maxTokens?: number },
+  ): Promise<{ content: string; inputTokens: number; outputTokens: number }>
+}
+```
+
+Endpoint: `${OPENROUTER_BASE_URL}/chat/completions` (default `https://openrouter.ai/api/v1`).
+Headers: `Authorization: Bearer ${OPENROUTER_API_KEY}`, `HTTP-Referer: https://urateams.com`, `X-Title: urateam`.
+Streaming: not used in v1; single response per call.
+
+## 5. Data flow
+
+```
+runner.ts (review stage call site, ~line 1500)
+  ├─ providers = getEnabledProviders(process.env)
+  ├─ for p of providers:
+  │     runs = await p.runReview(ctx)        // each provider returns N runs (agentic = 1, openrouter = REVIEW_MODELS.length)
+  │     allRuns.push(...runs)
+  ├─ agenticFindings = allRuns.filter(r => r.providerId === "agentic").flatMap(r => r.findings)
+  ├─ handoff.context.reviewFindings = [...existing, ...agenticFindings]   // merge gate unchanged
+  ├─ fanoutRuns = allRuns.filter(r => r.providerId !== "agentic")
+  ├─ if (prNumber && fanoutRuns.length) await postFanoutCommentsToPR(prNumber, fanoutRuns)   // calls addPRComment from repo/github.ts once per run
+  └─ await persistReviewModelRuns(stageRunId, allRuns)
+```
+
+### 5.1 Single-shot prompt input
+
+`review-prompt.ts` builds a deterministic prompt from `ReviewContext`:
+
+1. **Intent block**: `handoff.context.issueIntent`, `constraints`, `assumptions`
+2. **Diff block**: `git diff <baseRef>...HEAD` from `workdir`
+3. **Changed-file bodies**: full content of files in the diff, in repo path order
+4. **Instruction**: review for reuse, quality, efficiency; emit a JSON object matching `{"findings": ReviewFinding[]}`
+
+Token budget enforced before send: if estimated input exceeds `REVIEW_MODELS_MAX_INPUT_TOKENS`, drop file bodies tail-first (keep diff hunks always). Record dropped count in `ReviewModelRun.truncatedFiles`.
+
+Output parsing: extract first balanced `{...}` from response, JSON.parse, validate against `ReviewFindingSchema`. Parse failure → run.status = "failed", errorMessage = "model output not parseable as ReviewFinding[]".
+
+### 5.2 PR comment shape
+
+One comment per fanout `ReviewModelRun`, posted via the existing `addPRComment(octokit, owner, repo, prNumber, body)` helper in `packages/core/src/repo/github.ts:96`:
+
+```markdown
+🔎 Review by `anthropic/claude-3.5-sonnet` (via OpenRouter)
+
+Status: completed · 12,431 in / 1,802 out tokens · 18.4s
+
+| Severity | File | Line | Category | Description |
+|---|---|---|---|---|
+| warning | src/foo.ts | 42 | reuse | Duplicates logic from `bar.ts:88`. |
+
+_Advisory only — does not block merge. See deep-review for blocking findings._
+```
+
+Failed run:
+```markdown
+🔎 Review by `openai/gpt-4o` (via OpenRouter)
+
+Status: failed · <error message> · 32.1s
+
+_Advisory only — does not block merge._
+```
+
+Truncated input adds: `_Note: input truncated; <N> file bodies dropped to fit context window._`
+
+## 6. Configuration
+
+| Env var | Required when | Default | Notes |
+|---|---|---|---|
+| `OPENROUTER_API_KEY` | fanout enabled | — | `sk-or-...` |
+| `REVIEW_MODELS` | fanout enabled | — | comma-separated; whitespace trimmed; empty entries dropped |
+| `REVIEW_MODELS_TIMEOUT_MS` | optional | `300000` | per-model AbortController deadline |
+| `REVIEW_MODELS_MAX_INPUT_TOKENS` | optional | `150000` | input cap before truncation |
+| `OPENROUTER_BASE_URL` | optional | `https://openrouter.ai/api/v1` | testing override only |
+
+Read directly via `process.env` (matches existing convention in `entrypoint.ts`).
+
+### 6.1 `.env.example` additions
+
+```bash
+# OpenRouter multi-model review fanout (BEC-134, OSS, optional)
+# When both are set, each comma-separated model produces a single-shot review
+# in addition to the default Claude Agent SDK deep-review.
+# OPENROUTER_API_KEY=sk-or-...
+# REVIEW_MODELS=anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-2.5-pro
+```
+
+### 6.2 `create-urateam` scaffolder
+
+Add to `ScaffoldOptions`:
+
+```ts
+openrouterApiKey?: string
+reviewModels?: string[]
+```
+
+`buildEnv()` writes the two lines uncommented when both options are present, otherwise leaves the example block commented. No interactive wizard prompts in v1 — scaffolder is options-driven.
+
+## 7. Schema migration
+
+New table:
+
+```ts
+export const reviewModelRuns = sqliteTable("review_model_runs", {
+  id: text("id").primaryKey(),
+  stageRunId: text("stage_run_id").notNull().references(() => stageRuns.id),
+  providerId: text("provider_id").notNull(),     // "agentic" | "openrouter"
+  modelId: text("model_id").notNull(),
+  status: text("status").notNull(),              // "completed" | "failed"
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  durationMs: integer("duration_ms").notNull().default(0),
+  errorMessage: text("error_message"),
+  truncatedFiles: integer("truncated_files").notNull().default(0),
+  startedAt: integer("started_at", { mode: "timestamp" }),
+  completedAt: integer("completed_at", { mode: "timestamp" }),
+})
+```
+
+Index on `stageRunId` for run-detail queries.
+
+`stage_runs.input_tokens` / `output_tokens` continue to be populated as the SUM across all `review_model_runs` rows for that stage (so dashboards showing stage totals do not break).
+
+Cost rollup updated to JOIN `review_model_runs` with `modelPricing` for accurate per-model cost; falls back to existing stage-level rollup when no rows exist (older runs).
+
+## 8. Error handling
+
+| Failure | Behavior |
+|---|---|
+| One fanout model rejects | `Promise.allSettled` captures it. That run's `status = "failed"`. Other models proceed. Stage continues. |
+| All N fanout models fail | Stage does not fail (agentic still ran). `logger.warn` with model count. PR comments still posted with "failed" status so user sees the cost of misconfigured key. |
+| `REVIEW_MODELS` set, `OPENROUTER_API_KEY` unset (or vice versa) | Runner throws at startup with explicit message before any pipeline work. |
+| Per-model timeout | `AbortController` fires at `REVIEW_MODELS_TIMEOUT_MS`. Treated as failed run with `errorMessage = "timed out after Nms"`. |
+| Input over token cap | Truncate file bodies tail-first; record `truncatedFiles` count; never silently drop diff hunks. |
+| Malformed model JSON | Run fails with `errorMessage = "model output not parseable as ReviewFinding[]"`. |
+| OpenRouter HTTP 4xx/5xx | Run fails with `errorMessage = "openrouter <status> <body-snippet>"`. No retry in v1 (best-effort). |
+| `REVIEW_MODELS=" , ,"` (all empty after trim) | Treated as unset → fanout disabled, no error. |
+| Agentic deep-review fails | Existing behavior unchanged: stage fails. (Fanout's outcome is irrelevant when agentic itself crashes.) |
+
+## 9. Testing
+
+| File | Coverage |
+|---|---|
+| `__tests__/openrouter-client.test.ts` | Happy path, 4xx, 5xx, timeout (AbortController), `fetch` mocked via vitest. |
+| `__tests__/openrouter-fanout.test.ts` | N=3 parallel, partial failure (1/3 rejects), all-fail, malformed JSON, token-cap truncation, empty `REVIEW_MODELS`. |
+| `__tests__/review-provider-registry.test.ts` | Env permutations: neither set, both set, one set (validation throws), whitespace-only, single empty entry. |
+| `__tests__/agentic-deep-review-provider.test.ts` | Wrapper preserves existing behavior — assert `runDeepReview` called with same args; output shape matches `ReviewModelRun`. |
+| `__tests__/review-prompt.test.ts` | Prompt construction with intent + diff + files; truncation drops file bodies, never diff hunks; parser extracts first balanced `{...}` and validates against schema. |
+| `__tests__/db-review-model-runs.test.ts` | Schema migration up; insert + read; index exists. |
+| `__tests__/cost/per-run-multi-model.test.ts` | Cost rollup JOINs `review_model_runs`; falls back to stage-level when no rows. |
+| `__tests__/e2e-pipeline.test.ts` (extend) | With `REVIEW_MODELS` set in env, both providers ran; `review_model_runs` rows exist; agentic findings still in `reviewFindings`; fanout findings NOT in `reviewFindings`. |
+
+No new mocks for the Claude Agent SDK (existing tests cover `runDeepReview`).
+
+## 10. Out of scope (deferred to v2 or post-v1)
+
+- Consensus-vote synthesis across models (BEC-134 v2)
+- Direct-key providers (Anthropic / OpenAI without OpenRouter) — abstraction ready
+- Pooled / managed OpenRouter key (parked per BEC-132)
+- Dashboard UI surfacing per-model findings (v1 surface = PR comments + `review_model_runs` table)
+- Treating fanout findings as a merge gate (advisory in v1)
+- Streaming responses
+- Per-model retries on transient HTTP errors
+
+## 11. Acceptance criteria mapping (from BEC-134)
+
+| Acceptance criterion | Where covered |
+|---|---|
+| `REVIEW_MODELS` parsed; review fans out N parallel calls | §4.2 registry, §5 data flow |
+| Each model's findings posted as a labeled PR comment | §5.2 PR comment shape |
+| Failure of one model doesn't block others | §8 error handling, §9 partial-failure test |
+| Cost / token usage logged per model in run record | §7 schema, §9 cost-rollup test |
+| Provider abstraction allows direct-key providers later without changing review stage code | §4.1 interface, §10 out-of-scope |
+| Tests cover aggregation + partial-failure paths | §9 testing |
+
+## 12. Release & cascade
+
+- Bump `@urateam/core` (this is core code) → next sequential version after `0.1.15`
+- Cascade `@urateam/cli` and `@urateam/dashboard` patch versions even though dashboard does not surface fanout in v1 (consistent monorepo cadence per Phase 2 hardening playbook)
+- Tag follows urateam-bump convention (next sequential after `v0.1.29`)
+- No license-tier check (OSS feature)

--- a/packages/core/src/__tests__/agentic-deep-review-provider.test.ts
+++ b/packages/core/src/__tests__/agentic-deep-review-provider.test.ts
@@ -36,11 +36,12 @@ describe("AgenticDeepReviewProvider", () => {
     );
     const provider = new AgenticDeepReviewProvider();
 
+    const handoff = makeHandoff();
     const runs = await provider.runReview({
       runId: "r1",
       stageRunId: "s1",
       workdir: "/tmp/x",
-      handoff: makeHandoff(),
+      handoff,
       baseRef: "main",
       prNumber: null,
     });
@@ -52,7 +53,9 @@ describe("AgenticDeepReviewProvider", () => {
     expect(runs[0].findings).toHaveLength(1);
     expect(runs[0].inputTokens).toBe(100);
     expect(runs[0].outputTokens).toBe(50);
+    expect(runs[0].durationMs).toBeGreaterThanOrEqual(0);
     expect(runDeepReviewMock).toHaveBeenCalledOnce();
+    expect(runDeepReviewMock).toHaveBeenCalledWith(handoff, "/tmp/x");
   });
 
   it("returns failed run with errorMessage when runDeepReview throws", async () => {
@@ -62,11 +65,12 @@ describe("AgenticDeepReviewProvider", () => {
     );
     const provider = new AgenticDeepReviewProvider();
 
+    const handoff = makeHandoff();
     const runs = await provider.runReview({
       runId: "r1",
       stageRunId: "s1",
       workdir: "/tmp/x",
-      handoff: makeHandoff(),
+      handoff,
       baseRef: "main",
       prNumber: null,
     });
@@ -75,5 +79,6 @@ describe("AgenticDeepReviewProvider", () => {
     expect(runs[0].status).toBe("failed");
     expect(runs[0].errorMessage).toContain("agent sdk down");
     expect(runs[0].findings).toHaveLength(0);
+    expect(runs[0].durationMs).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/core/src/__tests__/agentic-deep-review-provider.test.ts
+++ b/packages/core/src/__tests__/agentic-deep-review-provider.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HandoffArtifact } from "../types.js";
+
+const runDeepReviewMock = vi.fn();
+vi.mock("../executor/deep-review.js", () => ({
+  runDeepReview: (...args: unknown[]) => runDeepReviewMock(...args),
+  deepFindingsToReviewFindings: (findings: unknown[]) => findings,
+}));
+
+const makeHandoff = (): HandoffArtifact => ({
+  runId: "r1",
+  issueId: "i1",
+  stage: "review",
+  timestamp: new Date().toISOString(),
+  summary: "",
+  filesChanged: [],
+  approach: "",
+  context: { issueIntent: "do x", constraints: [], assumptions: [] },
+  tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 },
+});
+
+describe("AgenticDeepReviewProvider", () => {
+  beforeEach(() => { runDeepReviewMock.mockReset(); });
+
+  it("returns a single ReviewModelRun with completed status on success", async () => {
+    runDeepReviewMock.mockResolvedValue({
+      findings: [
+        { severity: "warning", file: "a.ts", line: 1, category: "x", description: "d", fix: "f" },
+      ],
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+
+    const { AgenticDeepReviewProvider } = await import(
+      "../executor/review/agentic-deep-review.js"
+    );
+    const provider = new AgenticDeepReviewProvider();
+
+    const runs = await provider.runReview({
+      runId: "r1",
+      stageRunId: "s1",
+      workdir: "/tmp/x",
+      handoff: makeHandoff(),
+      baseRef: "main",
+      prNumber: null,
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].providerId).toBe("agentic");
+    expect(runs[0].status).toBe("completed");
+    expect(runs[0].modelId).toBe("claude-haiku-4-5-20251001");
+    expect(runs[0].findings).toHaveLength(1);
+    expect(runs[0].inputTokens).toBe(100);
+    expect(runs[0].outputTokens).toBe(50);
+    expect(runDeepReviewMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns failed run with errorMessage when runDeepReview throws", async () => {
+    runDeepReviewMock.mockRejectedValue(new Error("agent sdk down"));
+    const { AgenticDeepReviewProvider } = await import(
+      "../executor/review/agentic-deep-review.js"
+    );
+    const provider = new AgenticDeepReviewProvider();
+
+    const runs = await provider.runReview({
+      runId: "r1",
+      stageRunId: "s1",
+      workdir: "/tmp/x",
+      handoff: makeHandoff(),
+      baseRef: "main",
+      prNumber: null,
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("failed");
+    expect(runs[0].errorMessage).toContain("agent sdk down");
+    expect(runs[0].findings).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/cost/per-run-multi-model.test.ts
+++ b/packages/core/src/__tests__/cost/per-run-multi-model.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { computeRunCost } from "../../cost/per-run.js";
+import { installTestProLicense, restoreLicense } from "../helpers/license.js";
+
+// computeRunCost short-circuits to zero without an enterprise license.
+beforeEach(async () => {
+  await installTestProLicense("enterprise");
+});
+afterEach(async () => {
+  await restoreLicense();
+});
+
+const config = {
+  costs: {
+    modelPricing: {
+      "claude-haiku-4-5-20251001": { inputPerMillion: 1, outputPerMillion: 5 },
+      "anthropic/claude-3.5-sonnet": { inputPerMillion: 3, outputPerMillion: 15 },
+      "claude-sonnet-4-6": { inputPerMillion: 3, outputPerMillion: 15 },
+    },
+    hourlyEngRate: 50,
+    timeSavedPerPrDefault: 4,
+  },
+  pipelineConfigs: {
+    "auto-implement": {
+      stageModels: { implement: "claude-sonnet-4-6" },
+      profile: { model: "claude-sonnet-4-6" },
+      timeSavedPerPr: 6,
+    } as any,
+  },
+} as any;
+
+describe("computeRunCost — multi-model rollup (BEC-134)", () => {
+  it("uses modelRuns per-model pricing when present", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [
+      {
+        stage: "review",
+        inputTokens: 1000,  // stage-level totals (ignored when modelRuns present)
+        outputTokens: 500,
+        modelRuns: [
+          // 600/1_000_000 * 1 + 300/1_000_000 * 5 = 0.0006 + 0.0015 = 0.0021
+          { modelId: "claude-haiku-4-5-20251001", inputTokens: 600, outputTokens: 300 },
+          // 400/1_000_000 * 3 + 200/1_000_000 * 15 = 0.0012 + 0.003 = 0.0042
+          { modelId: "anthropic/claude-3.5-sonnet", inputTokens: 400, outputTokens: 200 },
+        ],
+      },
+    ] as any;
+    const cost = computeRunCost(run, stages, config);
+    // total: 0.0021 + 0.0042 = 0.0063
+    expect(cost.dollars).toBeCloseTo(0.0063, 5);
+    // token totals come from model rows, not stage-level
+    expect(cost.inputTokens).toBe(1000);   // 600 + 400
+    expect(cost.outputTokens).toBe(500);   // 300 + 200
+  });
+
+  it("falls back to stage-level rollup when modelRuns is empty", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [
+      {
+        stage: "review",
+        inputTokens: 1_000_000,
+        outputTokens: 500_000,
+        modelRuns: [],  // empty → use stage-level fallback
+      },
+    ] as any;
+    const cost = computeRunCost(run, stages, config);
+    // review stage uses pipeline profile model: claude-sonnet-4-6 ($3/$15 per M)
+    // 1M * $3 + 0.5M * $15 = $3 + $7.5 = $10.5
+    expect(cost.dollars).toBeCloseTo(10.5, 2);
+    expect(cost.inputTokens).toBe(1_000_000);
+    expect(cost.outputTokens).toBe(500_000);
+  });
+
+  it("falls back to stage-level rollup when modelRuns is absent", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [
+      // no modelRuns field at all — backward-compat for pre-BEC-134 rows
+      { stage: "implement", inputTokens: 1_000_000, outputTokens: 1_000_000 },
+    ] as any;
+    const cost = computeRunCost(run, stages, config);
+    // implement stage model: claude-sonnet-4-6 ($3/$15 per M)
+    // 1M * $3 + 1M * $15 = $18
+    expect(cost.dollars).toBeCloseTo(18, 2);
+  });
+
+  it("mixes model-run and stage-level stages correctly", () => {
+    const run = { pipelineKey: "auto-implement", status: "completed" } as any;
+    const stages = [
+      // implement: no modelRuns → stage-level fallback (claude-sonnet-4-6)
+      { stage: "implement", inputTokens: 1_000_000, outputTokens: 0, modelRuns: [] },
+      // review: per-model pricing
+      {
+        stage: "review",
+        inputTokens: 0,
+        outputTokens: 0,
+        modelRuns: [
+          { modelId: "claude-haiku-4-5-20251001", inputTokens: 1_000_000, outputTokens: 0 },
+        ],
+      },
+    ] as any;
+    const cost = computeRunCost(run, stages, config);
+    // implement: 1M * $3 = $3
+    // review haiku: 1M * $1 = $1
+    // total: $4
+    expect(cost.dollars).toBeCloseTo(4, 5);
+  });
+});

--- a/packages/core/src/__tests__/db-review-model-runs.test.ts
+++ b/packages/core/src/__tests__/db-review-model-runs.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrationsSqlite } from "../db/migrator.js";
+
+describe("review_model_runs migration (sqlite)", () => {
+  it("creates the table with expected columns", () => {
+    const db = new Database(":memory:");
+    runMigrationsSqlite(db);
+
+    const cols = db
+      .prepare("PRAGMA table_info(review_model_runs)")
+      .all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual(
+      [
+        "completed_at",
+        "duration_ms",
+        "error_message",
+        "id",
+        "input_tokens",
+        "model_id",
+        "output_tokens",
+        "provider_id",
+        "stage_run_id",
+        "started_at",
+        "status",
+        "truncated_files",
+      ].sort(),
+    );
+  });
+
+  it("creates an index on stage_run_id", () => {
+    const db = new Database(":memory:");
+    runMigrationsSqlite(db);
+    const indexes = db
+      .prepare("PRAGMA index_list(review_model_runs)")
+      .all() as Array<{ name: string }>;
+    expect(indexes.some((i) => i.name.includes("stage_run_id"))).toBe(true);
+  });
+
+  it("inserts and reads rows", () => {
+    const db = new Database(":memory:");
+    runMigrationsSqlite(db);
+
+    // Need a stage_run row first (FK)
+    db.prepare(
+      "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run("p1", "i1", "t", "k", "u", "running", Math.floor(Date.now() / 1000));
+    db.prepare(
+      "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "p1", "review", "completed", Math.floor(Date.now() / 1000));
+
+    db.prepare(
+      "INSERT INTO review_model_runs (id, stage_run_id, provider_id, model_id, status, input_tokens, output_tokens, duration_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("r1", "s1", "openrouter", "anthropic/claude-3.5-sonnet", "completed", 100, 50, 1000);
+
+    const rows = db
+      .prepare("SELECT * FROM review_model_runs WHERE stage_run_id = ?")
+      .all("s1");
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/core/src/__tests__/db-review-model-runs.test.ts
+++ b/packages/core/src/__tests__/db-review-model-runs.test.ts
@@ -64,7 +64,7 @@ describe("review_model_runs migration (sqlite)", () => {
 });
 
 describe("insertReviewModelRuns", () => {
-  it("writes one row per ReviewModelRun", () => {
+  it("writes one row per ReviewModelRun", async () => {
     const sqliteDb = new Database(":memory:");
     runMigrationsSqlite(sqliteDb);
     sqliteDb.prepare(
@@ -75,7 +75,7 @@ describe("insertReviewModelRuns", () => {
     ).run("s1", "p1", "review", "completed", Math.floor(Date.now() / 1000));
 
     const db = drizzleSqlite(sqliteDb);
-    insertReviewModelRuns(db, "s1", [
+    await insertReviewModelRuns(db, "s1", [
       {
         modelId: "anthropic/claude-3.5-sonnet",
         providerId: "openrouter",

--- a/packages/core/src/__tests__/db-review-model-runs.test.ts
+++ b/packages/core/src/__tests__/db-review-model-runs.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import Database from "better-sqlite3";
 import { runMigrationsSqlite } from "../db/migrator.js";
+import { insertReviewModelRuns } from "../db/review-model-runs.js";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
 
 describe("review_model_runs migration (sqlite)", () => {
   it("creates the table with expected columns", () => {
@@ -58,5 +60,52 @@ describe("review_model_runs migration (sqlite)", () => {
       .prepare("SELECT * FROM review_model_runs WHERE stage_run_id = ?")
       .all("s1");
     expect(rows).toHaveLength(1);
+  });
+});
+
+describe("insertReviewModelRuns", () => {
+  it("writes one row per ReviewModelRun", () => {
+    const sqliteDb = new Database(":memory:");
+    runMigrationsSqlite(sqliteDb);
+    sqliteDb.prepare(
+      "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run("p1", "i1", "t", "k", "u", "running", Math.floor(Date.now() / 1000));
+    sqliteDb.prepare(
+      "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("s1", "p1", "review", "completed", Math.floor(Date.now() / 1000));
+
+    const db = drizzleSqlite(sqliteDb);
+    insertReviewModelRuns(db, "s1", [
+      {
+        modelId: "anthropic/claude-3.5-sonnet",
+        providerId: "openrouter",
+        status: "completed",
+        findings: [],
+        inputTokens: 100,
+        outputTokens: 50,
+        durationMs: 1000,
+      },
+      {
+        modelId: "openai/gpt-4o",
+        providerId: "openrouter",
+        status: "failed",
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: 200,
+        errorMessage: "rate limited",
+        truncatedFiles: 2,
+      },
+    ]);
+
+    const rows = sqliteDb
+      .prepare("SELECT * FROM review_model_runs WHERE stage_run_id = ? ORDER BY model_id")
+      .all("s1") as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].model_id).toBe("anthropic/claude-3.5-sonnet");
+    expect(rows[0].input_tokens).toBe(100);
+    expect(rows[1].status).toBe("failed");
+    expect(rows[1].error_message).toBe("rate limited");
+    expect(rows[1].truncated_files).toBe(2);
   });
 });

--- a/packages/core/src/__tests__/e2e-fanout.test.ts
+++ b/packages/core/src/__tests__/e2e-fanout.test.ts
@@ -1,0 +1,216 @@
+/**
+ * E2E fanout integration test — BEC-134 Task 14
+ *
+ * Drives `runReviewProviders` end-to-end with:
+ *   - Real in-memory SQLite DB (better-sqlite3 + runMigrationsSqlite + Drizzle)
+ *     so actual review_model_runs rows are written and queryable
+ *   - Mocked OpenRouter HTTP client  (avoids network)
+ *   - Mocked agentic deep-review     (avoids Claude SDK)
+ *
+ * Verifies the four required properties:
+ *   1. Both providers (agentic + openrouter) ran
+ *   2. review_model_runs rows were persisted for both providers
+ *   3. Agentic findings appear in agenticFindings (merge-gate path)
+ *   4. Fanout findings do NOT appear in agenticFindings (advisory only)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+import { runMigrationsSqlite } from "../db/migrator.js";
+import * as schema from "../db/schema.js";
+import { eq } from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Hoist mocks so they are available at module-evaluation time
+// ---------------------------------------------------------------------------
+
+const chatCompletionMock = vi.hoisted(() => vi.fn());
+const runDeepReviewMock = vi.hoisted(() => vi.fn());
+
+/**
+ * Mock the OpenRouter HTTP client — intercepts the single method that
+ * OpenRouterFanoutProvider calls, so no real network request is made.
+ */
+vi.mock("../executor/review/openrouter-client.js", () => ({
+  OpenRouterClient: vi.fn().mockImplementation(() => ({
+    chatCompletion: chatCompletionMock,
+  })),
+}));
+
+/**
+ * Mock runDeepReview (called inside AgenticDeepReviewProvider) — avoids
+ * loading the Claude Agent SDK and any real sub-process invocations.
+ * deepFindingsToReviewFindings is the real util; mock only runDeepReview.
+ */
+vi.mock("../executor/deep-review.js", async (orig) => {
+  const real = await orig<typeof import("../executor/deep-review.js")>();
+  return {
+    ...real,
+    runDeepReview: runDeepReviewMock,
+  };
+});
+
+/**
+ * Mock workdir snapshot — OpenRouterFanoutProvider calls this before building
+ * the review prompt. Return empty diff/files so prompt building is trivial.
+ */
+vi.mock("../executor/review/workdir-snapshot.js", () => ({
+  collectWorkdirSnapshot: vi.fn().mockResolvedValue({ diff: "", files: [] }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("E2E fanout integration (BEC-134 Task 14)", () => {
+  let rawDb: InstanceType<typeof Database>;
+  let db: ReturnType<typeof drizzleSqlite<typeof schema>>;
+  let stageRunId: string;
+
+  beforeEach(() => {
+    // Fresh in-memory SQLite — run ALL migrations so review_model_runs exists
+    rawDb = new Database(":memory:");
+    rawDb.pragma("foreign_keys = ON");
+    runMigrationsSqlite(rawDb);
+    db = drizzleSqlite(rawDb, { schema });
+
+    // Seed FK chain: pipeline_run → stage_run so review_model_runs can reference it
+    const pipelineRunId = "pr-fanout-e2e";
+    const now = Math.floor(Date.now() / 1000);
+    rawDb
+      .prepare(
+        "INSERT INTO pipeline_runs (id, issue_id, issue_title, pipeline_key, repo_url, status, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run(pipelineRunId, "FANOUT-1", "Fanout e2e test", "auto-implement", "https://github.com/test/repo.git", "running", now);
+
+    stageRunId = "sr-fanout-e2e";
+    rawDb
+      .prepare(
+        "INSERT INTO stage_runs (id, pipeline_run_id, stage, status, started_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(stageRunId, pipelineRunId, "review", "running", now);
+
+    // Agentic: returns one blocking finding matching DeepReviewFinding shape
+    runDeepReviewMock.mockResolvedValue({
+      findings: [
+        {
+          agent: "quality",
+          severity: "blocking",
+          file: "src/auth.ts",
+          line: 42,
+          category: "error-handling",
+          description: "Null pointer risk in auth.ts",
+          fix: "Add a null check before dereferencing",
+        },
+      ],
+      inputTokens: 80,
+      outputTokens: 20,
+    });
+
+    // OpenRouter fanout: valid { findings: [...] } envelope per parseReviewFindings contract
+    const fanoutResponseContent = JSON.stringify({
+      findings: [
+        {
+          severity: "suggestion",
+          file: "src/auth.ts",
+          line: 10,
+          category: "quality",
+          description: "Consider extracting a helper function",
+          fix: "Extract the repeated logic into a shared helper",
+        },
+      ],
+    });
+    chatCompletionMock.mockResolvedValue({
+      content: fanoutResponseContent,
+      inputTokens: 50,
+      outputTokens: 15,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    rawDb.close();
+  });
+
+  it("runs both providers, persists review_model_runs rows, and routes findings correctly", async () => {
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+
+    const handoff = {
+      runId: "pr-fanout-e2e",
+      issueId: "FANOUT-1",
+      stage: "review",
+      timestamp: new Date().toISOString(),
+      summary: "Implemented auth feature",
+      filesChanged: ["src/auth.ts"],
+      approach: "Standard implementation",
+      context: {
+        issueIntent: "Add OAuth login",
+        constraints: [],
+        assumptions: [],
+      },
+      tokenBudget: { contextTokensUsed: 100, recommendedMaxTurns: 5 },
+    };
+
+    const result = await runReviewProviders(
+      {
+        runId: "pr-fanout-e2e",
+        stageRunId,
+        workdir: "/tmp/fanout-e2e-workdir",
+        handoff,
+        baseRef: "main",
+        prNumber: null,
+      },
+      {
+        env: {
+          REVIEW_MODELS: "anthropic/claude-3.5-sonnet",
+          OPENROUTER_API_KEY: "sk-or-test-key",
+        } as NodeJS.ProcessEnv,
+        db: db as any,
+      },
+    );
+
+    // ── 1. Both providers ran ────────────────────────────────────────────────
+    expect(runDeepReviewMock, "agentic provider should have run once").toHaveBeenCalledOnce();
+    expect(chatCompletionMock, "openrouter provider should have run once").toHaveBeenCalledOnce();
+
+    // ── 2. review_model_runs rows persisted for both providers ───────────────
+    const rows = db
+      .select()
+      .from(schema.reviewModelRuns)
+      .where(eq(schema.reviewModelRuns.stageRunId, stageRunId))
+      .all();
+
+    expect(rows, "should have one row per provider").toHaveLength(2);
+
+    const providerIds = rows.map((r) => r.providerId).sort();
+    expect(providerIds).toEqual(["agentic", "openrouter"]);
+
+    for (const row of rows) {
+      expect(row.status).toBe("completed");
+    }
+
+    // ── 3. Agentic findings appear in agenticFindings (merge gate) ───────────
+    expect(result.agenticFindings).toHaveLength(1);
+    expect(result.agenticFindings[0]!.severity).toBe("blocking");
+    expect(result.agenticFindings[0]!.description).toContain("Null pointer risk");
+
+    // ── 4. Fanout findings do NOT appear in agenticFindings (advisory only) ──
+    const fanoutRuns = result.allRuns.filter((r) => r.providerId !== "agentic");
+    expect(fanoutRuns).toHaveLength(1);
+    expect(fanoutRuns[0]!.findings).toHaveLength(1);
+    expect(fanoutRuns[0]!.findings[0]!.severity).toBe("suggestion");
+
+    // Fanout findings must not leak into the merge-gate findings list
+    const agenticDescriptions = result.agenticFindings.map((f) => f.description);
+    for (const fanoutRun of fanoutRuns) {
+      for (const finding of fanoutRun.findings) {
+        expect(agenticDescriptions).not.toContain(finding.description);
+      }
+    }
+
+    // ── Bonus: token counts accumulated across both providers ────────────────
+    expect(result.totalInputTokens).toBe(130);   // 80 agentic + 50 openrouter
+    expect(result.totalOutputTokens).toBe(35);   // 20 agentic + 15 openrouter
+  });
+});

--- a/packages/core/src/__tests__/e2e-pipeline.test.ts
+++ b/packages/core/src/__tests__/e2e-pipeline.test.ts
@@ -113,6 +113,7 @@ vi.mock("../executor/executor.js", () => ({
         turns: 2,
         handoffArtifact: makeHandoffArtifact(runId, issueId, stage),
         handoffIsStructured: true,
+        stageRunId: `mock-${runId}-${stage}`,
       } satisfies StageResult;
     },
   ),

--- a/packages/core/src/__tests__/notifier-discord.test.ts
+++ b/packages/core/src/__tests__/notifier-discord.test.ts
@@ -49,7 +49,7 @@ describe("DiscordNotifier", () => {
     const notifier = new DiscordNotifier();
     await notifier.onPipelineStart(makeRun());
     await notifier.onStageComplete(makeRun(), "test", {
-      status: "completed", inputTokens: 100, outputTokens: 50, turns: 3,
+      status: "completed", inputTokens: 100, outputTokens: 50, turns: 3, stageRunId: "sr1",
     });
     await notifier.onPipelineComplete(makeRun(), {
       prUrl: "https://example.com/pr/1", totalInputTokens: 1000, totalOutputTokens: 500, stagesCompleted: 3,
@@ -71,14 +71,14 @@ describe("DiscordNotifier", () => {
 
     // Stage complete (success) -> green (0x00ff00)
     await notifier.onStageComplete(makeRun(), "implement", {
-      status: "completed", inputTokens: 100, outputTokens: 50, turns: 3,
+      status: "completed", inputTokens: 100, outputTokens: 50, turns: 3, stageRunId: "sr2",
     });
     body = JSON.parse(mockFetch.mock.calls[1][1].body);
     expect(body.embeds[0].color).toBe(0x00ff00);
 
     // Stage complete (failed) -> red (0xff0000)
     await notifier.onStageComplete(makeRun(), "test", {
-      status: "failed", inputTokens: 100, outputTokens: 50, turns: 3, errorMessage: "oops",
+      status: "failed", inputTokens: 100, outputTokens: 50, turns: 3, errorMessage: "oops", stageRunId: "sr3",
     });
     body = JSON.parse(mockFetch.mock.calls[2][1].body);
     expect(body.embeds[0].color).toBe(0xff0000);

--- a/packages/core/src/__tests__/notifier-slack.test.ts
+++ b/packages/core/src/__tests__/notifier-slack.test.ts
@@ -53,7 +53,7 @@ describe("SlackNotifier", () => {
     const notifier = new SlackNotifier();
     await notifier.onPipelineStart(makeRun());
     await notifier.onStageComplete(makeRun(), "test", {
-      status: "completed", inputTokens: 100, outputTokens: 50, turns: 3,
+      status: "completed", inputTokens: 100, outputTokens: 50, turns: 3, stageRunId: "sr1",
     });
     await notifier.onPipelineComplete(makeRun(), {
       prUrl: "https://example.com/pr/1", totalInputTokens: 1000, totalOutputTokens: 500, stagesCompleted: 3,
@@ -77,7 +77,7 @@ describe("SlackNotifier", () => {
   it("sends stage complete payload", async () => {
     const notifier = new SlackNotifier("https://hooks.slack.com/test");
     await notifier.onStageComplete(makeRun(), "implement", {
-      status: "completed", inputTokens: 1000, outputTokens: 500, turns: 5,
+      status: "completed", inputTokens: 1000, outputTokens: 500, turns: 5, stageRunId: "sr2",
     });
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);

--- a/packages/core/src/__tests__/notifier.test.ts
+++ b/packages/core/src/__tests__/notifier.test.ts
@@ -25,6 +25,7 @@ function makeStageResult(overrides: Partial<StageResult> = {}): StageResult {
     inputTokens: 1000,
     outputTokens: 500,
     turns: 5,
+    stageRunId: "test-stage-run-id",
     ...overrides,
   };
 }

--- a/packages/core/src/__tests__/openrouter-client.test.ts
+++ b/packages/core/src/__tests__/openrouter-client.test.ts
@@ -41,6 +41,8 @@ describe("OpenRouterClient", () => {
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer sk-or-test");
     expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["HTTP-Referer"]).toBe("https://urateams.com");
+    expect(headers["X-Title"]).toBe("urateam");
   });
 
   it("throws on non-2xx with status and snippet of body", async () => {

--- a/packages/core/src/__tests__/openrouter-client.test.ts
+++ b/packages/core/src/__tests__/openrouter-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("OpenRouterClient", () => {
+  const fetchMock = vi.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("posts to /chat/completions with auth header and returns content + tokens", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "hello" } }],
+          usage: { prompt_tokens: 12, completion_tokens: 7 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({
+      apiKey: "sk-or-test",
+      baseUrl: "https://example.test/api/v1",
+    });
+    const result = await client.chatCompletion(
+      "anthropic/claude-3.5-sonnet",
+      [{ role: "user", content: "hi" }],
+      { signal: new AbortController().signal },
+    );
+    expect(result).toEqual({ content: "hello", inputTokens: 12, outputTokens: 7 });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.test/api/v1/chat/completions");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer sk-or-test");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("throws on non-2xx with status and snippet of body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("rate limited bro", { status: 429 }),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    await expect(
+      client.chatCompletion("m", [{ role: "user", content: "x" }], {
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/openrouter 429/);
+  });
+
+  it("propagates AbortController abort as a rejection", async () => {
+    const ac = new AbortController();
+    fetchMock.mockImplementation((_url, init: RequestInit) => {
+      return new Promise((_, reject) => {
+        init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    const p = client.chatCompletion("m", [{ role: "user", content: "x" }], { signal: ac.signal });
+    ac.abort();
+    await expect(p).rejects.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/openrouter-fanout.test.ts
+++ b/packages/core/src/__tests__/openrouter-fanout.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HandoffArtifact } from "../types.js";
+
+const chatCompletion = vi.fn();
+vi.mock("../executor/review/openrouter-client.js", () => ({
+  OpenRouterClient: class {
+    chatCompletion = chatCompletion;
+  },
+}));
+// Stub git diff + file collection so test does not need a real workdir
+vi.mock("../executor/review/workdir-snapshot.js", () => ({
+  collectWorkdirSnapshot: async () => ({
+    diff: "diff --git a/x b/x\n+y",
+    files: [{ path: "x", body: "y" }],
+  }),
+}));
+
+const handoff: HandoffArtifact = {
+  runId: "r1",
+  issueId: "i1",
+  stage: "review",
+  timestamp: "2026-04-30T00:00:00Z",
+  summary: "",
+  filesChanged: ["x"],
+  approach: "",
+  context: { issueIntent: "do x", constraints: [], assumptions: [] },
+  tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 },
+};
+
+const ctx = () => ({
+  runId: "r1",
+  stageRunId: "s1",
+  workdir: "/tmp/wd",
+  handoff,
+  baseRef: "main",
+  prNumber: 42,
+});
+
+describe("OpenRouterFanoutProvider", () => {
+  beforeEach(() => { chatCompletion.mockReset(); });
+
+  const validJson = `{"findings":[{"severity":"warning","file":"a","line":1,"category":"quality","description":"d","fix":"f"}]}`;
+
+  it("runs N parallel calls and returns one ReviewModelRun per model", async () => {
+    chatCompletion.mockResolvedValue({ content: validJson, inputTokens: 10, outputTokens: 5 });
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k",
+      baseUrl: "https://x/api/v1",
+      models: ["m1", "m2", "m3"],
+      timeoutMs: 1000,
+      maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    expect(runs).toHaveLength(3);
+    expect(runs.map((r) => r.modelId).sort()).toEqual(["m1", "m2", "m3"]);
+    expect(runs.every((r) => r.status === "completed")).toBe(true);
+    expect(chatCompletion).toHaveBeenCalledTimes(3);
+  });
+
+  it("partial failure: one model rejects, others complete", async () => {
+    chatCompletion
+      .mockResolvedValueOnce({ content: validJson, inputTokens: 1, outputTokens: 1 })
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ content: validJson, inputTokens: 1, outputTokens: 1 });
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k", baseUrl: "https://x/api/v1",
+      models: ["m1", "m2", "m3"], timeoutMs: 1000, maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    const failed = runs.filter((r) => r.status === "failed");
+    const ok = runs.filter((r) => r.status === "completed");
+    expect(failed).toHaveLength(1);
+    expect(failed[0].errorMessage).toContain("boom");
+    expect(ok).toHaveLength(2);
+  });
+
+  it("malformed JSON output → run failed with parser error", async () => {
+    chatCompletion.mockResolvedValue({ content: "not json", inputTokens: 1, outputTokens: 1 });
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k", baseUrl: "https://x/api/v1",
+      models: ["m1"], timeoutMs: 1000, maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    expect(runs[0].status).toBe("failed");
+    expect(runs[0].errorMessage).toContain("not parseable");
+  });
+
+  it("all models fail → returns N failed runs (does not throw)", async () => {
+    chatCompletion.mockRejectedValue(new Error("dead"));
+    const { OpenRouterFanoutProvider } = await import(
+      "../executor/review/openrouter-fanout.js"
+    );
+    const p = new OpenRouterFanoutProvider({
+      apiKey: "k", baseUrl: "https://x/api/v1",
+      models: ["m1", "m2"], timeoutMs: 1000, maxInputTokens: 100_000,
+    });
+    const runs = await p.runReview(ctx());
+    expect(runs).toHaveLength(2);
+    expect(runs.every((r) => r.status === "failed")).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/post-fanout-comments.test.ts
+++ b/packages/core/src/__tests__/post-fanout-comments.test.ts
@@ -70,4 +70,37 @@ describe("postFanoutCommentsToPR", () => {
     expect(body).toContain("input truncated");
     expect(body).toContain("3");
   });
+
+  it("escapes newlines and pipes in description cells", async () => {
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    const runWithNewline: ReviewModelRun = {
+      ...completedRun,
+      findings: [
+        { severity: "warning", file: "a.ts", line: 1, category: "quality",
+          description: "first line\nsecond line | with pipe", fix: "f" },
+      ],
+    };
+    await postFanoutCommentsToPR({} as never, "o", "r", 1, [runWithNewline]);
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).not.toMatch(/first line\nsecond line/);  // newline must be replaced
+    expect(body).toContain("first line second line \\| with pipe");
+  });
+
+  it("continues posting remaining runs when one addPRComment rejects", async () => {
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    addPRComment
+      .mockRejectedValueOnce(new Error("rate limit"))
+      .mockResolvedValueOnce(undefined);
+
+    // Should not throw
+    await expect(
+      postFanoutCommentsToPR({} as never, "o", "r", 1, [completedRun, failedRun]),
+    ).resolves.toBeUndefined();
+    // Both addPRComment calls were attempted
+    expect(addPRComment).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/core/src/__tests__/post-fanout-comments.test.ts
+++ b/packages/core/src/__tests__/post-fanout-comments.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReviewModelRun } from "../executor/review/review-provider.js";
+
+const { addPRComment } = vi.hoisted(() => ({ addPRComment: vi.fn() }));
+vi.mock("../repo/github.js", () => ({ addPRComment }));
+
+const completedRun: ReviewModelRun = {
+  modelId: "anthropic/claude-3.5-sonnet",
+  providerId: "openrouter",
+  status: "completed",
+  findings: [
+    { severity: "warning", file: "a.ts", line: 1, category: "quality", description: "d", fix: "f" },
+  ],
+  inputTokens: 100,
+  outputTokens: 50,
+  durationMs: 1000,
+};
+
+const failedRun: ReviewModelRun = {
+  modelId: "openai/gpt-4o",
+  providerId: "openrouter",
+  status: "failed",
+  findings: [],
+  inputTokens: 0,
+  outputTokens: 0,
+  durationMs: 200,
+  errorMessage: "rate limited",
+};
+
+describe("postFanoutCommentsToPR", () => {
+  beforeEach(() => {
+    addPRComment.mockReset();
+  });
+
+  it("posts one comment per run with model id and findings table", async () => {
+    addPRComment.mockResolvedValue(undefined);
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    await postFanoutCommentsToPR({} as never, "owner", "repo", 42, [completedRun]);
+    expect(addPRComment).toHaveBeenCalledOnce();
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).toContain("anthropic/claude-3.5-sonnet");
+    expect(body).toContain("Status: completed");
+    expect(body).toContain("warning");
+    expect(body).toContain("a.ts");
+    expect(body).toContain("Advisory only");
+  });
+
+  it("posts a 'failed' comment with errorMessage", async () => {
+    addPRComment.mockResolvedValue(undefined);
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    await postFanoutCommentsToPR({} as never, "o", "r", 1, [failedRun]);
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).toContain("Status: failed");
+    expect(body).toContain("rate limited");
+  });
+
+  it("notes truncated input when truncatedFiles > 0", async () => {
+    addPRComment.mockResolvedValue(undefined);
+    const { postFanoutCommentsToPR } = await import(
+      "../executor/review/post-fanout-comments.js"
+    );
+    await postFanoutCommentsToPR({} as never, "o", "r", 1, [
+      { ...completedRun, truncatedFiles: 3 },
+    ]);
+    const body = (addPRComment.mock.calls[0][4] as string);
+    expect(body).toContain("input truncated");
+    expect(body).toContain("3");
+  });
+});

--- a/packages/core/src/__tests__/ralph-review-fix-regression.test.ts
+++ b/packages/core/src/__tests__/ralph-review-fix-regression.test.ts
@@ -116,6 +116,7 @@ vi.mock("../executor/executor.js", () => ({
         turns: 1,
         handoffArtifact: makeHandoffArtifact(runId, issueId, stage, reviewFindings),
         handoffIsStructured: true,
+        stageRunId: `mock-${runId}-${stage}`,
       } satisfies StageResult;
     },
   ),

--- a/packages/core/src/__tests__/review-prompt.test.ts
+++ b/packages/core/src/__tests__/review-prompt.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildReviewPrompt,
+  parseReviewFindings,
+  estimateTokens,
+} from "../executor/review/review-prompt.js";
+import type { HandoffArtifact } from "../types.js";
+
+const handoff: HandoffArtifact = {
+  runId: "r1",
+  issueId: "i1",
+  stage: "review",
+  timestamp: "2026-04-30T00:00:00Z",
+  summary: "",
+  filesChanged: ["src/foo.ts"],
+  approach: "",
+  context: {
+    issueIntent: "Fix bug X",
+    constraints: ["no new deps"],
+    assumptions: ["node 20"],
+  },
+  tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 },
+};
+
+describe("buildReviewPrompt", () => {
+  it("includes intent, constraints, diff, and JSON-output instruction", () => {
+    const prompt = buildReviewPrompt({
+      handoff,
+      diff: "diff --git a/src/foo.ts b/src/foo.ts\n+++ b/src/foo.ts\n@@\n+x",
+      files: [{ path: "src/foo.ts", body: "export const x = 1;" }],
+      maxInputTokens: 100_000,
+    });
+    expect(prompt.messages).toHaveLength(2);
+    expect(prompt.messages[0].role).toBe("system");
+    expect(prompt.messages[1].role).toBe("user");
+    expect(prompt.messages[1].content).toContain("Fix bug X");
+    expect(prompt.messages[1].content).toContain("no new deps");
+    expect(prompt.messages[1].content).toContain("diff --git");
+    expect(prompt.messages[1].content).toContain("export const x = 1;");
+    expect(prompt.messages[0].content).toContain("findings");  // schema instruction
+    expect(prompt.truncatedFiles).toBe(0);
+  });
+
+  it("drops file bodies tail-first when over budget but keeps the diff", () => {
+    const big = "x".repeat(20_000);
+    const out = buildReviewPrompt({
+      handoff,
+      diff: "diff --git a/foo b/foo\n+y",
+      files: [
+        { path: "a.ts", body: big },
+        { path: "b.ts", body: big },
+        { path: "c.ts", body: big },
+      ],
+      maxInputTokens: 6_000, // forces truncation
+    });
+    expect(out.truncatedFiles).toBeGreaterThan(0);
+    expect(out.messages[1].content).toContain("diff --git");
+  });
+});
+
+describe("parseReviewFindings", () => {
+  it("extracts the first balanced JSON object and validates against schema", () => {
+    const raw = `Sure, here is the review:
+\`\`\`json
+{ "findings": [
+  { "severity": "warning", "file": "a.ts", "line": 1, "category": "x", "description": "d", "fix": "f" }
+] }
+\`\`\`
+End.`;
+    const findings = parseReviewFindings(raw);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("warning");
+  });
+
+  it("throws on malformed JSON", () => {
+    expect(() => parseReviewFindings("not json at all")).toThrow();
+  });
+
+  it("throws when schema validation fails", () => {
+    expect(() => parseReviewFindings('{"findings":[{"bad":true}]}')).toThrow();
+  });
+});
+
+describe("estimateTokens", () => {
+  it("returns a roughly char/4 estimate", () => {
+    expect(estimateTokens("a".repeat(40))).toBe(10);
+  });
+});

--- a/packages/core/src/__tests__/review-prompt.test.ts
+++ b/packages/core/src/__tests__/review-prompt.test.ts
@@ -79,6 +79,19 @@ End.`;
   it("throws when schema validation fails", () => {
     expect(() => parseReviewFindings('{"findings":[{"bad":true}]}')).toThrow();
   });
+
+  it("ignores { inside string literals before the real envelope", () => {
+    const raw = `I noticed "a {problem}" here. {"findings":[]}`;
+    expect(parseReviewFindings(raw)).toEqual([]);
+  });
+
+  it("handles \\uXXXX escapes inside string literals", () => {
+    // " is a double-quote; the scanner must not terminate the string here.
+    const raw = `Model output: { "findings": [{ "severity": "warning", "file": "a\\u0022.ts", "line": 1, "category": "x", "description": "d", "fix": "f" }] }`;
+    const findings = parseReviewFindings(raw);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toContain('"');
+  });
 });
 
 describe("estimateTokens", () => {

--- a/packages/core/src/__tests__/review-provider-registry.test.ts
+++ b/packages/core/src/__tests__/review-provider-registry.test.ts
@@ -33,3 +33,48 @@ describe("review-provider registry", () => {
     expect(typeof p.runReview).toBe("function");
   });
 });
+
+describe("review-provider registry — fanout selection", () => {
+  it("returns only agentic when REVIEW_MODELS unset", () => {
+    const ps = getEnabledProviders({});
+    expect(ps.map((p) => p.id)).toEqual(["agentic"]);
+  });
+
+  it("adds openrouter when both vars set", () => {
+    const ps = getEnabledProviders({
+      REVIEW_MODELS: "anthropic/claude-3.5-sonnet,openai/gpt-4o",
+      OPENROUTER_API_KEY: "sk-or-x",
+    });
+    expect(ps.map((p) => p.id).sort()).toEqual(["agentic", "openrouter"]);
+  });
+
+  it("throws when REVIEW_MODELS set but OPENROUTER_API_KEY missing", () => {
+    expect(() => getEnabledProviders({ REVIEW_MODELS: "x/y" })).toThrow(
+      /OPENROUTER_API_KEY/,
+    );
+  });
+
+  it("throws when OPENROUTER_API_KEY set but REVIEW_MODELS missing", () => {
+    expect(() => getEnabledProviders({ OPENROUTER_API_KEY: "sk" })).toThrow(
+      /REVIEW_MODELS/,
+    );
+  });
+
+  it("treats whitespace-only REVIEW_MODELS as unset (and throws since OPENROUTER_API_KEY is set without effective models)", () => {
+    expect(() =>
+      getEnabledProviders({ REVIEW_MODELS: " , , ", OPENROUTER_API_KEY: "sk" }),
+    ).toThrow(/REVIEW_MODELS/);
+  });
+
+  it("trims whitespace and drops empty entries from REVIEW_MODELS", () => {
+    const ps = getEnabledProviders({
+      REVIEW_MODELS: " m1 , , m2 ,",
+      OPENROUTER_API_KEY: "sk",
+    });
+    const fanout = ps.find((p) => p.id === "openrouter");
+    expect(fanout).toBeDefined();
+    // White-box: read the configured models off the provider.
+    const models = (fanout as unknown as { cfg: { models: string[] } }).cfg.models;
+    expect(models).toEqual(["m1", "m2"]);
+  });
+});

--- a/packages/core/src/__tests__/review-provider-registry.test.ts
+++ b/packages/core/src/__tests__/review-provider-registry.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import {
+  getEnabledProviders,
+  type ReviewProvider,
+  type ReviewModelRun,
+  type ReviewContext,
+} from "../executor/review/review-provider.js";
+
+describe("review-provider registry", () => {
+  it("exports the ReviewProvider interface and ReviewModelRun type", () => {
+    // Compile-time existence check via type assignment
+    const _checkRun: ReviewModelRun = {
+      modelId: "x",
+      providerId: "agentic",
+      status: "completed",
+      findings: [],
+      inputTokens: 0,
+      outputTokens: 0,
+      durationMs: 0,
+    };
+    expect(_checkRun.modelId).toBe("x");
+  });
+
+  it("returns at least the agentic provider when env is empty", () => {
+    const providers = getEnabledProviders({});
+    expect(providers.length).toBeGreaterThanOrEqual(1);
+    expect(providers.some((p) => p.id === "agentic")).toBe(true);
+  });
+
+  it("ReviewProvider has runReview signature", () => {
+    const providers = getEnabledProviders({});
+    const p: ReviewProvider = providers[0];
+    expect(typeof p.runReview).toBe("function");
+  });
+});

--- a/packages/core/src/__tests__/runner-fanout-integration.test.ts
+++ b/packages/core/src/__tests__/runner-fanout-integration.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { fanoutRunReview, agenticRunReview, insertReviewModelRunsMock, postFanoutCommentsToPRMock } = vi.hoisted(() => ({
+  fanoutRunReview: vi.fn(),
+  agenticRunReview: vi.fn(),
+  insertReviewModelRunsMock: vi.fn(),
+  postFanoutCommentsToPRMock: vi.fn(),
+}));
+
+vi.mock("../executor/review/review-provider.js", async (orig) => {
+  const real = await orig<typeof import("../executor/review/review-provider.js")>();
+  return {
+    ...real,
+    getEnabledProviders: () => [
+      { id: "agentic", runReview: agenticRunReview },
+      { id: "openrouter", runReview: fanoutRunReview },
+    ],
+  };
+});
+vi.mock("../db/review-model-runs.js", () => ({
+  insertReviewModelRuns: insertReviewModelRunsMock,
+}));
+vi.mock("../executor/review/post-fanout-comments.js", () => ({
+  postFanoutCommentsToPR: postFanoutCommentsToPRMock,
+}));
+
+describe("runner fanout integration", () => {
+  beforeEach(() => {
+    fanoutRunReview.mockReset();
+    agenticRunReview.mockReset();
+    insertReviewModelRunsMock.mockReset();
+    postFanoutCommentsToPRMock.mockReset();
+  });
+
+  it("runs fanout once per stage execution and posts comments", async () => {
+    fanoutRunReview.mockResolvedValue([
+      {
+        modelId: "anthropic/claude-3.5-sonnet",
+        providerId: "openrouter",
+        status: "completed",
+        findings: [],
+        inputTokens: 1, outputTokens: 1, durationMs: 1,
+      },
+    ]);
+    agenticRunReview.mockResolvedValue([
+      {
+        modelId: "claude-haiku-4-5-20251001",
+        providerId: "agentic",
+        status: "completed",
+        findings: [],
+        inputTokens: 1, outputTokens: 1, durationMs: 1,
+      },
+    ]);
+
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+    const ctx = {
+      runId: "r1", stageRunId: "s1", workdir: "/tmp/x",
+      handoff: { runId: "r1", issueId: "i1", stage: "review", timestamp: "",
+        summary: "", filesChanged: [], approach: "",
+        context: { issueIntent: "x", constraints: [], assumptions: [] },
+        tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
+      baseRef: "main", prNumber: 42,
+    };
+    const result = await runReviewProviders(ctx, {
+      env: { REVIEW_MODELS: "anthropic/claude-3.5-sonnet", OPENROUTER_API_KEY: "sk-or" },
+      db: {} as never,
+      octokit: {} as never,
+      owner: "o",
+      repo: "r",
+    });
+
+    expect(agenticRunReview).toHaveBeenCalledOnce();
+    expect(fanoutRunReview).toHaveBeenCalledOnce();
+    expect(insertReviewModelRunsMock).toHaveBeenCalledOnce();
+    const persisted = insertReviewModelRunsMock.mock.calls[0][2] as Array<{ providerId: string }>;
+    expect(persisted).toHaveLength(2);
+    expect(postFanoutCommentsToPRMock).toHaveBeenCalledOnce();
+    const postedRuns = postFanoutCommentsToPRMock.mock.calls[0][4] as Array<{ providerId: string }>;
+    expect(postedRuns.every((r) => r.providerId === "openrouter")).toBe(true);
+    expect(result.agenticFindings).toHaveLength(0);
+    expect(result.totalInputTokens).toBe(2);
+    expect(result.totalOutputTokens).toBe(2);
+  });
+
+  it("does not post comments when prNumber is null", async () => {
+    fanoutRunReview.mockResolvedValue([]);
+    agenticRunReview.mockResolvedValue([]);
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+    await runReviewProviders(
+      { runId: "r1", stageRunId: "s1", workdir: "/tmp/x",
+        handoff: { runId: "r1", issueId: "i1", stage: "review", timestamp: "",
+          summary: "", filesChanged: [], approach: "",
+          context: { issueIntent: "x", constraints: [], assumptions: [] },
+          tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
+        baseRef: "main", prNumber: null },
+      { env: {}, db: {} as never, octokit: {} as never, owner: "o", repo: "r" },
+    );
+    expect(postFanoutCommentsToPRMock).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if fanout provider rejects (best-effort)", async () => {
+    agenticRunReview.mockResolvedValue([
+      { modelId: "claude-haiku-4-5-20251001", providerId: "agentic", status: "completed",
+        findings: [], inputTokens: 0, outputTokens: 0, durationMs: 0 },
+    ]);
+    fanoutRunReview.mockRejectedValue(new Error("network gone"));
+    const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");
+    const result = await runReviewProviders(
+      { runId: "r1", stageRunId: "s1", workdir: "/tmp/x",
+        handoff: { runId: "r1", issueId: "i1", stage: "review", timestamp: "",
+          summary: "", filesChanged: [], approach: "",
+          context: { issueIntent: "x", constraints: [], assumptions: [] },
+          tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
+        baseRef: "main", prNumber: 1 },
+      { env: { REVIEW_MODELS: "x", OPENROUTER_API_KEY: "k" },
+        db: {} as never, octokit: {} as never, owner: "o", repo: "r" },
+    );
+    expect(result.agenticFindings).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/runner-fanout-integration.test.ts
+++ b/packages/core/src/__tests__/runner-fanout-integration.test.ts
@@ -64,9 +64,6 @@ describe("runner fanout integration", () => {
     const result = await runReviewProviders(ctx, {
       env: { REVIEW_MODELS: "anthropic/claude-3.5-sonnet", OPENROUTER_API_KEY: "sk-or" },
       db: {} as never,
-      octokit: {} as never,
-      owner: "o",
-      repo: "r",
     });
 
     expect(agenticRunReview).toHaveBeenCalledOnce();
@@ -96,7 +93,7 @@ describe("runner fanout integration", () => {
           context: { issueIntent: "x", constraints: [], assumptions: [] },
           tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
         baseRef: "main", prNumber: null },
-      { env: {}, db: {} as never, octokit: {} as never, owner: "o", repo: "r" },
+      { env: {}, db: {} as never },
     );
     expect(postFanoutCommentsToPRMock).not.toHaveBeenCalled();
   });
@@ -116,7 +113,7 @@ describe("runner fanout integration", () => {
           tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 0 } },
         baseRef: "main", prNumber: 1 },
       { env: { REVIEW_MODELS: "x", OPENROUTER_API_KEY: "k" },
-        db: {} as never, octokit: {} as never, owner: "o", repo: "r" },
+        db: {} as never },
     );
     expect(result.agenticFindings).toEqual([]);
   });

--- a/packages/core/src/__tests__/runner-fanout-integration.test.ts
+++ b/packages/core/src/__tests__/runner-fanout-integration.test.ts
@@ -32,7 +32,7 @@ describe("runner fanout integration", () => {
     postFanoutCommentsToPRMock.mockReset();
   });
 
-  it("runs fanout once per stage execution and posts comments", async () => {
+  it("runs fanout once per stage execution and persists rows; runner posts comments separately", async () => {
     fanoutRunReview.mockResolvedValue([
       {
         modelId: "anthropic/claude-3.5-sonnet",
@@ -74,15 +74,18 @@ describe("runner fanout integration", () => {
     expect(insertReviewModelRunsMock).toHaveBeenCalledOnce();
     const persisted = insertReviewModelRunsMock.mock.calls[0][2] as Array<{ providerId: string }>;
     expect(persisted).toHaveLength(2);
-    expect(postFanoutCommentsToPRMock).toHaveBeenCalledOnce();
-    const postedRuns = postFanoutCommentsToPRMock.mock.calls[0][4] as Array<{ providerId: string }>;
-    expect(postedRuns.every((r) => r.providerId === "openrouter")).toBe(true);
+    // BEC-134: helper no longer posts; the runner posts after PR creation
+    // using `result.allRuns` filtered to non-agentic.
+    expect(postFanoutCommentsToPRMock).not.toHaveBeenCalled();
+    const fanoutFromResult = result.allRuns.filter((r) => r.providerId !== "agentic");
+    expect(fanoutFromResult).toHaveLength(1);
+    expect(fanoutFromResult[0]!.providerId).toBe("openrouter");
     expect(result.agenticFindings).toHaveLength(0);
     expect(result.totalInputTokens).toBe(2);
     expect(result.totalOutputTokens).toBe(2);
   });
 
-  it("does not post comments when prNumber is null", async () => {
+  it("does not post comments (helper never posts post-BEC-134)", async () => {
     fanoutRunReview.mockResolvedValue([]);
     agenticRunReview.mockResolvedValue([]);
     const { runReviewProviders } = await import("../pipeline/review-providers-runner.js");

--- a/packages/core/src/cost/aggregate.ts
+++ b/packages/core/src/cost/aggregate.ts
@@ -1,6 +1,6 @@
 import { and, gte, lt, inArray } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
-import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { pipelineRuns, stageRuns, costRollupsDaily, reviewModelRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { createLogger } from "../logger.js";
 import { isFeatureLicensed } from "../license.js";
@@ -111,10 +111,25 @@ export async function aggregateAll(
   const runIds = runs.map((r: any) => r.id);
   const stages = await db.select().from(stageRuns).where(inArray(stageRuns.pipelineRunId, runIds));
 
+  // BEC-134: fetch per-model rows and attach them to their parent stage_run.
+  const stageIds = stages.map((s: any) => s.id);
+  const modelRunRows = stageIds.length > 0
+    ? await db.select().from(reviewModelRuns).where(
+        inArray(reviewModelRuns.stageRunId, stageIds),
+      )
+    : [];
+  const modelRunsByStage = new Map<string, any[]>();
+  for (const mr of modelRunRows) {
+    const arr = modelRunsByStage.get(mr.stageRunId) ?? [];
+    arr.push(mr);
+    modelRunsByStage.set(mr.stageRunId, arr);
+  }
+
   const stagesByRun = new Map<string, any[]>();
   for (const s of stages) {
+    const enriched = { ...s, modelRuns: modelRunsByStage.get(s.id) ?? [] };
     const arr = stagesByRun.get(s.pipelineRunId) ?? [];
-    arr.push(s);
+    arr.push(enriched);
     stagesByRun.set(s.pipelineRunId, arr);
   }
 

--- a/packages/core/src/cost/csv.ts
+++ b/packages/core/src/cost/csv.ts
@@ -1,6 +1,6 @@
 import type { AnyDb } from "../db/client.js";
 import { and, gte, lt, inArray } from "drizzle-orm";
-import { pipelineRuns, stageRuns } from "../db/schema.js";
+import { pipelineRuns, stageRuns, reviewModelRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { isFeatureLicensed } from "../license.js";
 import { createLogger } from "../logger.js";
@@ -79,10 +79,26 @@ export async function* streamCostCsv(
     .select()
     .from(stageRuns)
     .where(inArray(stageRuns.pipelineRunId, runIds));
+
+  // BEC-134: fetch per-model rows and attach them to their parent stage_run.
+  const stageIds = stages.map((s: any) => s.id);
+  const modelRunRows = stageIds.length > 0
+    ? await db.select().from(reviewModelRuns).where(
+        inArray(reviewModelRuns.stageRunId, stageIds),
+      )
+    : [];
+  const modelRunsByStage = new Map<string, any[]>();
+  for (const mr of modelRunRows) {
+    const arr = modelRunsByStage.get(mr.stageRunId) ?? [];
+    arr.push(mr);
+    modelRunsByStage.set(mr.stageRunId, arr);
+  }
+
   const stagesByRun = new Map<string, any[]>();
   for (const s of stages) {
+    const enriched = { ...s, modelRuns: modelRunsByStage.get(s.id) ?? [] };
     const arr = stagesByRun.get(s.pipelineRunId) ?? [];
-    arr.push(s);
+    arr.push(enriched);
     stagesByRun.set(s.pipelineRunId, arr);
   }
 

--- a/packages/core/src/cost/per-run.ts
+++ b/packages/core/src/cost/per-run.ts
@@ -18,10 +18,22 @@ interface PipelineRunRow {
   runType?: string | null;
 }
 
+/** Per-model token row from review_model_runs. */
+export interface ModelRunRow {
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
 interface StageRunRow {
   stage: string;
   inputTokens: number;
   outputTokens: number;
+  /**
+   * When present (BEC-134), cost is computed per model instead of using the
+   * stage-level token totals against a single configured model.
+   */
+  modelRuns?: ModelRunRow[];
 }
 
 interface CostConfig {
@@ -54,15 +66,27 @@ export function computeRunCost(
   let inputTokens = 0;
   let outputTokens = 0;
   for (const s of stages) {
-    const modelName =
-      pc?.stageModels?.[s.stage] ??
-      pc?.profile?.model ??
-      "claude-sonnet-4-6";
-    const rate = resolveModelRate(modelName, config);
-    dollars += (s.inputTokens * rate.inputPerMillion) / 1_000_000;
-    dollars += (s.outputTokens * rate.outputPerMillion) / 1_000_000;
-    inputTokens += s.inputTokens;
-    outputTokens += s.outputTokens;
+    if (s.modelRuns && s.modelRuns.length > 0) {
+      // BEC-134: per-model pricing using review_model_runs rows.
+      for (const mr of s.modelRuns) {
+        const rate = resolveModelRate(mr.modelId, config);
+        dollars += (mr.inputTokens * rate.inputPerMillion) / 1_000_000;
+        dollars += (mr.outputTokens * rate.outputPerMillion) / 1_000_000;
+        inputTokens += mr.inputTokens;
+        outputTokens += mr.outputTokens;
+      }
+    } else {
+      // Fallback: stage-level tokens against the configured model for this stage.
+      const modelName =
+        pc?.stageModels?.[s.stage] ??
+        pc?.profile?.model ??
+        "claude-sonnet-4-6";
+      const rate = resolveModelRate(modelName, config);
+      dollars += (s.inputTokens * rate.inputPerMillion) / 1_000_000;
+      dollars += (s.outputTokens * rate.outputPerMillion) / 1_000_000;
+      inputTokens += s.inputTokens;
+      outputTokens += s.outputTokens;
+    }
   }
   const timeSavedHours =
     run.status === "completed" && run.runType !== "review-feedback"

--- a/packages/core/src/cost/rollup.ts
+++ b/packages/core/src/cost/rollup.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { and, gte, lt, inArray, max } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
-import { pipelineRuns, stageRuns, costRollupsDaily } from "../db/schema.js";
+import { pipelineRuns, stageRuns, costRollupsDaily, reviewModelRuns } from "../db/schema.js";
 import { computeRunCost } from "./per-run.js";
 import { createLogger } from "../logger.js";
 import { isFeatureLicensed } from "../license.js";
@@ -65,10 +65,25 @@ async function rollOneDay(
     inArray(stageRuns.pipelineRunId, runIds),
   );
 
+  // BEC-134: fetch per-model rows and attach them to their parent stage_run.
+  const stageIds = stages.map((s: any) => s.id);
+  const modelRunRows = stageIds.length > 0
+    ? await db.select().from(reviewModelRuns).where(
+        inArray(reviewModelRuns.stageRunId, stageIds),
+      )
+    : [];
+  const modelRunsByStage = new Map<string, any[]>();
+  for (const mr of modelRunRows) {
+    const arr = modelRunsByStage.get(mr.stageRunId) ?? [];
+    arr.push(mr);
+    modelRunsByStage.set(mr.stageRunId, arr);
+  }
+
   const stagesByRun = new Map<string, any[]>();
   for (const s of stages) {
+    const enriched = { ...s, modelRuns: modelRunsByStage.get(s.id) ?? [] };
     const arr = stagesByRun.get(s.pipelineRunId) ?? [];
-    arr.push(s);
+    arr.push(enriched);
     stagesByRun.set(s.pipelineRunId, arr);
   }
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -229,6 +229,24 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
   );
   CREATE INDEX IF NOT EXISTS idx_cost_rollups_date ON cost_rollups_daily(date);
   CREATE INDEX IF NOT EXISTS idx_cost_rollups_date_pipeline ON cost_rollups_daily(date, pipeline_key);
+
+  CREATE TABLE IF NOT EXISTS review_model_runs (
+    id TEXT PRIMARY KEY,
+    stage_run_id TEXT NOT NULL REFERENCES stage_runs(id),
+    provider_id TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    error_message TEXT,
+    truncated_files INTEGER NOT NULL DEFAULT 0,
+    started_at ${ts},
+    completed_at ${ts}
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_review_model_runs_stage_run_id
+    ON review_model_runs(stage_run_id);
 `;
 }
 

--- a/packages/core/src/db/migrations/postgres/009_review_model_runs.sql
+++ b/packages/core/src/db/migrations/postgres/009_review_model_runs.sql
@@ -1,0 +1,18 @@
+-- BEC-134: per-model results from review-stage fanout.
+CREATE TABLE IF NOT EXISTS review_model_runs (
+  id TEXT PRIMARY KEY,
+  stage_run_id TEXT NOT NULL REFERENCES stage_runs(id),
+  provider_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  truncated_files INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_model_runs_stage_run_id
+  ON review_model_runs(stage_run_id);

--- a/packages/core/src/db/migrations/sqlite/008_review_model_runs.sql
+++ b/packages/core/src/db/migrations/sqlite/008_review_model_runs.sql
@@ -1,0 +1,18 @@
+-- BEC-134: per-model results from review-stage fanout.
+CREATE TABLE IF NOT EXISTS review_model_runs (
+  id TEXT PRIMARY KEY,
+  stage_run_id TEXT NOT NULL REFERENCES stage_runs(id),
+  provider_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  truncated_files INTEGER NOT NULL DEFAULT 0,
+  started_at INTEGER,
+  completed_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_model_runs_stage_run_id
+  ON review_model_runs(stage_run_id);

--- a/packages/core/src/db/review-model-runs.ts
+++ b/packages/core/src/db/review-model-runs.ts
@@ -1,16 +1,13 @@
 import { reviewModelRuns } from "./schema.js";
 import type { ReviewModelRun } from "../executor/review/review-provider.js";
 import { randomUUID } from "node:crypto";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { AnyDb } from "./client.js";
 
-export type Db = BetterSQLite3Database | PostgresJsDatabase;
-
-export function insertReviewModelRuns(
-  db: Db,
+export async function insertReviewModelRuns(
+  db: AnyDb,
   stageRunId: string,
   runs: ReviewModelRun[],
-): void {
+): Promise<void> {
   if (runs.length === 0) return;
   const now = new Date();
   const rows = runs.map((r) => ({
@@ -27,7 +24,7 @@ export function insertReviewModelRuns(
     startedAt: now,
     completedAt: now,
   }));
-  // Drizzle's insert is sync on better-sqlite3, async on postgres-js. Both
-  // accept this shape via type-narrowing: cast through unknown for the call site.
-  (db as unknown as BetterSQLite3Database).insert(reviewModelRuns).values(rows).run();
+  // AnyDb escape-hatch: Drizzle's insert returns a Promise on postgres-js and
+  // a sync builder on better-sqlite3. Awaiting works correctly for both drivers.
+  await (db as any).insert(reviewModelRuns).values(rows);
 }

--- a/packages/core/src/db/review-model-runs.ts
+++ b/packages/core/src/db/review-model-runs.ts
@@ -1,0 +1,33 @@
+import { reviewModelRuns } from "./schema.js";
+import type { ReviewModelRun } from "../executor/review/review-provider.js";
+import { randomUUID } from "node:crypto";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+export type Db = BetterSQLite3Database | PostgresJsDatabase;
+
+export function insertReviewModelRuns(
+  db: Db,
+  stageRunId: string,
+  runs: ReviewModelRun[],
+): void {
+  if (runs.length === 0) return;
+  const now = new Date();
+  const rows = runs.map((r) => ({
+    id: randomUUID(),
+    stageRunId,
+    providerId: r.providerId,
+    modelId: r.modelId,
+    status: r.status,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    durationMs: r.durationMs,
+    errorMessage: r.errorMessage,
+    truncatedFiles: r.truncatedFiles ?? 0,
+    startedAt: now,
+    completedAt: now,
+  }));
+  // Drizzle's insert is sync on better-sqlite3, async on postgres-js. Both
+  // accept this shape via type-narrowing: cast through unknown for the call site.
+  (db as unknown as BetterSQLite3Database).insert(reviewModelRuns).values(rows).run();
+}

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -224,3 +224,21 @@ export const costRollupsDaily = sqliteTable("cost_rollups_daily", {
 }, (t) => [
   unique().on(t.date, t.pipelineKey, t.linearTeamId, t.repoUrl),
 ]);
+
+/** BEC-134: per-model results from review-stage fanout. */
+export const reviewModelRuns = sqliteTable("review_model_runs", {
+  id: text("id").primaryKey(),
+  stageRunId: text("stage_run_id")
+    .notNull()
+    .references(() => stageRuns.id),
+  providerId: text("provider_id").notNull(),
+  modelId: text("model_id").notNull(),
+  status: text("status").notNull(),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  durationMs: integer("duration_ms").notNull().default(0),
+  errorMessage: text("error_message"),
+  truncatedFiles: integer("truncated_files").notNull().default(0),
+  startedAt: crossTimestamp("started_at"),
+  completedAt: crossTimestamp("completed_at"),
+});

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -214,6 +214,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       inputTokens,
       outputTokens,
       turns,
+      stageRunId,
     };
   } catch (error) {
     const errorMessage =
@@ -245,6 +246,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       outputTokens,
       turns,
       errorMessage,
+      stageRunId,
     };
   }
 }

--- a/packages/core/src/executor/review/agentic-deep-review.ts
+++ b/packages/core/src/executor/review/agentic-deep-review.ts
@@ -1,0 +1,39 @@
+import { runDeepReview, deepFindingsToReviewFindings } from "../deep-review.js";
+import type { ReviewProvider, ReviewModelRun, ReviewContext } from "./review-provider.js";
+
+const DEEP_REVIEW_MODEL = "claude-haiku-4-5-20251001";
+
+export class AgenticDeepReviewProvider implements ReviewProvider {
+  readonly id = "agentic" as const;
+
+  async runReview(ctx: ReviewContext): Promise<ReviewModelRun[]> {
+    const startedAt = Date.now();
+    try {
+      const result = await runDeepReview(ctx.handoff, ctx.workdir);
+      return [
+        {
+          modelId: DEEP_REVIEW_MODEL,
+          providerId: "agentic",
+          status: "completed",
+          findings: deepFindingsToReviewFindings(result.findings),
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+          durationMs: Date.now() - startedAt,
+        },
+      ];
+    } catch (err) {
+      return [
+        {
+          modelId: DEEP_REVIEW_MODEL,
+          providerId: "agentic",
+          status: "failed",
+          findings: [],
+          inputTokens: 0,
+          outputTokens: 0,
+          durationMs: Date.now() - startedAt,
+          errorMessage: err instanceof Error ? err.message : String(err),
+        },
+      ];
+    }
+  }
+}

--- a/packages/core/src/executor/review/openrouter-client.ts
+++ b/packages/core/src/executor/review/openrouter-client.ts
@@ -38,7 +38,7 @@ export class OpenRouterClient {
       body: JSON.stringify({
         model: modelId,
         messages,
-        max_tokens: opts.maxTokens,
+        ...(opts.maxTokens !== undefined && { max_tokens: opts.maxTokens }),
       }),
       signal: opts.signal,
     });

--- a/packages/core/src/executor/review/openrouter-client.ts
+++ b/packages/core/src/executor/review/openrouter-client.ts
@@ -1,0 +1,59 @@
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface OpenRouterClientConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+export interface ChatCompletionResult {
+  content: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ChatCompletionOpts {
+  signal: AbortSignal;
+  maxTokens?: number;
+}
+
+export class OpenRouterClient {
+  constructor(private readonly cfg: OpenRouterClientConfig) {}
+
+  async chatCompletion(
+    modelId: string,
+    messages: ChatMessage[],
+    opts: ChatCompletionOpts,
+  ): Promise<ChatCompletionResult> {
+    const res = await fetch(`${this.cfg.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${this.cfg.apiKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://urateams.com",
+        "X-Title": "urateam",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        messages,
+        max_tokens: opts.maxTokens,
+      }),
+      signal: opts.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`openrouter ${res.status} ${body.slice(0, 200)}`);
+    }
+    const json = (await res.json()) as {
+      choices: Array<{ message: { content: string } }>;
+      usage: { prompt_tokens: number; completion_tokens: number };
+    };
+    return {
+      content: json.choices[0]?.message?.content ?? "",
+      inputTokens: json.usage?.prompt_tokens ?? 0,
+      outputTokens: json.usage?.completion_tokens ?? 0,
+    };
+  }
+}

--- a/packages/core/src/executor/review/openrouter-fanout.ts
+++ b/packages/core/src/executor/review/openrouter-fanout.ts
@@ -1,0 +1,101 @@
+import type { ReviewProvider, ReviewModelRun, ReviewContext } from "./review-provider.js";
+import { OpenRouterClient } from "./openrouter-client.js";
+import { buildReviewPrompt, parseReviewFindings } from "./review-prompt.js";
+import { collectWorkdirSnapshot } from "./workdir-snapshot.js";
+import { createLogger } from "../../logger.js";
+
+const log = createLogger({ component: "OpenRouterFanout" });
+
+export interface OpenRouterFanoutConfig {
+  apiKey: string;
+  baseUrl: string;
+  models: string[];
+  timeoutMs: number;
+  maxInputTokens: number;
+}
+
+export class OpenRouterFanoutProvider implements ReviewProvider {
+  readonly id = "openrouter" as const;
+  private readonly client: OpenRouterClient;
+
+  constructor(private readonly cfg: OpenRouterFanoutConfig) {
+    this.client = new OpenRouterClient({ apiKey: cfg.apiKey, baseUrl: cfg.baseUrl });
+  }
+
+  async runReview(ctx: ReviewContext): Promise<ReviewModelRun[]> {
+    const snapshot = await collectWorkdirSnapshot(ctx.workdir, ctx.baseRef);
+    const prompt = buildReviewPrompt({
+      handoff: ctx.handoff,
+      diff: snapshot.diff,
+      files: snapshot.files,
+      maxInputTokens: this.cfg.maxInputTokens,
+    });
+
+    const settled = await Promise.allSettled(
+      this.cfg.models.map((modelId) => this.runOne(modelId, prompt)),
+    );
+
+    return settled.map((res, i) => {
+      const modelId = this.cfg.models[i];
+      if (res.status === "fulfilled") {
+        return { ...res.value, truncatedFiles: prompt.truncatedFiles || undefined };
+      }
+      const err = res.reason as Error;
+      log.warn({ modelId, err: err.message }, "fanout model failed");
+      return {
+        modelId,
+        providerId: "openrouter" as const,
+        status: "failed" as const,
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: 0,
+        errorMessage: err.message,
+        truncatedFiles: prompt.truncatedFiles || undefined,
+      };
+    });
+  }
+
+  private async runOne(
+    modelId: string,
+    prompt: ReturnType<typeof buildReviewPrompt>,
+  ): Promise<ReviewModelRun> {
+    const startedAt = Date.now();
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.cfg.timeoutMs);
+    try {
+      const result = await this.client.chatCompletion(modelId, prompt.messages, {
+        signal: ac.signal,
+      });
+      const findings = parseReviewFindings(result.content);
+      return {
+        modelId,
+        providerId: "openrouter" as const,
+        status: "completed" as const,
+        findings,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        durationMs: Date.now() - startedAt,
+      };
+    } catch (err) {
+      const msg =
+        ac.signal.aborted
+          ? `timed out after ${this.cfg.timeoutMs}ms`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return {
+        modelId,
+        providerId: "openrouter" as const,
+        status: "failed" as const,
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: Date.now() - startedAt,
+        errorMessage: msg,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/core/src/executor/review/openrouter-fanout.ts
+++ b/packages/core/src/executor/review/openrouter-fanout.ts
@@ -51,7 +51,7 @@ export class OpenRouterFanoutProvider implements ReviewProvider {
         outputTokens: 0,
         durationMs: 0,
         errorMessage: err.message,
-        truncatedFiles: prompt.truncatedFiles || undefined,
+        truncatedFiles: prompt.truncatedFiles > 0 ? prompt.truncatedFiles : undefined,
       };
     });
   }

--- a/packages/core/src/executor/review/post-fanout-comments.ts
+++ b/packages/core/src/executor/review/post-fanout-comments.ts
@@ -1,0 +1,54 @@
+import type { Octokit } from "@octokit/rest";
+import { addPRComment } from "../../repo/github.js";
+import type { ReviewModelRun } from "./review-provider.js";
+
+export async function postFanoutCommentsToPR(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  runs: ReviewModelRun[],
+): Promise<void> {
+  for (const run of runs) {
+    await addPRComment(octokit, owner, repo, prNumber, renderRunMarkdown(run));
+  }
+}
+
+function renderRunMarkdown(run: ReviewModelRun): string {
+  const tokens = `${run.inputTokens.toLocaleString()} in / ${run.outputTokens.toLocaleString()} out tokens`;
+  const seconds = (run.durationMs / 1000).toFixed(1);
+  const header = `🔎 Review by \`${run.modelId}\` (via OpenRouter)\n\n`;
+  if (run.status === "failed") {
+    return [
+      header,
+      `Status: failed · ${run.errorMessage ?? "unknown error"} · ${seconds}s\n\n`,
+      "_Advisory only — does not block merge._\n",
+    ].join("");
+  }
+  const table =
+    run.findings.length === 0
+      ? "_No findings._\n"
+      : [
+          "| Severity | File | Line | Category | Description |",
+          "|---|---|---|---|---|",
+          ...run.findings.map(
+            (f) =>
+              `| ${f.severity} | ${escapePipe(f.file)} | ${f.line} | ${escapePipe(f.category)} | ${escapePipe(f.description)} |`,
+          ),
+        ].join("\n");
+  const truncationNote =
+    run.truncatedFiles && run.truncatedFiles > 0
+      ? `\n\n_Note: input truncated; ${run.truncatedFiles} file ${run.truncatedFiles === 1 ? "body" : "bodies"} dropped to fit context window._`
+      : "";
+  return [
+    header,
+    `Status: completed · ${tokens} · ${seconds}s\n\n`,
+    table,
+    truncationNote,
+    "\n\n_Advisory only — does not block merge. See deep-review for blocking findings._\n",
+  ].join("");
+}
+
+function escapePipe(s: string): string {
+  return s.replace(/\|/g, "\\|");
+}

--- a/packages/core/src/executor/review/post-fanout-comments.ts
+++ b/packages/core/src/executor/review/post-fanout-comments.ts
@@ -1,6 +1,9 @@
 import type { Octokit } from "@octokit/rest";
 import { addPRComment } from "../../repo/github.js";
 import type { ReviewModelRun } from "./review-provider.js";
+import { createLogger } from "../../logger.js";
+
+const log = createLogger({ component: "PostFanoutComments" });
 
 export async function postFanoutCommentsToPR(
   octokit: Octokit,
@@ -9,9 +12,20 @@ export async function postFanoutCommentsToPR(
   prNumber: number,
   runs: ReviewModelRun[],
 ): Promise<void> {
-  for (const run of runs) {
-    await addPRComment(octokit, owner, repo, prNumber, renderRunMarkdown(run));
-  }
+  const results = await Promise.allSettled(
+    runs.map((run) =>
+      addPRComment(octokit, owner, repo, prNumber, renderRunMarkdown(run)),
+    ),
+  );
+  results.forEach((res, i) => {
+    if (res.status === "rejected") {
+      const err = res.reason instanceof Error ? res.reason.message : String(res.reason);
+      log.warn(
+        { modelId: runs[i].modelId, err },
+        "failed to post fanout PR comment",
+      );
+    }
+  });
 }
 
 function renderRunMarkdown(run: ReviewModelRun): string {
@@ -33,7 +47,7 @@ function renderRunMarkdown(run: ReviewModelRun): string {
           "|---|---|---|---|---|",
           ...run.findings.map(
             (f) =>
-              `| ${f.severity} | ${escapePipe(f.file)} | ${f.line} | ${escapePipe(f.category)} | ${escapePipe(f.description)} |`,
+              `| ${f.severity} | ${escapeCell(f.file)} | ${f.line} | ${escapeCell(f.category)} | ${escapeCell(f.description)} |`,
           ),
         ].join("\n");
   const truncationNote =
@@ -49,6 +63,6 @@ function renderRunMarkdown(run: ReviewModelRun): string {
   ].join("");
 }
 
-function escapePipe(s: string): string {
-  return s.replace(/\|/g, "\\|");
+function escapeCell(s: string): string {
+  return s.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 }

--- a/packages/core/src/executor/review/review-prompt.ts
+++ b/packages/core/src/executor/review/review-prompt.ts
@@ -59,6 +59,7 @@ export function buildReviewPrompt(input: BuildPromptInput): BuiltPrompt {
     estimateTokens(intentBlock) +
     estimateTokens(diffBlock);
   let remaining = maxInputTokens - fixedTokens;
+  if (remaining < 0) remaining = 0;
   const includedFiles: typeof files = [];
   let truncatedFiles = 0;
   for (const f of files) {
@@ -97,19 +98,20 @@ function extractFirstJsonObject(s: string): string | null {
   let depth = 0;
   let start = -1;
   let inString = false;
-  let escape = false;
   for (let i = 0; i < s.length; i++) {
     const c = s[i];
-    if (escape) {
-      escape = false;
-      continue;
-    }
     if (inString) {
       if (c === "\\") {
-        escape = true;
-      } else if (c === '"') {
-        inString = false;
+        // Handle JSON escapes: skip next char, plus 4 more for \uXXXX
+        const next = s[i + 1];
+        if (next === "u") {
+          i += 5;  // \u + 4 hex digits
+        } else {
+          i += 1;  // any other single-char escape
+        }
+        continue;
       }
+      if (c === '"') inString = false;
       continue;
     }
     if (c === '"') {

--- a/packages/core/src/executor/review/review-prompt.ts
+++ b/packages/core/src/executor/review/review-prompt.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { ReviewFindingSchema, type ReviewFinding, type HandoffArtifact } from "../../types.js";
+import type { ChatMessage } from "./openrouter-client.js";
+
+const SYSTEM_PROMPT = `You are a careful code reviewer. Review the diff and changed files for issues in three dimensions:
+- reuse: duplication of existing code
+- quality: bugs, error-handling, type misuse, edge cases
+- efficiency: needless work, N+1 queries, hot-loop allocations
+
+Output exactly one JSON object and nothing else, matching this shape:
+{ "findings": [
+    { "severity": "blocking" | "warning" | "suggestion",
+      "file": "path/to/file.ext",
+      "line": <integer>,
+      "category": "reuse" | "quality" | "efficiency",
+      "description": "<concise>",
+      "fix": "<concrete suggestion>" }
+  ]
+}
+Return an empty findings array if you find nothing.`;
+
+export interface BuildPromptInput {
+  handoff: HandoffArtifact;
+  diff: string;
+  files: Array<{ path: string; body: string }>;
+  maxInputTokens: number;
+}
+
+export interface BuiltPrompt {
+  messages: ChatMessage[];
+  estimatedInputTokens: number;
+  truncatedFiles: number;
+}
+
+/** Cheap heuristic: ~4 chars/token. Good enough to gate truncation. */
+export function estimateTokens(s: string): number {
+  return Math.ceil(s.length / 4);
+}
+
+export function buildReviewPrompt(input: BuildPromptInput): BuiltPrompt {
+  const { handoff, diff, files, maxInputTokens } = input;
+  const intentBlock = [
+    "## Intent",
+    handoff.context.issueIntent,
+    "",
+    "## Constraints",
+    ...handoff.context.constraints.map((c) => `- ${c}`),
+    "",
+    "## Assumptions",
+    ...handoff.context.assumptions.map((a) => `- ${a}`),
+    "",
+  ].join("\n");
+
+  const diffBlock = ["## Diff", "```diff", diff, "```", ""].join("\n");
+
+  // Token-budget tail-truncate file bodies. Keep diff and intent always.
+  const fixedTokens =
+    estimateTokens(SYSTEM_PROMPT) +
+    estimateTokens(intentBlock) +
+    estimateTokens(diffBlock);
+  let remaining = maxInputTokens - fixedTokens;
+  const includedFiles: typeof files = [];
+  let truncatedFiles = 0;
+  for (const f of files) {
+    const block = `\n## File: ${f.path}\n\`\`\`\n${f.body}\n\`\`\`\n`;
+    const cost = estimateTokens(block);
+    if (cost <= remaining) {
+      includedFiles.push(f);
+      remaining -= cost;
+    } else {
+      truncatedFiles += 1;
+    }
+  }
+
+  const filesBlock = includedFiles
+    .map((f) => `\n## File: ${f.path}\n\`\`\`\n${f.body}\n\`\`\`\n`)
+    .join("");
+
+  const userContent = `${intentBlock}\n${diffBlock}\n${filesBlock}`;
+
+  return {
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userContent },
+    ],
+    estimatedInputTokens: fixedTokens + estimateTokens(filesBlock),
+    truncatedFiles,
+  };
+}
+
+const FindingsEnvelopeSchema = z.object({
+  findings: z.array(ReviewFindingSchema),
+});
+
+/** Extract the first balanced top-level JSON object from a string. */
+function extractFirstJsonObject(s: string): string | null {
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === "\\") {
+        escape = true;
+      } else if (c === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "{") {
+      if (depth === 0) start = i;
+      depth += 1;
+    } else if (c === "}") {
+      depth -= 1;
+      if (depth === 0 && start >= 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+export function parseReviewFindings(raw: string): ReviewFinding[] {
+  const objStr = extractFirstJsonObject(raw);
+  if (!objStr)
+    throw new Error(
+      "model output not parseable as ReviewFinding[]: no JSON object found",
+    );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(objStr);
+  } catch (e) {
+    throw new Error(
+      `model output not parseable as ReviewFinding[]: ${(e as Error).message}`,
+    );
+  }
+  const result = FindingsEnvelopeSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `model output not parseable as ReviewFinding[]: ${result.error.message}`,
+    );
+  }
+  return result.data.findings;
+}

--- a/packages/core/src/executor/review/review-provider.ts
+++ b/packages/core/src/executor/review/review-provider.ts
@@ -1,5 +1,6 @@
 import type { HandoffArtifact, ReviewFinding } from "../../types.js";
 import { AgenticDeepReviewProvider } from "./agentic-deep-review.js";
+import { OpenRouterFanoutProvider } from "./openrouter-fanout.js";
 
 export type ReviewProviderId = "agentic" | "openrouter";
 
@@ -29,6 +30,45 @@ export interface ReviewProvider {
   runReview(ctx: ReviewContext): Promise<ReviewModelRun[]>;
 }
 
-export function getEnabledProviders(_env: NodeJS.ProcessEnv): ReviewProvider[] {
-  return [new AgenticDeepReviewProvider()];
+const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_TIMEOUT_MS = 300_000;
+const DEFAULT_MAX_INPUT_TOKENS = 150_000;
+
+export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[] {
+  const providers: ReviewProvider[] = [new AgenticDeepReviewProvider()];
+
+  const rawModels = env.REVIEW_MODELS ?? "";
+  const models = rawModels.split(",").map((s) => s.trim()).filter(Boolean);
+  const apiKey = env.OPENROUTER_API_KEY ?? "";
+  const fanoutDesired = models.length > 0;
+  const keyPresent = apiKey.length > 0;
+
+  if (fanoutDesired && !keyPresent) {
+    throw new Error(
+      "REVIEW_MODELS is set but OPENROUTER_API_KEY is missing — both must be set or both unset.",
+    );
+  }
+  if (keyPresent && !fanoutDesired) {
+    throw new Error(
+      "OPENROUTER_API_KEY is set but REVIEW_MODELS is missing or empty — both must be set or both unset.",
+    );
+  }
+  if (!fanoutDesired) return providers;
+
+  providers.push(
+    new OpenRouterFanoutProvider({
+      apiKey,
+      baseUrl: env.OPENROUTER_BASE_URL ?? DEFAULT_BASE_URL,
+      models,
+      timeoutMs: parseIntOr(env.REVIEW_MODELS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+      maxInputTokens: parseIntOr(env.REVIEW_MODELS_MAX_INPUT_TOKENS, DEFAULT_MAX_INPUT_TOKENS),
+    }),
+  );
+  return providers;
+}
+
+function parseIntOr(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
 }

--- a/packages/core/src/executor/review/review-provider.ts
+++ b/packages/core/src/executor/review/review-provider.ts
@@ -1,0 +1,44 @@
+import type { HandoffArtifact, ReviewFinding } from "../../types.js";
+
+export type ReviewProviderId = "agentic" | "openrouter";
+
+export interface ReviewContext {
+  runId: string;
+  stageRunId: string;
+  workdir: string;
+  handoff: HandoffArtifact;
+  baseRef: string;
+  prNumber: number | null;
+}
+
+export interface ReviewModelRun {
+  modelId: string;
+  providerId: ReviewProviderId;
+  status: "completed" | "failed";
+  findings: ReviewFinding[];
+  inputTokens: number;
+  outputTokens: number;
+  durationMs: number;
+  errorMessage?: string;
+  truncatedFiles?: number;
+}
+
+export interface ReviewProvider {
+  readonly id: ReviewProviderId;
+  runReview(ctx: ReviewContext): Promise<ReviewModelRun[]>;
+}
+
+// Stub registry — Task 7 fills in real selection logic.
+// For now, returns only a placeholder that satisfies the interface, so callers
+// in later tasks can typecheck. AgenticDeepReviewProvider arrives in Task 2;
+// we wire it in here at that point.
+const placeholderAgentic: ReviewProvider = {
+  id: "agentic",
+  async runReview(_ctx) {
+    return [];
+  },
+};
+
+export function getEnabledProviders(_env: NodeJS.ProcessEnv): ReviewProvider[] {
+  return [placeholderAgentic];
+}

--- a/packages/core/src/executor/review/review-provider.ts
+++ b/packages/core/src/executor/review/review-provider.ts
@@ -1,4 +1,5 @@
 import type { HandoffArtifact, ReviewFinding } from "../../types.js";
+import { AgenticDeepReviewProvider } from "./agentic-deep-review.js";
 
 export type ReviewProviderId = "agentic" | "openrouter";
 
@@ -28,17 +29,6 @@ export interface ReviewProvider {
   runReview(ctx: ReviewContext): Promise<ReviewModelRun[]>;
 }
 
-// Stub registry — Task 7 fills in real selection logic.
-// For now, returns only a placeholder that satisfies the interface, so callers
-// in later tasks can typecheck. AgenticDeepReviewProvider arrives in Task 2;
-// we wire it in here at that point.
-const placeholderAgentic: ReviewProvider = {
-  id: "agentic",
-  async runReview(_ctx) {
-    return [];
-  },
-};
-
 export function getEnabledProviders(_env: NodeJS.ProcessEnv): ReviewProvider[] {
-  return [placeholderAgentic];
+  return [new AgenticDeepReviewProvider()];
 }

--- a/packages/core/src/executor/review/workdir-snapshot.ts
+++ b/packages/core/src/executor/review/workdir-snapshot.ts
@@ -1,0 +1,34 @@
+import { gitExecSafe } from "../../repo/git.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface WorkdirSnapshot {
+  diff: string;
+  files: Array<{ path: string; body: string }>;
+}
+
+/**
+ * Collect the diff against baseRef and the body of every changed file.
+ * Used as input to the single-shot review prompt.
+ */
+export async function collectWorkdirSnapshot(
+  workdir: string,
+  baseRef: string,
+): Promise<WorkdirSnapshot> {
+  const diff = await gitExecSafe(["diff", `${baseRef}...HEAD`], workdir);
+  const namesOut = await gitExecSafe(
+    ["diff", "--name-only", `${baseRef}...HEAD`],
+    workdir,
+  );
+  const paths = namesOut.split("\n").map((s) => s.trim()).filter(Boolean);
+  const files: Array<{ path: string; body: string }> = [];
+  for (const p of paths) {
+    try {
+      const body = await readFile(join(workdir, p), "utf8");
+      files.push({ path: p, body });
+    } catch {
+      // file deleted in HEAD — skip
+    }
+  }
+  return { diff, files };
+}

--- a/packages/core/src/pipeline/review-providers-runner.ts
+++ b/packages/core/src/pipeline/review-providers-runner.ts
@@ -1,0 +1,108 @@
+import type { Octokit } from "@octokit/rest";
+import {
+  getEnabledProviders,
+  type ReviewContext,
+  type ReviewModelRun,
+} from "../executor/review/review-provider.js";
+import { insertReviewModelRuns } from "../db/review-model-runs.js";
+import type { AnyDb } from "../db/client.js";
+import { postFanoutCommentsToPR } from "../executor/review/post-fanout-comments.js";
+import type { ReviewFinding } from "../types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "ReviewProvidersRunner" });
+
+export interface RunReviewProvidersOpts {
+  env: NodeJS.ProcessEnv;
+  db: AnyDb;
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+}
+
+export interface RunReviewProvidersResult {
+  agenticFindings: ReviewFinding[];
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  allRuns: ReviewModelRun[];
+}
+
+/**
+ * Runs all enabled review providers in sequence, persists their per-model
+ * results to `review_model_runs`, and (when a PR exists) posts a fanout
+ * advisory comment per non-agentic run.
+ *
+ * Provider failures are caught and recorded as advisory `failed` runs rather
+ * than rethrown, so a flaky third-party model can never fail the pipeline.
+ *
+ * Persistence and comment-posting are skipped when `ctx.stageRunId === ""`
+ * (the runner does not always have a stage_run row to associate the rows
+ * with — see runner.ts comment near the deep-review loop).
+ */
+export async function runReviewProviders(
+  ctx: ReviewContext,
+  opts: RunReviewProvidersOpts,
+): Promise<RunReviewProvidersResult> {
+  const providers = getEnabledProviders(opts.env);
+  const allRuns: ReviewModelRun[] = [];
+
+  for (const p of providers) {
+    try {
+      const runs = await p.runReview(ctx);
+      allRuns.push(...runs);
+    } catch (err) {
+      log.warn(
+        { providerId: p.id, err: err instanceof Error ? err.message : String(err) },
+        "review provider threw — recording as advisory failure",
+      );
+      allRuns.push({
+        modelId: p.id,
+        providerId: p.id,
+        status: "failed",
+        findings: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        durationMs: 0,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (ctx.stageRunId) {
+    try {
+      await insertReviewModelRuns(opts.db, ctx.stageRunId, allRuns);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "insertReviewModelRuns failed — continuing",
+      );
+    }
+  } else {
+    log.warn(
+      "runReviewProviders called without stageRunId; skipping per-model persistence",
+    );
+  }
+
+  const fanoutRuns = allRuns.filter((r) => r.providerId !== "agentic");
+  if (ctx.prNumber !== null && fanoutRuns.length > 0) {
+    try {
+      await postFanoutCommentsToPR(opts.octokit, opts.owner, opts.repo, ctx.prNumber, fanoutRuns);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "post-fanout-comments failed — continuing",
+      );
+    }
+  }
+
+  const agenticFindings = allRuns
+    .filter((r) => r.providerId === "agentic")
+    .flatMap((r) => r.findings);
+
+  return {
+    agenticFindings,
+    totalInputTokens: allRuns.reduce((s, r) => s + r.inputTokens, 0),
+    totalOutputTokens: allRuns.reduce((s, r) => s + r.outputTokens, 0),
+    allRuns,
+  };
+}

--- a/packages/core/src/pipeline/review-providers-runner.ts
+++ b/packages/core/src/pipeline/review-providers-runner.ts
@@ -1,4 +1,3 @@
-import type { Octokit } from "@octokit/rest";
 import {
   getEnabledProviders,
   type ReviewContext,
@@ -14,11 +13,6 @@ const log = createLogger({ component: "ReviewProvidersRunner" });
 export interface RunReviewProvidersOpts {
   env: NodeJS.ProcessEnv;
   db: AnyDb;
-  /** Reserved for future use — the runner posts fanout PR comments itself
-   *  after PR creation (BEC-134), so the helper no longer needs Octokit. */
-  octokit: Octokit;
-  owner: string;
-  repo: string;
 }
 
 export interface RunReviewProvidersResult {

--- a/packages/core/src/pipeline/review-providers-runner.ts
+++ b/packages/core/src/pipeline/review-providers-runner.ts
@@ -6,7 +6,6 @@ import {
 } from "../executor/review/review-provider.js";
 import { insertReviewModelRuns } from "../db/review-model-runs.js";
 import type { AnyDb } from "../db/client.js";
-import { postFanoutCommentsToPR } from "../executor/review/post-fanout-comments.js";
 import type { ReviewFinding } from "../types.js";
 import { createLogger } from "../logger.js";
 
@@ -15,6 +14,8 @@ const log = createLogger({ component: "ReviewProvidersRunner" });
 export interface RunReviewProvidersOpts {
   env: NodeJS.ProcessEnv;
   db: AnyDb;
+  /** Reserved for future use — the runner posts fanout PR comments itself
+   *  after PR creation (BEC-134), so the helper no longer needs Octokit. */
   octokit: Octokit;
   owner: string;
   repo: string;
@@ -28,16 +29,20 @@ export interface RunReviewProvidersResult {
 }
 
 /**
- * Runs all enabled review providers in sequence, persists their per-model
- * results to `review_model_runs`, and (when a PR exists) posts a fanout
- * advisory comment per non-agentic run.
+ * Runs all enabled review providers in sequence and persists their per-model
+ * results to `review_model_runs` when a stage_run row id is provided.
  *
  * Provider failures are caught and recorded as advisory `failed` runs rather
  * than rethrown, so a flaky third-party model can never fail the pipeline.
  *
- * Persistence and comment-posting are skipped when `ctx.stageRunId === ""`
- * (the runner does not always have a stage_run row to associate the rows
- * with — see runner.ts comment near the deep-review loop).
+ * Persistence is skipped when `ctx.stageRunId === ""` (callers without an
+ * associated stage_runs row).
+ *
+ * BEC-134: this helper no longer posts fanout PR comments. The runner posts
+ * them itself AFTER PR creation, since the PR doesn't exist yet at the point
+ * fanout runs (deep-review block, before the push/PR phase). Callers receive
+ * `allRuns` and can pass non-agentic runs to `postFanoutCommentsToPR` once
+ * `prNumber` is known.
  */
 export async function runReviewProviders(
   ctx: ReviewContext,
@@ -81,18 +86,6 @@ export async function runReviewProviders(
     log.warn(
       "runReviewProviders called without stageRunId; skipping per-model persistence",
     );
-  }
-
-  const fanoutRuns = allRuns.filter((r) => r.providerId !== "agentic");
-  if (ctx.prNumber !== null && fanoutRuns.length > 0) {
-    try {
-      await postFanoutCommentsToPR(opts.octokit, opts.owner, opts.repo, ctx.prNumber, fanoutRuns);
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "post-fanout-comments failed — continuing",
-      );
-    }
   }
 
   const agenticFindings = allRuns

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -856,7 +856,7 @@ export class PipelineRunner {
 
         // BEC-134: track the most recent review stage_run id so fanout
         // persistence can reuse it.
-        if (stageType === "review" && result.stageRunId) {
+        if (stageType === "review") {
           lastReviewStageRunId = result.stageRunId;
         }
 
@@ -1268,7 +1268,7 @@ export class PipelineRunner {
             });
 
             // BEC-134: track latest review stage_run id for fanout persistence.
-            if (fixStage === "review" && fixResult.stageRunId) {
+            if (fixStage === "review") {
               lastReviewStageRunId = fixResult.stageRunId;
             }
 
@@ -1417,22 +1417,6 @@ export class PipelineRunner {
 
           runLog.info({ drPass, passLimit }, "deep review: running review providers");
 
-          // Resolve owner/repo for fanout PR comment posting. The PR is created
-          // *after* this loop, so prNumber is null here — fanout comments will
-          // not be posted on the deep-review pass; only persistence occurs.
-          let ownerForReview = "";
-          let repoForReview = "";
-          try {
-            const parsed = parseRepoUrl(repoConfig.url);
-            ownerForReview = parsed.owner;
-            repoForReview = parsed.repo;
-          } catch {
-            // non-GitHub URL — fanout still runs, just no comment posting.
-          }
-          const octokitForReview = this.githubConfig
-            ? await createGitHubClient(this.githubConfig)
-            : ({} as unknown as Awaited<ReturnType<typeof createGitHubClient>>);
-
           // Gate fanout to drPass===1 by passing an empty env on subsequent
           // passes — getEnabledProviders then returns only the agentic provider.
           // BEC-134: associate review_model_runs rows with the most recent
@@ -1450,9 +1434,6 @@ export class PipelineRunner {
           const reviewResult = await runReviewProviders(reviewCtx, {
             env: drPass === 1 ? process.env : ({} as NodeJS.ProcessEnv),
             db: this.db as AnyDb,
-            octokit: octokitForReview,
-            owner: ownerForReview,
-            repo: repoForReview,
           });
 
           // BEC-134: capture fanout (non-agentic) runs from the first deep-review
@@ -1576,9 +1557,7 @@ export class PipelineRunner {
 
           // BEC-134: refresh latest review stage_run id for any subsequent
           // fanout persistence inside this loop.
-          if (drReviewResult.stageRunId) {
-            lastReviewStageRunId = drReviewResult.stageRunId;
-          }
+          lastReviewStageRunId = drReviewResult.stageRunId;
 
           run.totalInputTokens += drReviewResult.inputTokens;
           run.totalOutputTokens += drReviewResult.outputTokens;

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -19,6 +19,8 @@ import { checkRequirements, buildRalphContext } from "../executor/ralph.js";
 import { checkTestQuality } from "../executor/test-quality.js";
 import { buildDeepReviewContext } from "../executor/deep-review.js";
 import { runReviewProviders } from "./review-providers-runner.js";
+import { postFanoutCommentsToPR } from "../executor/review/post-fanout-comments.js";
+import type { ReviewModelRun } from "../executor/review/review-provider.js";
 import { extractHandoff } from "../executor/extract-handoff.js";
 import { DEFAULT_AGENT_CLAUDE_MD } from "../executor/agent-config.js";
 import { generatePRDescription } from "./pr-description.js";
@@ -752,6 +754,17 @@ export class PipelineRunner {
       // Track cumulative files modified across all stages for coordination
       let allModifiedFiles: string[] = [];
 
+      // Track the most recent review stage_run id so the deep-review fanout
+      // can persist its `review_model_runs` rows against the right stage row.
+      // Updated after every executeStage("review", ...) call across the main
+      // stage loop, the review-fix loop, and the deep-review loop.
+      let lastReviewStageRunId = "";
+
+      // Fanout runs captured from the deep-review block (BEC-134). The PR
+      // doesn't exist yet when fanout runs, so we hold the runs in-memory
+      // and post one labeled comment per non-agentic run AFTER PR creation.
+      let pendingFanoutRuns: ReviewModelRun[] = [];
+
       // Track RALPH satisfaction state across the pipeline for draft PR decision
       let ralphSatisfied = true;
       let ralphGaps: string[] = [];
@@ -840,6 +853,12 @@ export class PipelineRunner {
           devcontainerSession,
           stageModels: config.stageModels,
         });
+
+        // BEC-134: track the most recent review stage_run id so fanout
+        // persistence can reuse it.
+        if (stageType === "review" && result.stageRunId) {
+          lastReviewStageRunId = result.stageRunId;
+        }
 
         // RALPH loop for implement stage — iteratively harden against requirements.
         // Tokens are tracked via a flag to prevent double-counting at the outer
@@ -1248,6 +1267,11 @@ export class PipelineRunner {
               stageModels: config.stageModels,
             });
 
+            // BEC-134: track latest review stage_run id for fanout persistence.
+            if (fixStage === "review" && fixResult.stageRunId) {
+              lastReviewStageRunId = fixResult.stageRunId;
+            }
+
             run.totalInputTokens += fixResult.inputTokens;
             run.totalOutputTokens += fixResult.outputTokens;
 
@@ -1411,11 +1435,13 @@ export class PipelineRunner {
 
           // Gate fanout to drPass===1 by passing an empty env on subsequent
           // passes — getEnabledProviders then returns only the agentic provider.
+          // BEC-134: associate review_model_runs rows with the most recent
+          // review stage_run row (from the main stage loop or review-fix loop).
+          // PR doesn't exist yet here, so prNumber stays null; the runner posts
+          // fanout PR comments after PR creation using `pendingFanoutRuns`.
           const reviewCtx = {
             runId,
-            // No stage_run row exists for this deep-review iteration yet —
-            // runReviewProviders skips persistence when stageRunId is empty.
-            stageRunId: "",
+            stageRunId: lastReviewStageRunId,
             workdir: worktreePath,
             handoff,
             baseRef: repoConfig.defaultBranch ?? "main",
@@ -1428,6 +1454,15 @@ export class PipelineRunner {
             owner: ownerForReview,
             repo: repoForReview,
           });
+
+          // BEC-134: capture fanout (non-agentic) runs from the first deep-review
+          // pass for posting to the PR after creation. Subsequent passes have an
+          // empty env (agentic-only), so no fanout runs to capture there.
+          if (drPass === 1) {
+            pendingFanoutRuns = reviewResult.allRuns.filter(
+              (r) => r.providerId !== "agentic",
+            );
+          }
 
           const deepResult = {
             findings: reviewResult.agenticFindings,
@@ -1538,6 +1573,12 @@ export class PipelineRunner {
             devcontainerSession,
             stageModels: config.stageModels,
           });
+
+          // BEC-134: refresh latest review stage_run id for any subsequent
+          // fanout persistence inside this loop.
+          if (drReviewResult.stageRunId) {
+            lastReviewStageRunId = drReviewResult.stageRunId;
+          }
 
           run.totalInputTokens += drReviewResult.inputTokens;
           run.totalOutputTokens += drReviewResult.outputTokens;
@@ -1885,6 +1926,45 @@ export class PipelineRunner {
               teams: reviewerRequest.teams,
             }),
           );
+        }
+
+        // BEC-134: Post fanout (per-model) review comments on the PR. Best-effort —
+        // failures never block the pipeline. Requires the GitHub App for Octokit
+        // access; the gh-CLI/GitLab paths skip this (parity gap accepted for v1).
+        if (
+          prUrl &&
+          pendingFanoutRuns.length > 0 &&
+          !isGitLab &&
+          this.githubConfig
+        ) {
+          const fanoutPrNumberMatch = prUrl.match(/\/pull\/(\d+)/);
+          const fanoutPrNumber = fanoutPrNumberMatch
+            ? parseInt(fanoutPrNumberMatch[1]!, 10)
+            : null;
+          if (fanoutPrNumber !== null) {
+            try {
+              const { owner: fanoutOwner, repo: fanoutRepo } = parseRepoUrl(
+                repoConfig.url,
+              );
+              const fanoutOctokit = await createGitHubClient(this.githubConfig);
+              await postFanoutCommentsToPR(
+                fanoutOctokit,
+                fanoutOwner,
+                fanoutRepo,
+                fanoutPrNumber,
+                pendingFanoutRuns,
+              );
+              runLog.info(
+                { prNumber: fanoutPrNumber, count: pendingFanoutRuns.length },
+                "fanout: posted per-model PR comments",
+              );
+            } catch (err) {
+              runLog.warn(
+                { err: err instanceof Error ? err.message : String(err) },
+                "fanout: post-fanout-comments failed — continuing",
+              );
+            }
+          }
         }
 
         // 4. Flag for human review when conflicts could not be auto-resolved

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -17,11 +17,8 @@ import { validateHandoff } from "../executor/validate.js";
 import { isFeatureLicensed } from "../license.js";
 import { checkRequirements, buildRalphContext } from "../executor/ralph.js";
 import { checkTestQuality } from "../executor/test-quality.js";
-import {
-  runDeepReview,
-  buildDeepReviewContext,
-  deepFindingsToReviewFindings,
-} from "../executor/deep-review.js";
+import { buildDeepReviewContext } from "../executor/deep-review.js";
+import { runReviewProviders } from "./review-providers-runner.js";
 import { extractHandoff } from "../executor/extract-handoff.js";
 import { DEFAULT_AGENT_CLAUDE_MD } from "../executor/agent-config.js";
 import { generatePRDescription } from "./pr-description.js";
@@ -1394,8 +1391,49 @@ export class PipelineRunner {
             break;
           }
 
-          runLog.info({ drPass, passLimit }, "deep review: running parallel sub-agents");
-          const deepResult = await runDeepReview(handoff, worktreePath);
+          runLog.info({ drPass, passLimit }, "deep review: running review providers");
+
+          // Resolve owner/repo for fanout PR comment posting. The PR is created
+          // *after* this loop, so prNumber is null here — fanout comments will
+          // not be posted on the deep-review pass; only persistence occurs.
+          let ownerForReview = "";
+          let repoForReview = "";
+          try {
+            const parsed = parseRepoUrl(repoConfig.url);
+            ownerForReview = parsed.owner;
+            repoForReview = parsed.repo;
+          } catch {
+            // non-GitHub URL — fanout still runs, just no comment posting.
+          }
+          const octokitForReview = this.githubConfig
+            ? await createGitHubClient(this.githubConfig)
+            : ({} as unknown as Awaited<ReturnType<typeof createGitHubClient>>);
+
+          // Gate fanout to drPass===1 by passing an empty env on subsequent
+          // passes — getEnabledProviders then returns only the agentic provider.
+          const reviewCtx = {
+            runId,
+            // No stage_run row exists for this deep-review iteration yet —
+            // runReviewProviders skips persistence when stageRunId is empty.
+            stageRunId: "",
+            workdir: worktreePath,
+            handoff,
+            baseRef: repoConfig.defaultBranch ?? "main",
+            prNumber: null,
+          };
+          const reviewResult = await runReviewProviders(reviewCtx, {
+            env: drPass === 1 ? process.env : ({} as NodeJS.ProcessEnv),
+            db: this.db as AnyDb,
+            octokit: octokitForReview,
+            owner: ownerForReview,
+            repo: repoForReview,
+          });
+
+          const deepResult = {
+            findings: reviewResult.agenticFindings,
+            inputTokens: reviewResult.totalInputTokens,
+            outputTokens: reviewResult.totalOutputTokens,
+          };
 
           run.totalInputTokens += deepResult.inputTokens;
           run.totalOutputTokens += deepResult.outputTokens;
@@ -1422,8 +1460,26 @@ export class PipelineRunner {
           }
           previousFindingsCount = findingsCount;
 
-          // Re-run implement stage with deep review context
-          const deepReviewContext = buildDeepReviewContext(drPass, deepResult.findings, handoff);
+          // Re-run implement stage with deep review context. The agentic
+          // review provider already converts DeepReviewFinding -> ReviewFinding
+          // and encodes the source agent as `category = "<agent>:<category>"`;
+          // recover it here so the context prompt groups findings correctly.
+          const deepFindingsForContext = deepResult.findings.map((f) => {
+            const colon = f.category.indexOf(":");
+            const prefix = colon > 0 ? f.category.slice(0, colon) : "quality";
+            const agent: "reuse" | "quality" | "efficiency" =
+              prefix === "reuse" || prefix === "efficiency" ? prefix : "quality";
+            return {
+              agent,
+              severity: f.severity,
+              file: f.file,
+              line: f.line,
+              category: colon > 0 ? f.category.slice(colon + 1) : f.category,
+              description: f.description,
+              fix: f.fix,
+            };
+          });
+          const deepReviewContext = buildDeepReviewContext(drPass, deepFindingsForContext, handoff);
           runLog.info({ drPass }, "deep review: re-running implement stage");
 
           const drImplementResult = await executeStage({
@@ -1512,13 +1568,14 @@ export class PipelineRunner {
           // Merge deep review findings into handoff context so downstream logic
           // (e.g. auto-merge gate) can see them as standard ReviewFindings.
           if (handoff && deepResult.findings.length > 0) {
-            const asReviewFindings = deepFindingsToReviewFindings(deepResult.findings);
+            // deepResult.findings is already ReviewFinding[] (the agentic
+            // provider wrapper performs the conversion before returning).
             const existingFindings = handoff.context.reviewFindings ?? [];
             handoff = {
               ...handoff,
               context: {
                 ...handoff.context,
-                reviewFindings: [...existingFindings, ...asReviewFindings],
+                reviewFindings: [...existingFindings, ...deepResult.findings],
               },
             };
           }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -319,7 +319,7 @@ export interface StageResult {
   /** ID of the `stage_runs` row created for this execution. Used by callers that
    *  need to associate per-stage artifacts (e.g. `review_model_runs`) with the
    *  same row the executor inserted. Always populated by `executeStage`. */
-  stageRunId?: string;
+  stageRunId: string;
 }
 
 // --- Pipeline Run ---

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -316,6 +316,10 @@ export interface StageResult {
   outputTokens: number;
   turns: number;
   errorMessage?: string;
+  /** ID of the `stage_runs` row created for this execution. Used by callers that
+   *  need to associate per-stage artifacts (e.g. `review_model_runs`) with the
+   *  same row the executor inserted. Always populated by `executeStage`. */
+  stageRunId?: string;
 }
 
 // --- Pipeline Run ---

--- a/packages/create-urateam/src/index.ts
+++ b/packages/create-urateam/src/index.ts
@@ -89,6 +89,10 @@ export interface ScaffoldOptions {
    * blank in .env so the operator can fill them in by hand.
    */
   autoGenSecrets?: boolean;
+  /** OpenRouter API key for multi-model review fanout (BEC-134). */
+  openrouterApiKey?: string;
+  /** Ordered list of model slugs for the review fanout (BEC-134). Written as REVIEW_MODELS=<csv>. */
+  reviewModels?: string[];
 }
 
 export interface LicenseInfo {
@@ -231,6 +235,8 @@ function buildEnv(
     slackWebhookUrl: string;
     discordWebhookUrl: string;
     agentProfiles: ScaffoldOptions["agentProfiles"];
+    openrouterApiKey: string;
+    reviewModels: string[];
   },
 ): string {
   const lines: string[] = [];
@@ -405,6 +411,13 @@ function buildEnv(
     push('# URATEAM_AGENT_PROFILES={"test":{"maxTurns":50,"maxInputTokens":80000}}');
   }
   blank();
+
+  if (options.openrouterApiKey && options.reviewModels && options.reviewModels.length > 0) {
+    push("");
+    push("# OpenRouter multi-model review fanout (BEC-134)");
+    push(`OPENROUTER_API_KEY=${options.openrouterApiKey}`);
+    push(`REVIEW_MODELS=${options.reviewModels.join(",")}`);
+  }
 
   push("# === Optional ===");
   push("# LOG_LEVEL=info");
@@ -594,6 +607,8 @@ export function scaffold(options: ScaffoldOptions): ScaffoldResult {
       slackWebhookUrl: options.slackWebhookUrl ?? "",
       discordWebhookUrl: options.discordWebhookUrl ?? "",
       agentProfiles: options.agentProfiles,
+      openrouterApiKey: options.openrouterApiKey ?? "",
+      reviewModels: options.reviewModels ?? [],
     });
     writeFileSync(envPath, envContent);
   }

--- a/packages/create-urateam/template/.urateam/.env.example
+++ b/packages/create-urateam/template/.urateam/.env.example
@@ -115,3 +115,14 @@ DASHBOARD_PASSWORD=
 
 # Logging
 # LOG_LEVEL=info
+
+# OpenRouter multi-model review fanout (BEC-134, OSS, optional)
+# When both vars are set, each comma-separated model produces a single-shot
+# advisory review in addition to the default Claude Agent SDK deep-review.
+# Findings post as labeled PR comments; they do NOT block auto-merge.
+# OPENROUTER_API_KEY=sk-or-...
+# REVIEW_MODELS=anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-2.5-pro
+# Optional knobs (defaults shown):
+# REVIEW_MODELS_TIMEOUT_MS=300000
+# REVIEW_MODELS_MAX_INPUT_TOKENS=150000
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1


### PR DESCRIPTION
## Summary

Adds OpenRouter-based multi-model fanout to the review stage. Each comma-separated model in `REVIEW_MODELS` gets a single-shot chat-completion review; findings post as labeled PR comments alongside (and advisory to) the existing 3-sub-agent agentic deep-review which remains the merge gate.

Closes [BEC-134](https://linear.app/beckerspace/issue/BEC-134).

## Architecture

`ReviewProvider` interface + registry pattern. Two implementations:
- `AgenticDeepReviewProvider` — thin wrapper around the existing `runDeepReview()` (no behavior change when `REVIEW_MODELS` is unset).
- `OpenRouterFanoutProvider` — N parallel single-shot reviews via `Promise.allSettled`, per-model AbortController timeouts, best-effort partial failure.

Direct-key providers (Anthropic / OpenAI without OpenRouter) plug in post-v1 by registering a new implementation — no review-stage caller change required.

## Behavior

| Env vars | Result |
|---|---|
| Neither set | Existing agentic deep-review unchanged. Zero regression for current users. |
| Both set | Agentic deep-review runs PLUS N OpenRouter calls. Per-model findings post as separate labeled PR comments after PR creation. |
| Only one set | Runner throws explicit error at startup. |

Fanout findings are **advisory only** in v1 — they do NOT contribute to the merge-blocking set. Consensus-vote synthesis is deferred to v2 per BEC-134's locked-in scope.

## Configuration

```bash
OPENROUTER_API_KEY=sk-or-...
REVIEW_MODELS=anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-2.5-pro
# Optional knobs (defaults shown):
# REVIEW_MODELS_TIMEOUT_MS=300000
# REVIEW_MODELS_MAX_INPUT_TOKENS=150000
# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
```

OSS tier — no license gate.

## Schema

New `review_model_runs` table (sqlite migration `008` + postgres migration `009`) stores per-model runs (provider, model, status, tokens, duration, errors, truncated-files count). Cost rollup updated to JOIN against this table for accurate per-model pricing; falls back to stage-level rollup when no rows exist.

## Files

- Spec: `docs/superpowers/specs/2026-04-30-bec-134-openrouter-fanout-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-bec-134-openrouter-fanout.md`
- 38 files, +4664/-31 lines, 25 commits

## Test plan

- [x] Unit suites: `review-provider-registry`, `agentic-deep-review-provider`, `db-review-model-runs`, `openrouter-client`, `review-prompt`, `openrouter-fanout`, `post-fanout-comments`, `runner-fanout-integration`, `cost/per-run-multi-model`
- [x] E2E: `e2e-fanout.test.ts` confirms both providers run, persist to `review_model_runs`, and only agentic findings flow into `reviewFindings`
- [x] Full repo test matrix (`pnpm -r test`): 1273 tests pass, 0 failed, 11 skipped (expected)
- [x] Full repo build (`pnpm -r build`): clean
- [ ] Sonnet review feedback addressed
- [ ] @urateam/core, cli, dashboard cascade-bumped to next sequential version once merged

## Known follow-ups (filed as separate work)

1. **drPass 2+ persists agentic findings under stage-prior stageRunId** (Minor): `lastReviewStageRunId` is from the upstream main/review-fix loop, not from the in-progress drReviewResult. Affects `review_model_runs` association on retry passes only; advisory data, low impact. Tracking gate: file as a follow-up if cost-rollup accuracy on retry passes becomes a concern.
2. **gh-CLI / GitLab paths skip fanout PR comments**: only the GitHub App path posts. Acceptable for v1 since urateam mostly targets GitHub App; add a `gh pr comment` fallback if user demand surfaces.
3. **Findings not persisted in `review_model_runs`**: held in-memory in the runner from deep-review block until PR creation, then posted. Adequate for v1 (advisory only). If we ever want to re-display fanout findings in a dashboard, add a `findings_json` TEXT column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)