### PR TITLE
test(core): bump vitest testTimeout 15s→30s for license-helper tests

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     include: ["src/__tests__/**/*.test.ts"],
     exclude: ["src/__tests__/integration/**/*.test.ts"],
     passWithNoTests: true,
-    testTimeout: 15_000,
+    // 30s — license-helper-using tests (sso/policy/rbac feature-flag tests +
+    // barrel re-export tests) do crypto + dynamic-import work that takes
+    // 4-5s in isolation and can exceed 15s under parallel-worker contention.
+    // 30s gives ~5x headroom over the slowest observed run while keeping
+    // legitimately-hung tests detectable in a single CI minute.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary
Five tests intermittently fail with \`Test timed out in 15000ms\` under \`pnpm vitest run\` parallel execution: \`sso-feature-flag\`, \`policy-license\`, \`rbac-license\`, plus two barrel re-export checks. We hit this consistently across BEC-134/135 sessions (the failures show up in CI but every test passes when run in isolation).

## Root cause
All five tests use \`installTestProLicense()\` (\`__tests__/helpers/license.ts\`), which does ed25519 keypair generation + dynamic import of \`license-public-key.js\` + JWT signing per test. That's 4-5s of work in isolation — easily >15s when N vitest workers compete for CPU.

## Fix
Bump \`testTimeout\` from 15000 to 30000 in \`packages/core/vitest.config.ts\`. ~5x headroom over the slowest observed isolation run, keeps genuinely hung tests detectable within a single CI minute.

## Why not a deeper fix?
Pre-generating the test keypair once at module-load (instead of per-test) would eliminate the slowness entirely, but it's a larger refactor — \`installTestProLicense\` patches the embedded public key on each invocation to support per-test tier overrides. Worth a separate ticket if this resurfaces post-30s.

## Test plan
- [x] No code changes — config-only
- [x] Suite still completes in <5min wall time

🤖 Generated with [Claude Code](https://claude.com/claude-code)