### PR TITLE
fix(cli): resolve @urateam/dashboard types in cli typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "turbo build",
+    "typecheck": "turbo typecheck",
     "test": "turbo test",
     "test:integration": "pnpm --filter @urateam/core test:integration && pnpm --filter create-urateam build && pnpm --filter create-urateam test:integration",
     "lint": "turbo lint",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "dev": "tsx src/index.ts"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc && node --input-type=module -e \"import{cpSync}from'node:fs';cpSync('src/db/migrations','dist/db/migrations',{recursive:true})\"",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "dev": "tsc --watch"

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc && node --input-type=module -e \"import{cpSync}from'node:fs';cpSync('src/static','dist/static',{recursive:true})\"",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "dev": "tsx watch src/server.ts"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "test": {
       "dependsOn": ["build"],
       "outputs": []


### PR DESCRIPTION
## Summary

- `packages/dashboard/dist/` is absent on a clean clone (dashboard must be built before cli can typecheck), causing `TS2307: Cannot find module '@urateam/dashboard'` in `dev.ts` and `start.ts`
- Added a `typecheck` task to `turbo.json` with `dependsOn: ["^build"]` — turbo now builds all workspace deps (dashboard, core) before running any package's typecheck
- Added `"typecheck": "tsc --noEmit"` scripts to all four packages (`cli`, `core`, `dashboard`, `create-urateam`) and wired `pnpm typecheck` at the repo root through turbo

## Test plan

- [ ] `pnpm typecheck` from repo root passes with 0 errors (6 tasks, all green)
- [ ] `cd packages/cli && npx tsc --noEmit` passes once dashboard is built (works as before once deps are built)
- [ ] `pnpm build` still works (no regression — `turbo build` unchanged)
- [ ] `pnpm test` still works (no regression — `turbo test` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)