### PR TITLE
chore(release): v0.1.31 — bump 0.1.16→0.1.17 + BEC-135 v2 follow-ups

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -49,11 +49,24 @@ describe("audit_events immutability", () => {
     ).toEqual([]);
   });
 
-  it("logAuditEventUnchecked is only called from license.ts", () => {
+  it("logAuditEventUnchecked is only called from license.ts or Pro-tier feature modules", () => {
     const repoRoot = path.resolve(__dirname, "../../../..");
+    // logAuditEventUnchecked is allowed in:
+    //   1. The writer itself (definition)
+    //   2. license.ts (license-validation failure path)
+    //   3. Pro-tier feature modules (PM agent, Release Manager) — their audit events
+    //      must appear in the audit table whenever the Pro feature is licensed,
+    //      independent of the Enterprise audit-log dashboard being unlocked.
+    //   4. This test file
     const allowed = [
       "packages/core/src/audit/writer.ts",
       "packages/core/src/license.ts",
+      "packages/core/src/pm/scheduler.ts",
+      "packages/core/src/pm/actions/triage.ts",
+      "packages/core/src/pm/actions/promote.ts",
+      "packages/core/src/pm/actions/resolve-approvals.ts",
+      "packages/core/src/release-manager/scheduler.ts",
+      "packages/core/src/release-manager/slack-handler.ts",
       "packages/core/src/__tests__/audit-immutability.test.ts",
     ];
 

--- a/packages/core/src/audit/writer.ts
+++ b/packages/core/src/audit/writer.ts
@@ -32,9 +32,15 @@ async function insertAuditEvent(db: AnyDb, event: AuditEvent): Promise<void> {
  * Fire-and-forget insert of an audit event. Write failures are logged but
  * never propagated — audit writes must not crash the caller.
  *
- * Gated on the `audit-log` enterprise feature (spec §8): when unlicensed,
- * this is a no-op so OSS/Pro deployments do not accumulate audit_events rows
- * indefinitely (retention sweep is also gated).
+ * Gated on the `audit-log` enterprise feature: when unlicensed, this is a
+ * no-op. This gate exists so events from Enterprise-only features (cost
+ * rollups, RBAC, SSO, org-policy) do not accumulate rows on Pro/OSS
+ * deployments that have no way to query, prune, or export them.
+ *
+ * **Pro-tier features (PM agent, Release Manager) emit their audit events
+ * via `logAuditEventUnchecked` instead** — those rows must appear in the
+ * audit table whenever the feature itself is licensed, regardless of
+ * whether the Enterprise audit-log dashboard is unlocked.
  *
  * Uses a dynamic import of `../license.js` to avoid a circular-import cycle
  * (license.ts calls into this module to record license-validation failures
@@ -52,11 +58,19 @@ export async function logAuditEvent(
 }
 
 /**
- * Unchecked writer used by the license-validation failure path itself.
- * Bypasses the `audit-log` feature gate because (a) recording why a license
- * was rejected must not depend on that license being valid, and (b) the
- * event is emitted at most once per process (license status is cached).
- * Do not use this from other call sites.
+ * Unchecked writer that bypasses the `audit-log` Enterprise feature gate.
+ *
+ * Used by:
+ * 1. The license-validation failure path itself — recording why a license
+ *    was rejected must not depend on that license being valid. (Bonus: the
+ *    event fires at most once per process, since license status is cached.)
+ * 2. Pro-tier feature events (PM agent decisions, Release Manager
+ *    fire/skip/approval/conflict events) — these must appear in the audit
+ *    table whenever the Pro feature is licensed, independent of the
+ *    Enterprise audit-log dashboard being unlocked.
+ *
+ * Use sparingly. Enterprise-only features should continue to use
+ * `logAuditEvent` so their events are properly gated.
  */
 export async function logAuditEventUnchecked(
   db: AnyDb,

--- a/packages/core/src/pm/actions/promote.ts
+++ b/packages/core/src/pm/actions/promote.ts
@@ -2,7 +2,7 @@ import type { PromoteResult, ConflictCheckResult } from "../types.js";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
 import type { AnyDb } from "../../db/client.js";
-import { logAuditEvent, pmPromotedEvent } from "../../audit/index.js";
+import { logAuditEventUnchecked, pmPromotedEvent } from "../../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:promote" });
 
@@ -83,7 +83,7 @@ export async function promoteReadyIssues(input: PromoteInput): Promise<PromoteRe
     await linearClient.updateIssue(candidate.id, { stateId: todoStateId });
 
     if (input.db) {
-      void logAuditEvent(input.db, pmPromotedEvent({
+      void logAuditEventUnchecked(input.db, pmPromotedEvent({
         issueId: candidate.identifier,
         fromState: "Backlog",
         toState: "Todo",

--- a/packages/core/src/pm/actions/resolve-approvals.ts
+++ b/packages/core/src/pm/actions/resolve-approvals.ts
@@ -4,7 +4,7 @@ import { pmApprovals } from "../../db/schema.js";
 import { eq } from "drizzle-orm";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
-import { logAuditEvent, pmDeprioritizedEvent, pmCancelledEvent } from "../../audit/index.js";
+import { logAuditEventUnchecked, pmDeprioritizedEvent, pmCancelledEvent } from "../../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:approvals" });
 
@@ -110,14 +110,14 @@ export async function resolveApprovals(input: ResolveApprovalsInput): Promise<Re
         log.error({ issueId: approval.issueId, action: approval.action }, "approved in DB but Linear action failed — manual intervention needed");
       } else {
         if (approval.action === "deprioritize") {
-          void logAuditEvent(db, pmDeprioritizedEvent({
+          void logAuditEventUnchecked(db, pmDeprioritizedEvent({
             issueId: approval.issueId,
             oldPriority: null,
             newPriority: 4,
             approvalId: approval.id,
           }));
         } else if (approval.action === "cancel") {
-          void logAuditEvent(db, pmCancelledEvent({
+          void logAuditEventUnchecked(db, pmCancelledEvent({
             issueId: approval.issueId,
             approvalId: approval.id,
             reason: approval.reason,

--- a/packages/core/src/pm/actions/triage.ts
+++ b/packages/core/src/pm/actions/triage.ts
@@ -3,7 +3,7 @@ import { parseJsonObject } from "../../executor/agent-stream.js";
 import { resolveWorkflowStates } from "../linear-helpers.js";
 import { createLogger } from "../../logger.js";
 import type { AnyDb } from "../../db/client.js";
-import { logAuditEvent, pmTriageClassifiedEvent } from "../../audit/index.js";
+import { logAuditEventUnchecked, pmTriageClassifiedEvent } from "../../audit/index.js";
 
 const log = createLogger({ component: "PmAgent:triage" });
 
@@ -138,7 +138,7 @@ export async function triageNewIssues(input: TriageInput): Promise<TriageResult[
 
         const result: TriageResult = { issueId: issue.identifier, priority, labels: issueLabels, complexity, rationale, acceptanceCriteria };
         if (input.db) {
-          void logAuditEvent(input.db, pmTriageClassifiedEvent({
+          void logAuditEventUnchecked(input.db, pmTriageClassifiedEvent({
             issueId: issue.identifier,
             label: pipelineLabel,
             rationale: String(rationale),

--- a/packages/core/src/pm/scheduler.ts
+++ b/packages/core/src/pm/scheduler.ts
@@ -22,7 +22,7 @@ import { sanitize } from "../executor/prompt/sanitizer.js";
 import { resolveWorkflowStates } from "./linear-helpers.js";
 import { sql } from "drizzle-orm";
 import { createLogger } from "../logger.js";
-import { logAuditEvent, budgetRefusedEvent, pruneAuditLog } from "../audit/index.js";
+import { logAuditEventUnchecked, budgetRefusedEvent, pruneAuditLog } from "../audit/index.js";
 import { pruneExpiredSessions } from "../auth/index.js";
 import { recomputeCostRollups } from "../cost/index.js";
 
@@ -175,7 +175,7 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
                 : s.scope.kind === "team"
                   ? `team:${s.scope.teamId}`
                   : `repo:${s.scope.repoUrl}`;
-            void logAuditEvent(
+            void logAuditEventUnchecked(
               db,
               budgetRefusedEvent({
                 scope: scopeKey,
@@ -195,7 +195,7 @@ export function createPmScheduler(deps: PmSchedulerDeps): PmScheduler {
           tick.budgetGuard.reason = `maxInFlight reached (${evaluation.activeCount}/${config.maxInFlight})`;
           // Emit a budget.run_refused event so operators can trace "why didn't
           // this run start?" when capacity (not token spend) is the blocker.
-          void logAuditEvent(
+          void logAuditEventUnchecked(
             db,
             budgetRefusedEvent({
               scope: "global",

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -5,7 +5,7 @@ import { Cron } from "croner";
 import type { AnyDb } from "../db/client.js";
 import { releaseApprovals, releaseDecisions } from "../db/schema.js";
 import { createLogger } from "../logger.js";
-import { logAuditEvent } from "../audit/writer.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
 import {
   releaseFiredEvent,
   releaseSkippedEvent,
@@ -46,7 +46,6 @@ export interface ReleaseManagerScheduler {
   pauseUntil(ts: Date): void;
 }
 
-const MAX_RETRY_ATTEMPTS = 3;
 const SLACK_DEDUP_WINDOW_MS = 24 * 3600 * 1000;
 
 export function createReleaseManagerScheduler(
@@ -81,7 +80,7 @@ export function createReleaseManagerScheduler(
     }
     const ok = await slack.postMessage(slackChannel, text).catch(() => false);
     if (!ok) {
-      void logAuditEvent(db, slackPostFailedEvent({ channel: slackChannel, reason: "post_returned_false" }));
+      void logAuditEventUnchecked(db, slackPostFailedEvent({ channel: slackChannel, reason: "post_returned_false" }));
       return;
     }
     lastSlackPostAt = now;
@@ -175,7 +174,7 @@ export function createReleaseManagerScheduler(
         reason: "manual_tag_detected",
         triggerStateJson,
       });
-      void logAuditEvent(db, releaseSkippedEvent({ repoUrl, branch, reason: "manual_tag_detected" }));
+      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: "manual_tag_detected" }));
       log.info({ repoUrl, branch }, "manual tag detected — re-baselining");
       return;
     }
@@ -197,7 +196,7 @@ export function createReleaseManagerScheduler(
         triggerStateJson,
         proposedVersion,
       });
-      void logAuditEvent(db, releaseSkippedEvent({ repoUrl, branch, reason: result.reason }));
+      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: result.reason }));
       // Slack notification with dedup
       await maybePostSlack(
         `:double_vertical_bar: Release skipped for *${repoUrl}* (${branch}): ${result.reason}`,
@@ -215,7 +214,7 @@ export function createReleaseManagerScheduler(
         triggerStateJson,
         proposedVersion,
       });
-      void logAuditEvent(db, releaseSkippedEvent({ repoUrl, branch, reason: "awaiting-approval" }));
+      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: "awaiting-approval" }));
       // Always post on first transition to awaiting-approval (bypass dedup).
       // Reset lastSlackSkipReason so a subsequent regular-skip will re-post.
       lastSlackSkipReason = null;
@@ -243,41 +242,35 @@ export function createReleaseManagerScheduler(
         triggerStateJson,
         proposedVersion,
       });
-      void logAuditEvent(db, releaseTagConflictEvent({ repoUrl, branch, tag: proposedVersion }));
+      void logAuditEventUnchecked(db, releaseTagConflictEvent({ repoUrl, branch, tag: proposedVersion }));
       return;
     }
 
     if (githubResult.kind === "release_create_failed") {
-      // Tag was created; release-creation failed. Increment attempt and write fire-pending.
-      const prevAttempt = await (db as any)
-        .select({ attemptCount: releaseDecisions.attemptCount })
-        .from(releaseDecisions)
-        .where(
-          and(
-            eq(releaseDecisions.repoUrl, repoUrl),
-            eq(releaseDecisions.branch, branch),
-            eq(releaseDecisions.decision, "fire-pending"),
-            eq(releaseDecisions.firedTag, proposedVersion),
-          ),
-        )
-        .limit(1);
-      const nextAttempt = ((prevAttempt?.[0]?.attemptCount as number) ?? 0) + 1;
-      const decision = nextAttempt >= MAX_RETRY_ATTEMPTS ? "skip" : "fire-pending";
-      const reason = decision === "skip" ? "release_create_failed_after_retries" : "release_create_failed_retrying";
+      // Tag was created; release-creation failed. Write a single skip row with the
+      // partial-fire details so an operator can see what happened and clean up the
+      // orphaned tag manually. v1 does NOT retry release-creation across ticks
+      // (the tag is now committed, so the next tick would hit `tag_exists` and
+      // skip again — see plan §"Known v1 simplifications"). Proper retry is a v2
+      // feature requiring a tick-start sweep that calls only `createRelease` for
+      // matching fire-pending rows.
       await persistDecision({
         id,
-        decision,
-        reason,
+        decision: "skip",
+        reason: "release_create_failed",
         triggerStateJson,
         proposedVersion,
         firedTag: proposedVersion,
         firedSha: state.headSha,
-        attemptCount: nextAttempt,
       });
-      if (decision === "skip") {
-        void logAuditEvent(db, releasePartialEvent({ repoUrl, branch, tag: proposedVersion, attemptCount: nextAttempt }));
-      }
-      log.error({ repoUrl, branch, tag: proposedVersion, attempt: nextAttempt, msg: githubResult.message }, "release create failed");
+      void logAuditEventUnchecked(
+        db,
+        releasePartialEvent({ repoUrl, branch, tag: proposedVersion, attemptCount: 1 }),
+      );
+      log.error(
+        { repoUrl, branch, tag: proposedVersion, msg: githubResult.message },
+        "release create failed — tag exists in GitHub but release page not created; manual cleanup required",
+      );
       return;
     }
 
@@ -289,7 +282,7 @@ export function createReleaseManagerScheduler(
         triggerStateJson,
         proposedVersion,
       });
-      void logAuditEvent(db, releaseSkippedEvent({ repoUrl, branch, reason: "tag_create_error" }));
+      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: "tag_create_error" }));
       log.error({ err: githubResult.message, repoUrl, branch }, "createTagAndRelease unknown error — wrote skip row");
       return;
     }
@@ -307,7 +300,7 @@ export function createReleaseManagerScheduler(
     if (state.hasFreshApproval) {
       await consumeApprovalRow(id);
     }
-    void logAuditEvent(
+    void logAuditEventUnchecked(
       db,
       releaseFiredEvent({
         repoUrl,

--- a/packages/core/src/release-manager/slack-handler.ts
+++ b/packages/core/src/release-manager/slack-handler.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { eq, and, desc } from "drizzle-orm";
 import type { AnyDb } from "../db/client.js";
 import { releaseApprovals, releaseDecisions } from "../db/schema.js";
-import { logAuditEvent } from "../audit/writer.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
 import { releaseApprovedEvent, releaseSkippedEvent } from "../audit/events.js";
 import { createLogger } from "../logger.js";
 
@@ -74,7 +74,7 @@ export async function handleReleaseSubcommand(
           approvedAt: new Date(),
           approvedBy: slackUserId,
         });
-        void logAuditEvent(db, releaseApprovedEvent({ repoUrl, branch, approvedBy: slackUserId }));
+        void logAuditEventUnchecked(db, releaseApprovedEvent({ repoUrl, branch, approvedBy: slackUserId }));
         return {
           text: `:white_check_mark: Approved by <@${slackUserId}>. Next eligible tick will fire if other rules pass.`,
           responseType: "in_channel",
@@ -108,7 +108,7 @@ export async function handleReleaseSubcommand(
         triggerStateJson: JSON.stringify({ source: "slack", slackUserId }),
         attemptCount: 0,
       });
-      void logAuditEvent(db, releaseSkippedEvent({
+      void logAuditEventUnchecked(db, releaseSkippedEvent({
         repoUrl,
         branch,
         reason: `manual:${cmd.reason}`,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
v0.1.31 release. Combines version cascade with two v2 follow-ups for BEC-135 (Release Manager agent, shipped in #140).

**Versions:**
- @urateam/core: 0.1.16 → 0.1.17
- @urateam/cli: 0.1.18 → 0.1.19
- @urateam/dashboard: 0.1.16 → 0.1.17

**Code changes (the v2 follow-ups, originally tracked in closed #141 + merged-into-this-branch #142):**
1. **Removed dead retry counter** in \`release-manager/scheduler.ts\`. The fire-pending retry path was unreachable because \`state.ts manualTagDetected\` only considers \`decision="fire"\` rows. Partial-fire (createRef succeeded, createRelease failed) now writes a single skip row + immediate releasePartialEvent audit. Operators clean up the orphaned tag manually. Proper retry-on-fire-pending sweep is queued as a v2 feature.
2. **Pro-tier audit events bypass Enterprise audit-log gate**. PM agent + Release Manager are Pro-tier features. Their audit events (pm.* and release.*) now use \`logAuditEventUnchecked\` so they appear in the audit table whenever the Pro license is unlocked, regardless of the Enterprise audit-log dashboard. Enterprise-only feature events (cost, RBAC, SSO, org-policy) continue to use \`logAuditEvent\` so they remain gated. Audit-log feature now correctly refers to retention/reader/export, not write.

After merge: tag \`v0.1.31\`, publish \`@urateam/core@0.1.17\` to npm with provenance.

## Test plan
- [x] Full core test suite: 1347 passed, 11 skipped (modulo same 5 pre-existing flaky timeouts on main)
- [x] All release-manager + PM action + audit tests pass
- [x] \`audit-immutability.test.ts\` allowlist updated to permit Pro-tier feature modules to call \`logAuditEventUnchecked\`
- [x] tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)