### PR TITLE
feat(qa): BEC-136 QA agent + release-readiness check (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-05-04-bec-136-qa-agent.md
+++ b/docs/superpowers/plans/2026-05-04-bec-136-qa-agent.md
@@ -1,0 +1,2902 @@
+# BEC-136 — QA Agent + Release-Readiness Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire a release-time QA gate into Release Manager: each tick verifies that a customer-defined GitHub Actions workflow has run green against the merge SHA before firing a release tag. If the workflow file is missing, file a Linear issue (idempotent via DB) and pause the release pipeline.
+
+**Architecture:** New module `packages/core/src/qa/` (3 source files: `types.ts`, `github.ts`, `gap.ts`) + integration into the existing Release Manager scheduler/decide/state via a 5th trigger field `qaCheck` on `ReleaseManagerTriggers`. Async fire-and-check across ticks: each tick either triggers a workflow_dispatch, observes an in-flight run, or files a gap issue — never blocks. Two minimal DB touchpoints: 2 new columns on `release_decisions` (`qaRunId`, `qaRunSha`) plus a tiny new `qa_gap_issues` table for filing-idempotency.
+
+**Tech Stack:** TypeScript, Zod v3, Drizzle ORM (sqlite + postgres), `@octokit/rest`, `@linear/sdk` (already a dep — used by PM agent), Vitest 3.x.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md` (322 lines, 13 sections — all decisions locked in §2).
+
+**Workflow conventions:**
+- Branch: `jonb3232/bec-136-v10-46-qa-agent-release-readiness-check-orchestrate-existing` (already created from main; spec already committed)
+- Worktree: `/tmp/urateam-fresh/.worktrees/bec-136` (pnpm install already done from BEC-135 era)
+- vitest 3.x: ALWAYS write `beforeEach(() => { ... })` block-body — never the arrow-returning-function form
+- Drizzle `Db` is a `SQLite | Postgres` union — calling `.insert()` on it directly trips a TS union-dispatch error; the codebase pattern is `(db as any).insert(...)`. Don't fight it.
+- Cross-dialect date filters MUST use Drizzle operators (`gte()`, `lt()`) — NOT raw `sql\`${col} >= ${date}\`` templates (those bypass the `crossTimestamp` serializer and break SQLite).
+- All Pro-tier audit events use `logAuditEventUnchecked` (per BEC-135 v2 audit-gating pattern memory entry).
+- After all tasks: open PR for Sonnet review; user merges; user does the version cascade + npm publish.
+
+---
+
+## Top-level file structure
+
+### Created (10 files)
+
+```
+packages/core/src/qa/
+  types.ts                                                   # QaCheckConfigSchema + QaTriggerResult union
+  github.ts                                                  # triggerWorkflow / pollWorkflowRun / workflowFileExists + audit emit on dispatch
+  gap.ts                                                     # detectMissingHarness / fileGapIssue (idempotent, audit on first file)
+  index.ts                                                   # barrel export
+
+packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql       # NEW
+packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql        # NEW
+packages/core/src/db/migrations/postgres/011_qa_run_columns.sql     # NEW
+packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql      # NEW
+
+packages/core/src/__tests__/
+  qa-config.test.ts
+  qa-github.test.ts
+  qa-gap.test.ts
+  qa-eval.test.ts
+  qa-audit-events.test.ts
+  db-qa-gap-issues.test.ts
+```
+
+### Modified (10 files)
+
+```
+packages/core/src/types.ts                                          # ADD 3 audit event types + qaCheck on RepoConfig (via release-manager schema chain)
+packages/core/src/audit/events.ts                                   # ADD 3 factories
+packages/core/src/db/schema.ts                                      # ADD qaRunId/qaRunSha columns to releaseDecisions; ADD qaGapIssues table
+packages/core/src/release-manager/types.ts                          # ADD qaCheck to ReleaseManagerTriggers; EXTEND CollectedState with qaRun field; EXTEND DecisionResult with qaActionNeeded
+packages/core/src/release-manager/triggers.ts                       # ADD evalQaCheck() at slot 4
+packages/core/src/release-manager/decide.ts                         # ADD qaCheck call before requireSlackApproval
+packages/core/src/release-manager/state.ts                          # ADD qaRun lookup in collectState()
+packages/core/src/release-manager/scheduler.ts                      # ADD qaActionNeeded dispatch (triggerWorkflow / fileGapIssue) + qa.run_completed audit on conclusion observed
+packages/core/src/__tests__/audit-immutability.test.ts              # ADD qa/github.ts + qa/gap.ts to allowlist
+packages/cli/src/commands/start.ts                                  # ADD startup validation (LINEAR_API_KEY required when qaCheck set)
+packages/create-urateam/template/.urateam/.env.example              # DOCUMENT RELEASE_MANAGER_TRIGGER_QA_* vars
+```
+
+### Test infra reminders (read before starting)
+
+- **vitest 3.x `beforeEach` quirk** — always block-body. Wrong: `beforeEach(() => () => { ... })`. Right: `beforeEach(() => { /* setup */ });`.
+- **Zod v3 syntax** — use `.refine()` and `.superRefine()`, not v4's `.check()`.
+- **License cache** — `_resetLicenseCache()` between tests if you alter `URATEAM_LICENSE_KEY`.
+- **Postgres test gating** — use `describe.skipIf(!process.env.TEST_POSTGRES_URL)` (codebase convention; NOT `URATEAM_TEST_PG_URL`).
+- **Audit event type schema is a strict Zod enum** — adding a new `eventType` requires editing `AuditEventTypeSchema` in `types.ts`.
+- **Drizzle return shape** — `createDb()` returns `Promise<Db>` directly. Tests using `const { db } = await makeDb()` need a wrapper that returns `{ db: db as any }`. The `as any` cast is the established codebase pattern.
+- **License-helper tests are slow.** New QA tests should NOT use `installTestProLicense()` unless a Pro license is genuinely needed — for pure-fn tests, just construct config objects directly.
+
+---
+
+## Task 1: Audit event types + factories
+
+**Files:**
+- Modify: `packages/core/src/types.ts:415-435` (extend `AuditEventTypeSchema`)
+- Modify: `packages/core/src/audit/events.ts` (append 3 factories)
+- Test: `packages/core/src/__tests__/qa-audit-events.test.ts` (CREATE)
+
+This task adds 3 new event-type strings to the strict Zod enum and 3 new factory helpers. No QA logic yet — just the audit primitives.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/qa-audit-events.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  qaRunTriggeredEvent,
+  qaRunCompletedEvent,
+  qaGapIssueFiledEvent,
+} from "../audit/events.js";
+import { AuditEventSchema } from "../types.js";
+
+describe("qa audit events", () => {
+  it("qaRunTriggeredEvent passes schema validation", () => {
+    const evt = qaRunTriggeredEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflow: ".github/workflows/smoke.yml",
+      runId: 12345,
+      sha: "abcdef0",
+    });
+    expect(evt.eventType).toBe("qa.run_triggered");
+    expect(evt.actor).toBe("release-manager");
+    expect(evt.actorType).toBe("release-manager");
+    expect(evt.scope).toBe("repo:https://github.com/org/repo");
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.runId).toBe(12345);
+  });
+
+  it("qaRunCompletedEvent passes schema validation with conclusion", () => {
+    const evt = qaRunCompletedEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      runId: 12345,
+      conclusion: "success",
+      durationMs: 600_000,
+    });
+    expect(evt.eventType).toBe("qa.run_completed");
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.conclusion).toBe("success");
+    expect(evt.payload.durationMs).toBe(600_000);
+  });
+
+  it("qaRunCompletedEvent supports synthetic timeout flag", () => {
+    const evt = qaRunCompletedEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      runId: 12345,
+      conclusion: "timed_out",
+      durationMs: 1_800_000,
+      synthetic: true,
+    });
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.synthetic).toBe(true);
+  });
+
+  it("qaGapIssueFiledEvent passes schema validation", () => {
+    const evt = qaGapIssueFiledEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    expect(evt.eventType).toBe("qa.gap_issue_filed");
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.linearIssueId).toBe("BEC-150");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-audit-events.test.ts
+```
+
+Expected: FAIL — TS errors about missing exports `qaRunTriggeredEvent`, etc.
+
+- [ ] **Step 3: Extend `AuditEventTypeSchema`**
+
+In `packages/core/src/types.ts:415-432`, find the existing `AuditEventTypeSchema` enum (the one extended in BEC-135 has `release.fired`, `release.skipped`, etc. at the end). Append three new entries before the closing `]`:
+
+```ts
+  "qa.run_triggered", "qa.run_completed", "qa.gap_issue_filed",
+```
+
+Final form:
+
+```ts
+export const AuditEventTypeSchema = z.enum([
+  "run.started", "run.completed", "run.failed",
+  "run.auto_merged", "run.auto_merge_skipped",
+  "pm.approval_requested", "pm.approval_resolved",
+  "pm.issue_promoted", "pm.issue_deprioritized", "pm.issue_cancelled",
+  "pm.triage_classified",
+  "budget.alert_fired", "budget.run_refused",
+  "license.validation_failed", "config.loaded",
+  "dashboard.manual_action",
+  "dashboard.login", "dashboard.logout", "dashboard.login_denied",
+  "policy.path_blocked", "policy.cost_exceeded",
+  "policy.override_used", "policy.reviewers_requested",
+  "release.fired", "release.skipped", "release.approved",
+  "release.tag_conflict", "release.partial",
+  "slack.post_failed",
+  "qa.run_triggered", "qa.run_completed", "qa.gap_issue_filed",
+]);
+```
+
+- [ ] **Step 4: Add the 3 factories**
+
+Append to `packages/core/src/audit/events.ts` (after the last release-manager factory, after `slackPostFailedEvent`):
+
+```ts
+export function qaRunTriggeredEvent(args: {
+  repoUrl: string;
+  branch: string;
+  workflow: string;
+  runId: number;
+  sha: string;
+}): AuditEvent {
+  return base({
+    eventType: "qa.run_triggered",
+    actor: "release-manager",
+    actorType: "release-manager",
+    scope: `repo:${args.repoUrl}`,
+    payload: {
+      branch: args.branch,
+      workflow: args.workflow,
+      runId: args.runId,
+      sha: args.sha,
+    },
+  });
+}
+
+export function qaRunCompletedEvent(args: {
+  repoUrl: string;
+  branch: string;
+  runId: number;
+  conclusion: "success" | "failure" | "cancelled" | "timed_out" | "action_required" | "skipped" | "stale" | "neutral";
+  durationMs: number;
+  /** Set to true when we synthesize a timeout (GitHub didn't conclude the run). */
+  synthetic?: boolean;
+}): AuditEvent {
+  return base({
+    eventType: "qa.run_completed",
+    actor: "release-manager",
+    actorType: "release-manager",
+    scope: `repo:${args.repoUrl}`,
+    payload: {
+      branch: args.branch,
+      runId: args.runId,
+      conclusion: args.conclusion,
+      durationMs: args.durationMs,
+      synthetic: args.synthetic ?? false,
+    },
+  });
+}
+
+export function qaGapIssueFiledEvent(args: {
+  repoUrl: string;
+  branch: string;
+  workflowPath: string;
+  linearIssueId: string;
+}): AuditEvent {
+  return base({
+    eventType: "qa.gap_issue_filed",
+    actor: "release-manager",
+    actorType: "release-manager",
+    scope: `repo:${args.repoUrl}`,
+    payload: {
+      branch: args.branch,
+      workflowPath: args.workflowPath,
+      linearIssueId: args.linearIssueId,
+    },
+  });
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-audit-events.test.ts src/__tests__/audit-types.test.ts
+```
+
+Expected: PASS — 4 new tests + existing audit-types tests still pass (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/types.ts packages/core/src/audit/events.ts packages/core/src/__tests__/qa-audit-events.test.ts
+git commit -m "feat(core): qa audit event types + factories (BEC-136)"
+```
+
+---
+
+## Task 2: DB schema — add qaRun columns + qaGapIssues table
+
+**Files:**
+- Modify: `packages/core/src/db/schema.ts` (extend `releaseDecisions`, add `qaGapIssues`)
+- Test: `packages/core/src/__tests__/db-qa-gap-issues.test.ts` (CREATE — will FAIL after this task; migrations in tasks 3-6 fix it)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/db-qa-gap-issues.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import { randomBytes, randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { eq, isNull, and } from "drizzle-orm";
+import { createDb } from "../db/index.js";
+import { qaGapIssues, releaseDecisions } from "../db/schema.js";
+
+function tmpDbPath(): string {
+  const id = randomBytes(8).toString("hex");
+  return `/tmp/laf-qa-gap-${id}.sqlite`;
+}
+
+describe("qa_gap_issues table", () => {
+  const paths: string[] = [];
+
+  async function makeDb() {
+    const path = tmpDbPath();
+    paths.push(path);
+    const db = await createDb({ driver: "sqlite", connectionString: path });
+    return { db: db as any };
+  }
+
+  afterEach(() => {
+    for (const p of paths) {
+      try { unlinkSync(p); } catch {}
+      try { unlinkSync(p + "-wal"); } catch {}
+      try { unlinkSync(p + "-shm"); } catch {}
+    }
+    paths.length = 0;
+  });
+
+  it("inserts and reads a qa_gap_issues row", async () => {
+    const { db } = await makeDb();
+    const id = `qg_${randomUUID()}`;
+    await db.insert(qaGapIssues).values({
+      id,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    const rows = await db.select().from(qaGapIssues).where(eq(qaGapIssues.id, id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].linearIssueId).toBe("BEC-150");
+    expect(rows[0].resolvedAt).toBeNull();
+  });
+
+  it("partial UNIQUE prevents re-filing while resolved_at is null", async () => {
+    const { db } = await makeDb();
+    await db.insert(qaGapIssues).values({
+      id: `qg_${randomUUID()}`,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    await expect(
+      db.insert(qaGapIssues).values({
+        id: `qg_${randomUUID()}`,
+        repoUrl: "https://github.com/org/repo",
+        branch: "main",
+        workflowPath: ".github/workflows/smoke.yml",
+        linearIssueId: "BEC-151",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("allows re-filing after the previous issue is resolved", async () => {
+    const { db } = await makeDb();
+    const firstId = `qg_${randomUUID()}`;
+    await db.insert(qaGapIssues).values({
+      id: firstId,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    await db.update(qaGapIssues)
+      .set({ resolvedAt: new Date() })
+      .where(eq(qaGapIssues.id, firstId));
+    // Second filing now succeeds
+    await db.insert(qaGapIssues).values({
+      id: `qg_${randomUUID()}`,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-160",
+    });
+    const rows = await db.select().from(qaGapIssues).where(
+      and(
+        eq(qaGapIssues.repoUrl, "https://github.com/org/repo"),
+        eq(qaGapIssues.workflowPath, ".github/workflows/smoke.yml"),
+      ),
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  it("releaseDecisions has qaRunId and qaRunSha columns", async () => {
+    const { db } = await makeDb();
+    const id = `rd_${randomUUID()}`;
+    await db.insert(releaseDecisions).values({
+      id,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      decidedAt: new Date(),
+      decision: "skip",
+      reason: "qa_running",
+      triggerStateJson: "{}",
+      attemptCount: 0,
+      qaRunId: 12345,
+      qaRunSha: "abcdef0",
+    });
+    const rows = await db.select().from(releaseDecisions).where(eq(releaseDecisions.id, id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].qaRunId).toBe(12345);
+    expect(rows[0].qaRunSha).toBe("abcdef0");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/db-qa-gap-issues.test.ts
+```
+
+Expected: FAIL — TS error about missing export `qaGapIssues`.
+
+- [ ] **Step 3: Extend `releaseDecisions` + add `qaGapIssues` table to schema.ts**
+
+In `packages/core/src/db/schema.ts`, find the `releaseDecisions` table definition (added by BEC-135). Add 2 new columns at the end of its column block (before the closing `}`):
+
+```ts
+  /** BEC-136: GitHub workflow run ID for the in-flight QA run. Null when no QA in flight. */
+  qaRunId: integer("qa_run_id"),
+  /** BEC-136: SHA the QA workflow was triggered against. Used to detect mid-run SHA mismatch. */
+  qaRunSha: text("qa_run_sha"),
+```
+
+Then, after the `releaseApprovals` table block, add a new table:
+
+```ts
+/** BEC-136: tracks Linear issues filed for missing QA workflows — partial UNIQUE prevents re-filing while open. */
+export const qaGapIssues = sqliteTable(
+  "qa_gap_issues",
+  {
+    id: text("id").primaryKey(),
+    repoUrl: text("repo_url").notNull(),
+    branch: text("branch").notNull(),
+    workflowPath: text("workflow_path").notNull(),
+    /** Linear issue identifier returned at file time (e.g., "BEC-150"). */
+    linearIssueId: text("linear_issue_id").notNull(),
+    filedAt: crossTimestamp("filed_at")
+      .notNull()
+      .$defaultFn(() => new Date()),
+    /** Set when the gap is detected as resolved (workflow file appears). Issue itself is closed manually by operator. */
+    resolvedAt: crossTimestamp("resolved_at"),
+  },
+  // The UNIQUE WHERE resolved_at IS NULL partial index is created in the
+  // raw migration SQL because Drizzle's sqliteTable.unique() helper does
+  // not support partial indexes. Migration files own that concern.
+);
+```
+
+- [ ] **Step 4: Run the test to verify it (still) fails for a different reason**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/db-qa-gap-issues.test.ts
+```
+
+Expected: FAIL with `no such table: qa_gap_issues` and/or `no such column: qa_run_id`. Schema is now defined but no migration creates the table/columns yet — Tasks 3-6 fix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/db/schema.ts packages/core/src/__tests__/db-qa-gap-issues.test.ts
+git commit -m "feat(core): drizzle schema for qa_run_columns + qa_gap_issues (BEC-136)"
+```
+
+---
+
+## Task 3: SQLite migration 010 — add qa_run columns
+
+**Files:**
+- Create: `packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql`
+
+- [ ] **Step 1: Create the migration**
+
+Write `packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql`:
+
+```sql
+-- BEC-136: QA agent — track in-flight workflow runs on the release_decisions table.
+
+ALTER TABLE release_decisions ADD COLUMN qa_run_id INTEGER;
+ALTER TABLE release_decisions ADD COLUMN qa_run_sha TEXT;
+
+-- Index for collectState's qaRun lookup: fastest path for "most recent decision with non-null qa_run_id"
+CREATE INDEX IF NOT EXISTS idx_release_decisions_qa_run_id
+  ON release_decisions(repo_url, branch, qa_run_id, decided_at DESC)
+  WHERE qa_run_id IS NOT NULL;
+```
+
+Note: SQLite's migrator is idempotent on `duplicate column name` errors (per `db/migrator.ts:122-135`), so re-running this migration is safe.
+
+- [ ] **Step 2: Run the test (now closer but still missing the gap table)**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/db-qa-gap-issues.test.ts
+```
+
+Expected: 1 of 4 tests now passes (the `releaseDecisions has qaRunId and qaRunSha columns` test). The other 3 still fail with `no such table: qa_gap_issues`. That's the right hand-off state.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql
+git commit -m "feat(core): sqlite migration 010 — add qa_run columns to release_decisions (BEC-136)"
+```
+
+---
+
+## Task 4: Postgres migration 011 — add qa_run columns
+
+**Files:**
+- Create: `packages/core/src/db/migrations/postgres/011_qa_run_columns.sql`
+
+- [ ] **Step 1: Create the migration**
+
+Write `packages/core/src/db/migrations/postgres/011_qa_run_columns.sql`:
+
+```sql
+-- BEC-136: QA agent — track in-flight workflow runs on the release_decisions table.
+
+ALTER TABLE release_decisions ADD COLUMN IF NOT EXISTS qa_run_id INTEGER;
+ALTER TABLE release_decisions ADD COLUMN IF NOT EXISTS qa_run_sha TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_release_decisions_qa_run_id
+  ON release_decisions(repo_url, branch, qa_run_id, decided_at DESC)
+  WHERE qa_run_id IS NOT NULL;
+```
+
+Postgres supports `ADD COLUMN IF NOT EXISTS` natively (unlike SQLite), so the migration is even cleaner.
+
+- [ ] **Step 2: Optional postgres test (skipped if TEST_POSTGRES_URL unset)**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && TEST_POSTGRES_URL="$TEST_POSTGRES_URL" npx vitest run src/__tests__/db-postgres.test.ts
+```
+
+Expected: PASS or SKIP. The new migration is purely additive — existing postgres tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/db/migrations/postgres/011_qa_run_columns.sql
+git commit -m "feat(core): postgres migration 011 — add qa_run columns (BEC-136)"
+```
+
+---
+
+## Task 5: SQLite migration 011 — qa_gap_issues table
+
+**Files:**
+- Create: `packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql`
+
+- [ ] **Step 1: Create the migration**
+
+Write `packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql`:
+
+```sql
+-- BEC-136: QA agent — Linear issue idempotency for missing QA workflows.
+
+CREATE TABLE IF NOT EXISTS qa_gap_issues (
+  id TEXT PRIMARY KEY,
+  repo_url TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  workflow_path TEXT NOT NULL,
+  linear_issue_id TEXT NOT NULL,
+  filed_at INTEGER NOT NULL,
+  resolved_at INTEGER
+);
+
+-- Partial UNIQUE: at most one open gap issue per (repo, branch, workflow) at a time.
+-- Once resolved (resolved_at IS NOT NULL), the row is preserved for audit but a new
+-- issue can be filed for the same gap in the future.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_qa_gap_issues_unique_open
+  ON qa_gap_issues(repo_url, branch, workflow_path)
+  WHERE resolved_at IS NULL;
+
+-- Lookup index for "is there an open gap for this (repo, branch, workflow)?" — partial too.
+CREATE INDEX IF NOT EXISTS idx_qa_gap_issues_lookup
+  ON qa_gap_issues(repo_url, branch, workflow_path, resolved_at);
+```
+
+- [ ] **Step 2: Run the test to verify it now passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/db-qa-gap-issues.test.ts
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql
+git commit -m "feat(core): sqlite migration 011 — qa_gap_issues table (BEC-136)"
+```
+
+---
+
+## Task 6: Postgres migration 012 — qa_gap_issues table
+
+**Files:**
+- Create: `packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql`
+
+- [ ] **Step 1: Create the migration**
+
+Write `packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql`:
+
+```sql
+-- BEC-136: QA agent — Linear issue idempotency for missing QA workflows.
+
+CREATE TABLE IF NOT EXISTS qa_gap_issues (
+  id TEXT PRIMARY KEY,
+  repo_url TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  workflow_path TEXT NOT NULL,
+  linear_issue_id TEXT NOT NULL,
+  filed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_qa_gap_issues_unique_open
+  ON qa_gap_issues(repo_url, branch, workflow_path)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_qa_gap_issues_lookup
+  ON qa_gap_issues(repo_url, branch, workflow_path, resolved_at);
+```
+
+- [ ] **Step 2: Optional postgres test**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && TEST_POSTGRES_URL="$TEST_POSTGRES_URL" npx vitest run src/__tests__/db-postgres.test.ts
+```
+
+Expected: PASS or SKIP. New migration is additive.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql
+git commit -m "feat(core): postgres migration 012 — qa_gap_issues table (BEC-136)"
+```
+
+---
+
+## Task 7: QaCheckConfigSchema + extend Release Manager types
+
+**Files:**
+- Create: `packages/core/src/qa/types.ts`
+- Modify: `packages/core/src/release-manager/types.ts` (extend `ReleaseManagerTriggers`, `CollectedState`, `DecisionResult`)
+- Test: `packages/core/src/__tests__/qa-config.test.ts` (CREATE)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/qa-config.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { QaCheckConfigSchema } from "../qa/types.js";
+import { ReleaseManagerConfigSchema } from "../release-manager/types.js";
+
+describe("QaCheckConfigSchema", () => {
+  it("parses minimal valid config", () => {
+    const cfg = QaCheckConfigSchema.parse({
+      workflow: ".github/workflows/smoke.yml",
+      linearTeamId: "team-uuid-123",
+    });
+    expect(cfg.workflow).toBe(".github/workflows/smoke.yml");
+    expect(cfg.timeoutMinutes).toBe(30); // default
+    expect(cfg.linearTeamId).toBe("team-uuid-123");
+    expect(cfg.workflowInputs).toBeUndefined();
+  });
+
+  it("respects custom timeoutMinutes", () => {
+    const cfg = QaCheckConfigSchema.parse({
+      workflow: ".github/workflows/smoke.yml",
+      linearTeamId: "team-uuid-123",
+      timeoutMinutes: 60,
+    });
+    expect(cfg.timeoutMinutes).toBe(60);
+  });
+
+  it("accepts workflowInputs object", () => {
+    const cfg = QaCheckConfigSchema.parse({
+      workflow: ".github/workflows/smoke.yml",
+      linearTeamId: "team-uuid-123",
+      workflowInputs: { environment: "preview" },
+    });
+    expect(cfg.workflowInputs).toEqual({ environment: "preview" });
+  });
+
+  it("rejects empty workflow string", () => {
+    expect(() =>
+      QaCheckConfigSchema.parse({
+        workflow: "",
+        linearTeamId: "team-uuid-123",
+      })
+    ).toThrow();
+  });
+
+  it("rejects empty linearTeamId", () => {
+    expect(() =>
+      QaCheckConfigSchema.parse({
+        workflow: ".github/workflows/smoke.yml",
+        linearTeamId: "",
+      })
+    ).toThrow();
+  });
+
+  it("rejects non-positive timeoutMinutes", () => {
+    expect(() =>
+      QaCheckConfigSchema.parse({
+        workflow: ".github/workflows/smoke.yml",
+        linearTeamId: "team-uuid-123",
+        timeoutMinutes: 0,
+      })
+    ).toThrow();
+  });
+});
+
+describe("ReleaseManagerConfigSchema with qaCheck", () => {
+  it("accepts a qaCheck trigger alongside existing triggers", () => {
+    const cfg = ReleaseManagerConfigSchema.parse({
+      enabled: true,
+      triggers: {
+        mergedPRsSince: 5,
+        qaCheck: {
+          workflow: ".github/workflows/smoke.yml",
+          linearTeamId: "team-uuid-123",
+        },
+      },
+    });
+    expect(cfg.triggers.qaCheck?.workflow).toBe(".github/workflows/smoke.yml");
+    expect(cfg.triggers.qaCheck?.timeoutMinutes).toBe(30);
+  });
+
+  it("treats qaCheck as a valid trigger to satisfy 'at least one trigger' guard", () => {
+    // qaCheck alone (no mergedPRsSince/timeSinceLastHours/ciGreenForMinutes/requireSlackApproval) should pass
+    const cfg = ReleaseManagerConfigSchema.parse({
+      enabled: true,
+      triggers: {
+        qaCheck: {
+          workflow: ".github/workflows/smoke.yml",
+          linearTeamId: "team-uuid-123",
+        },
+      },
+    });
+    expect(cfg.triggers.qaCheck).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-config.test.ts
+```
+
+Expected: FAIL — module not found `../qa/types.js`.
+
+- [ ] **Step 3: Create `qa/types.ts`**
+
+Write `packages/core/src/qa/types.ts`:
+
+```ts
+import { z } from "zod";
+
+export const QaCheckConfigSchema = z.object({
+  /** Path to the workflow file in the repo (e.g., ".github/workflows/smoke.yml"). */
+  workflow: z.string().min(1),
+  /** Max time to wait for a single workflow run before reporting timed_out. Default 30. */
+  timeoutMinutes: z.number().int().positive().default(30),
+  /** Linear team UUID for filing gap issues. Required for the gap-issue path. */
+  linearTeamId: z.string().min(1),
+  /** Optional inputs passed to workflow_dispatch (e.g., { environment: "preview" }). */
+  workflowInputs: z.record(z.string(), z.string()).optional(),
+});
+export type QaCheckConfig = z.infer<typeof QaCheckConfigSchema>;
+
+/**
+ * Result of evalQaCheck. Six kinds — more nuanced than the other triggers'
+ * { pass, reason } because the async lifecycle requires the scheduler to
+ * dispatch different actions per kind.
+ */
+export type QaTriggerResult =
+  | { pass: true; reason: string }
+  | { pass: false; reason: "qa_failed"; runId: number; conclusion: string }
+  | { pass: false; reason: "qa_running"; runId: number }
+  | { pass: false; reason: "qa_timed_out"; runId: number }
+  | { pass: false; reason: "qa_needs_trigger" }
+  | { pass: false; reason: "qa_no_workflow" };
+
+/** Snapshot of the most-recent in-flight QA run for (repo, branch). Null when nothing in flight. */
+export interface QaRunSnapshot {
+  runId: number;
+  runSha: string;
+  /** When the run was triggered (decided_at on the persisting row). Used for timeout calculation. */
+  triggeredAt: Date;
+}
+```
+
+- [ ] **Step 4: Extend `release-manager/types.ts`**
+
+In `packages/core/src/release-manager/types.ts`, add an import:
+
+```ts
+import { QaCheckConfigSchema, type QaRunSnapshot, type QaTriggerResult } from "../qa/types.js";
+```
+
+Extend `ReleaseManagerTriggersSchema` to add `qaCheck` as an optional field:
+
+```ts
+export const ReleaseManagerTriggersSchema = z.object({
+  mergedPRsSince: z.number().int().positive().optional(),
+  timeSinceLastHours: z.number().int().positive().optional(),
+  ciGreenForMinutes: z.number().int().positive().optional(),
+  requireSlackApproval: z.boolean().default(false),
+  /** BEC-136: trigger workflow + gate release on its result. */
+  qaCheck: QaCheckConfigSchema.optional(),
+});
+```
+
+Update the superRefine "at least one trigger" guard to recognize `qaCheck`:
+
+```ts
+.superRefine((cfg, ctx) => {
+  const t = cfg.triggers;
+  const anyTrigger =
+    t.mergedPRsSince !== undefined ||
+    t.timeSinceLastHours !== undefined ||
+    t.ciGreenForMinutes !== undefined ||
+    t.requireSlackApproval === true ||
+    t.qaCheck !== undefined;
+  if (!anyTrigger) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["triggers"],
+      message: "at least one trigger field must be set (mergedPRsSince, timeSinceLastHours, ciGreenForMinutes, requireSlackApproval=true, or qaCheck)",
+    });
+  }
+  // (existing requireSlackApproval/slackChannel guard unchanged)
+  if (t.requireSlackApproval === true && !cfg.slackChannel) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["slackChannel"],
+      message: "slackChannel is required when triggers.requireSlackApproval=true",
+    });
+  }
+});
+```
+
+Extend `CollectedState` with `qaRun` field:
+
+```ts
+export interface CollectedState {
+  // ... existing fields (lastTag, headSha, ciStatus, etc.) ...
+  /** BEC-136: in-flight QA run for this (repo, branch). Null when nothing in flight. */
+  qaRun: QaRunSnapshot | null;
+}
+```
+
+Extend `DecisionResult` with `qaActionNeeded`:
+
+```ts
+export type DecisionResult =
+  | { kind: "fire"; reason: string }
+  | { kind: "skip"; reason: string; qaActionNeeded?: QaTriggerResult }
+  | { kind: "awaiting-approval"; reason: string };
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-config.test.ts src/__tests__/release-manager-config.test.ts
+```
+
+Expected: PASS — new qa-config tests + existing release-manager-config tests all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/qa/types.ts packages/core/src/release-manager/types.ts packages/core/src/__tests__/qa-config.test.ts
+git commit -m "feat(core): QaCheckConfigSchema + extend ReleaseManagerTriggers with qaCheck (BEC-136)"
+```
+
+---
+
+## Task 8: GitHub IO — triggerWorkflow / pollWorkflowRun / workflowFileExists
+
+**Files:**
+- Create: `packages/core/src/qa/github.ts`
+- Test: `packages/core/src/__tests__/qa-github.test.ts` (CREATE)
+
+This module wraps Octokit calls and emits the `qa.run_triggered` audit event after dispatch.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/qa-github.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  triggerWorkflow,
+  pollWorkflowRun,
+  workflowFileExists,
+} from "../qa/github.js";
+import type { AnyDb } from "../db/client.js";
+
+const fakeDb = {} as AnyDb;
+const owner = "org";
+const repo = "repo";
+
+function makeMockOctokit(over: any = {}) {
+  return {
+    actions: {
+      createWorkflowDispatch: vi.fn(async () => ({ status: 204 })),
+      listWorkflowRuns: vi.fn(async () => ({
+        data: { workflow_runs: [{ id: 99999, head_sha: "abc123", status: "in_progress", conclusion: null, created_at: "2026-05-04T12:00:00Z", run_started_at: "2026-05-04T12:00:00Z" }] },
+      })),
+      getWorkflowRun: vi.fn(async () => ({
+        data: { id: 99999, head_sha: "abc123", status: "completed", conclusion: "success", run_started_at: "2026-05-04T12:00:00Z", updated_at: "2026-05-04T12:10:00Z" },
+      })),
+    },
+    repos: {
+      getContent: vi.fn(async () => ({ data: { type: "file", path: ".github/workflows/smoke.yml" } })),
+    },
+    ...over,
+  } as any;
+}
+
+describe("workflowFileExists", () => {
+  it("returns true when file content is fetched successfully", async () => {
+    const octokit = makeMockOctokit();
+    const exists = await workflowFileExists({ octokit, owner, repo, path: ".github/workflows/smoke.yml", ref: "main" });
+    expect(exists).toBe(true);
+    expect(octokit.repos.getContent).toHaveBeenCalledWith({ owner, repo, path: ".github/workflows/smoke.yml", ref: "main" });
+  });
+  it("returns false on 404", async () => {
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => {
+          const err: any = new Error("Not Found");
+          err.status = 404;
+          throw err;
+        }),
+      },
+    });
+    const exists = await workflowFileExists({ octokit, owner, repo, path: ".github/workflows/smoke.yml", ref: "main" });
+    expect(exists).toBe(false);
+  });
+  it("rethrows on 5xx", async () => {
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => {
+          const err: any = new Error("Server Error");
+          err.status = 500;
+          throw err;
+        }),
+      },
+    });
+    await expect(
+      workflowFileExists({ octokit, owner, repo, path: ".github/workflows/smoke.yml", ref: "main" })
+    ).rejects.toThrow("Server Error");
+  });
+});
+
+describe("triggerWorkflow", () => {
+  it("calls createWorkflowDispatch then finds the new run by SHA", async () => {
+    const octokit = makeMockOctokit();
+    const result = await triggerWorkflow({
+      octokit,
+      db: fakeDb,
+      owner,
+      repo,
+      repoUrl: `https://github.com/${owner}/${repo}`,
+      branch: "main",
+      workflow: ".github/workflows/smoke.yml",
+      ref: "abc123",
+      inputs: { environment: "preview" },
+    });
+    expect(result.kind).toBe("ok");
+    expect(result.kind === "ok" && result.runId).toBe(99999);
+    expect(octokit.actions.createWorkflowDispatch).toHaveBeenCalledWith({
+      owner,
+      repo,
+      workflow_id: ".github/workflows/smoke.yml",
+      ref: "abc123",
+      inputs: { environment: "preview" },
+    });
+  });
+
+  it("returns dispatch_404 on 404 (workflow file missing)", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const err: any = new Error("Not Found");
+          err.status = 404;
+          throw err;
+        }),
+      },
+    });
+    const result = await triggerWorkflow({
+      octokit, db: fakeDb, owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, branch: "main",
+      workflow: ".github/workflows/smoke.yml", ref: "abc123",
+    });
+    expect(result.kind).toBe("dispatch_404");
+  });
+
+  it("returns dispatch_422 on 422 (workflow not workflow_dispatch-triggered)", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const err: any = new Error("Unprocessable Entity");
+          err.status = 422;
+          throw err;
+        }),
+      },
+    });
+    const result = await triggerWorkflow({
+      octokit, db: fakeDb, owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, branch: "main",
+      workflow: ".github/workflows/smoke.yml", ref: "abc123",
+    });
+    expect(result.kind).toBe("dispatch_422");
+  });
+
+  it("returns dispatch_error on 5xx", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const err: any = new Error("Server Error");
+          err.status = 502;
+          throw err;
+        }),
+      },
+    });
+    const result = await triggerWorkflow({
+      octokit, db: fakeDb, owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, branch: "main",
+      workflow: ".github/workflows/smoke.yml", ref: "abc123",
+    });
+    expect(result.kind).toBe("dispatch_error");
+    expect(result.kind === "dispatch_error" && result.message).toMatch(/Server Error/);
+  });
+});
+
+describe("pollWorkflowRun", () => {
+  it("returns running for in_progress runs", async () => {
+    const octokit = makeMockOctokit();
+    const result = await pollWorkflowRun({ octokit, owner, repo, runId: 99999 });
+    expect(result.kind).toBe("running");
+  });
+
+  it("returns completed with conclusion=success", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        getWorkflowRun: vi.fn(async () => ({
+          data: { id: 99999, status: "completed", conclusion: "success", run_started_at: "2026-05-04T12:00:00Z", updated_at: "2026-05-04T12:10:00Z" },
+        })),
+      },
+    });
+    const result = await pollWorkflowRun({ octokit, owner, repo, runId: 99999 });
+    expect(result.kind).toBe("completed");
+    expect(result.kind === "completed" && result.conclusion).toBe("success");
+    expect(result.kind === "completed" && result.durationMs).toBe(10 * 60 * 1000);
+  });
+
+  it("returns completed with conclusion=failure", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        getWorkflowRun: vi.fn(async () => ({
+          data: { id: 99999, status: "completed", conclusion: "failure", run_started_at: "2026-05-04T12:00:00Z", updated_at: "2026-05-04T12:05:00Z" },
+        })),
+      },
+    });
+    const result = await pollWorkflowRun({ octokit, owner, repo, runId: 99999 });
+    expect(result.kind).toBe("completed");
+    expect(result.kind === "completed" && result.conclusion).toBe("failure");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-github.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `qa/github.ts`**
+
+Write `packages/core/src/qa/github.ts`:
+
+```ts
+import type { Octokit } from "@octokit/rest";
+import type { AnyDb } from "../db/client.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
+import { qaRunTriggeredEvent } from "../audit/events.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "Qa:github" });
+
+export interface WorkflowFileExistsInput {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  path: string;
+  ref: string;
+}
+
+/**
+ * Returns true when the workflow file exists at the given ref, false on 404,
+ * rethrows on other errors. The workflow file existence check uses the
+ * contents API rather than the actions API because the actions API requires
+ * the workflow to also be registered (i.e., GitHub must have parsed it on a
+ * push event), which can lag behind the file appearing in the repo.
+ */
+export async function workflowFileExists(input: WorkflowFileExistsInput): Promise<boolean> {
+  const { octokit, owner, repo, path, ref } = input;
+  try {
+    await octokit.repos.getContent({ owner, repo, path, ref });
+    return true;
+  } catch (err: any) {
+    if (err?.status === 404) return false;
+    throw err;
+  }
+}
+
+export interface TriggerWorkflowInput {
+  octokit: Octokit;
+  db: AnyDb;
+  owner: string;
+  repo: string;
+  repoUrl: string;
+  branch: string;
+  workflow: string;          // e.g. ".github/workflows/smoke.yml"
+  ref: string;               // SHA to dispatch against
+  inputs?: Record<string, string>;
+}
+
+export type TriggerWorkflowResult =
+  | { kind: "ok"; runId: number }
+  | { kind: "dispatch_404" }
+  | { kind: "dispatch_422"; message: string }
+  | { kind: "dispatch_error"; message: string };
+
+/**
+ * Trigger a workflow_dispatch and find the resulting run.
+ *
+ * GitHub's workflow_dispatch API returns 204 No Content on success — it does
+ * NOT return the run ID. To discover the run, we list runs for the workflow
+ * filtered by SHA + workflow path and take the most-recent. There's a brief
+ * eventual-consistency window (typically <5s) where the run may not appear yet;
+ * the caller's tick will retry naturally on the next iteration.
+ *
+ * On dispatch failure, the result is classified into 3 kinds so the scheduler
+ * can route appropriately:
+ *   - dispatch_404: drop into the qa_no_workflow path (file gap issue)
+ *   - dispatch_422: workflow exists but lacks `on: workflow_dispatch` — write skip
+ *   - dispatch_error: 5xx / rate limit — retry on next tick (uses retry counter)
+ *
+ * Emits qa.run_triggered audit event on the "ok" path.
+ */
+export async function triggerWorkflow(
+  input: TriggerWorkflowInput,
+): Promise<TriggerWorkflowResult> {
+  const { octokit, db, owner, repo, repoUrl, branch, workflow, ref, inputs } = input;
+
+  try {
+    await octokit.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: workflow,
+      ref,
+      ...(inputs ? { inputs } : {}),
+    });
+  } catch (err: any) {
+    const status = err?.status;
+    const msg = err?.message ?? String(err);
+    if (status === 404) return { kind: "dispatch_404" };
+    if (status === 422) return { kind: "dispatch_422", message: msg };
+    return { kind: "dispatch_error", message: msg };
+  }
+
+  // Find the just-triggered run. List the most recent runs for this workflow
+  // filtered by head SHA. Take the first match (most recent dispatch on this SHA).
+  let runId: number | null = null;
+  try {
+    const list = await octokit.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: workflow as any, // octokit accepts string filename
+      head_sha: ref,
+      per_page: 5,
+    });
+    const runs = (list as any).data?.workflow_runs ?? [];
+    runId = runs[0]?.id ?? null;
+  } catch (err) {
+    log.warn({ err, workflow, ref }, "listWorkflowRuns failed after dispatch — run will be picked up next tick");
+  }
+
+  if (runId === null) {
+    // Eventual-consistency window. Treat as needs-retry so the next tick re-evaluates.
+    return { kind: "dispatch_error", message: "dispatch succeeded but run not found yet" };
+  }
+
+  void logAuditEventUnchecked(
+    db,
+    qaRunTriggeredEvent({ repoUrl, branch, workflow, runId, sha: ref }),
+  );
+
+  return { kind: "ok", runId };
+}
+
+export interface PollWorkflowRunInput {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
+export type PollWorkflowRunResult =
+  | { kind: "running" }
+  | { kind: "completed"; conclusion: string; durationMs: number; startedAt: Date };
+
+export async function pollWorkflowRun(
+  input: PollWorkflowRunInput,
+): Promise<PollWorkflowRunResult> {
+  const { octokit, owner, repo, runId } = input;
+  const res = await octokit.actions.getWorkflowRun({ owner, repo, run_id: runId });
+  const data = (res as any).data;
+  const status: string = data?.status ?? "queued";
+  const conclusion: string | null = data?.conclusion ?? null;
+
+  if (status !== "completed") return { kind: "running" };
+
+  // Completed run — compute duration from run_started_at to updated_at.
+  const startedAtStr = data?.run_started_at ?? data?.created_at;
+  const updatedAtStr = data?.updated_at ?? new Date().toISOString();
+  const startedAt = startedAtStr ? new Date(startedAtStr) : new Date();
+  const updatedAt = new Date(updatedAtStr);
+  const durationMs = Math.max(0, updatedAt.getTime() - startedAt.getTime());
+
+  return {
+    kind: "completed",
+    conclusion: conclusion ?? "neutral",
+    durationMs,
+    startedAt,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-github.test.ts
+```
+
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/qa/github.ts packages/core/src/__tests__/qa-github.test.ts
+git commit -m "feat(qa): triggerWorkflow / pollWorkflowRun / workflowFileExists (BEC-136)"
+```
+
+---
+
+## Task 9: Linear gap-issue filing — qa/gap.ts
+
+**Files:**
+- Create: `packages/core/src/qa/gap.ts`
+- Test: `packages/core/src/__tests__/qa-gap.test.ts` (CREATE)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/qa-gap.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { eq, and, isNull } from "drizzle-orm";
+import { createDb } from "../db/index.js";
+import { qaGapIssues } from "../db/schema.js";
+import { fileGapIssue } from "../qa/gap.js";
+
+function tmpDbPath(): string {
+  const id = randomBytes(8).toString("hex");
+  return `/tmp/laf-qa-gap-fn-${id}.sqlite`;
+}
+
+describe("fileGapIssue", () => {
+  const paths: string[] = [];
+  let db: any;
+  const repoUrl = "https://github.com/org/repo";
+  const branch = "main";
+  const workflowPath = ".github/workflows/smoke.yml";
+
+  beforeEach(async () => {
+    const path = tmpDbPath();
+    paths.push(path);
+    const created = await createDb({ driver: "sqlite", connectionString: path });
+    db = created as any;
+  });
+
+  afterEach(() => {
+    for (const p of paths) {
+      try { unlinkSync(p); } catch {}
+      try { unlinkSync(p + "-wal"); } catch {}
+      try { unlinkSync(p + "-shm"); } catch {}
+    }
+    paths.length = 0;
+  });
+
+  function makeMockLinear(over: any = {}) {
+    return {
+      createIssue: vi.fn(async () => ({
+        issue: Promise.resolve({ identifier: "BEC-150", url: "https://linear.app/beckerspace/issue/BEC-150" }),
+      })),
+      ...over,
+    };
+  }
+
+  it("files a new issue when none exists, persists qa_gap_issues row", async () => {
+    const linear = makeMockLinear();
+    const result = await fileGapIssue({
+      db,
+      linear: linear as any,
+      repoUrl,
+      branch,
+      workflowPath,
+      linearTeamId: "team-uuid-123",
+    });
+    expect(result.kind).toBe("filed");
+    expect(result.kind === "filed" && result.linearIssueId).toBe("BEC-150");
+    expect(linear.createIssue).toHaveBeenCalledTimes(1);
+    const rows = await db.select().from(qaGapIssues).where(
+      and(eq(qaGapIssues.repoUrl, repoUrl), isNull(qaGapIssues.resolvedAt)),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].linearIssueId).toBe("BEC-150");
+  });
+
+  it("is idempotent — second call with existing open row is a no-op", async () => {
+    const linear = makeMockLinear();
+    await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    linear.createIssue.mockClear();
+
+    const result = await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    expect(result.kind).toBe("already_filed");
+    expect(result.kind === "already_filed" && result.linearIssueId).toBe("BEC-150");
+    expect(linear.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("re-files when the previous row was resolved", async () => {
+    const linear = makeMockLinear();
+    await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+
+    // Resolve the existing row
+    await db.update(qaGapIssues)
+      .set({ resolvedAt: new Date() })
+      .where(eq(qaGapIssues.linearIssueId, "BEC-150"));
+
+    // Update the mock to return a new ID for the second filing
+    linear.createIssue.mockResolvedValueOnce({
+      issue: Promise.resolve({ identifier: "BEC-160", url: "https://linear.app/beckerspace/issue/BEC-160" }),
+    });
+
+    const result = await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    expect(result.kind).toBe("filed");
+    expect(result.kind === "filed" && result.linearIssueId).toBe("BEC-160");
+    expect(linear.createIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns linear_error on Linear API failure", async () => {
+    const linear = makeMockLinear({
+      createIssue: vi.fn(async () => { throw new Error("Linear unauthorized"); }),
+    });
+    const result = await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    expect(result.kind).toBe("linear_error");
+    expect(result.kind === "linear_error" && result.message).toMatch(/unauthorized/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-gap.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `qa/gap.ts`**
+
+Write `packages/core/src/qa/gap.ts`:
+
+```ts
+import { randomUUID } from "node:crypto";
+import { eq, and, isNull } from "drizzle-orm";
+import type { LinearClient } from "@linear/sdk";
+import type { AnyDb } from "../db/client.js";
+import { qaGapIssues } from "../db/schema.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
+import { qaGapIssueFiledEvent } from "../audit/events.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "Qa:gap" });
+
+export interface FileGapIssueInput {
+  db: AnyDb;
+  linear: LinearClient;
+  repoUrl: string;
+  branch: string;
+  workflowPath: string;
+  linearTeamId: string;
+}
+
+export type FileGapIssueResult =
+  | { kind: "filed"; linearIssueId: string }
+  | { kind: "already_filed"; linearIssueId: string }
+  | { kind: "linear_error"; message: string };
+
+const ISSUE_TITLE_PREFIX = "QA workflow missing";
+const ISSUE_BODY_TEMPLATE = `# QA workflow missing
+
+The Release Manager attempted to verify a QA workflow for this branch but could not find the configured file.
+
+**Repo:** {repoUrl}
+**Branch:** {branch}
+**Expected workflow path:** \`{workflowPath}\`
+
+## What this means
+
+When the Release Manager fires a release on this branch, it expects a GitHub Actions workflow at the path above to verify the merge commit before tagging. The file is currently missing, so the agent has paused all release activity for this branch until you add it.
+
+## How to resolve
+
+1. Add a workflow file at \`{workflowPath}\` that:
+   - Has \`on: workflow_dispatch\` (so the Release Manager can trigger it)
+   - Runs your smoke / integration tests against the merge commit
+   - Exits zero on success and non-zero on failure
+
+2. Commit and push the workflow file. The Release Manager will detect it on the next tick and resume normal release decisions.
+
+3. Once the workflow has run green at least once, this Linear issue can be closed manually.
+
+## Reference
+
+The Release Manager and QA agent are documented at \`docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md\` in the urateam repo. v1 only supports rule-based detection (file exists / file missing) — there is no automatic test scaffolding in v1.
+
+🤖 Filed by urateam Release Manager (BEC-136).`;
+
+export async function fileGapIssue(input: FileGapIssueInput): Promise<FileGapIssueResult> {
+  const { db, linear, repoUrl, branch, workflowPath, linearTeamId } = input;
+
+  // Idempotency check: is there already an open gap row for this (repo, branch, workflow)?
+  const existing = await (db as any)
+    .select({ linearIssueId: qaGapIssues.linearIssueId })
+    .from(qaGapIssues)
+    .where(
+      and(
+        eq(qaGapIssues.repoUrl, repoUrl),
+        eq(qaGapIssues.branch, branch),
+        eq(qaGapIssues.workflowPath, workflowPath),
+        isNull(qaGapIssues.resolvedAt),
+      ),
+    )
+    .limit(1);
+  if (existing?.[0]?.linearIssueId) {
+    return { kind: "already_filed", linearIssueId: existing[0].linearIssueId };
+  }
+
+  // No open row — file a new Linear issue.
+  let identifier: string;
+  try {
+    const body = ISSUE_BODY_TEMPLATE
+      .replace("{repoUrl}", repoUrl)
+      .replace(/{branch}/g, branch)
+      .replace(/{workflowPath}/g, workflowPath);
+    const created = await linear.createIssue({
+      teamId: linearTeamId,
+      title: `${ISSUE_TITLE_PREFIX} for ${repoUrl} (${branch})`,
+      description: body,
+    });
+    const issue = await (created as any).issue;
+    identifier = issue?.identifier ?? "";
+    if (!identifier) {
+      return { kind: "linear_error", message: "Linear createIssue returned no identifier" };
+    }
+  } catch (err: any) {
+    const msg = err?.message ?? String(err);
+    log.error({ err, repoUrl, branch, workflowPath }, "Linear createIssue failed");
+    return { kind: "linear_error", message: msg };
+  }
+
+  // Persist the qa_gap_issues row to enforce idempotency.
+  await (db as any).insert(qaGapIssues).values({
+    id: `qg_${randomUUID()}`,
+    repoUrl,
+    branch,
+    workflowPath,
+    linearIssueId: identifier,
+    filedAt: new Date(),
+  });
+
+  void logAuditEventUnchecked(
+    db,
+    qaGapIssueFiledEvent({ repoUrl, branch, workflowPath, linearIssueId: identifier }),
+  );
+
+  return { kind: "filed", linearIssueId: identifier };
+}
+
+/** Mark the open gap-issue row as resolved (called when the workflow file appears). */
+export async function markGapResolved(input: {
+  db: AnyDb;
+  repoUrl: string;
+  branch: string;
+  workflowPath: string;
+}): Promise<void> {
+  const { db, repoUrl, branch, workflowPath } = input;
+  await (db as any)
+    .update(qaGapIssues)
+    .set({ resolvedAt: new Date() })
+    .where(
+      and(
+        eq(qaGapIssues.repoUrl, repoUrl),
+        eq(qaGapIssues.branch, branch),
+        eq(qaGapIssues.workflowPath, workflowPath),
+        isNull(qaGapIssues.resolvedAt),
+      ),
+    );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-gap.test.ts
+```
+
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/qa/gap.ts packages/core/src/__tests__/qa-gap.test.ts
+git commit -m "feat(qa): fileGapIssue with DB idempotency + markGapResolved (BEC-136)"
+```
+
+---
+
+## Task 10: evalQaCheck pure function
+
+**Files:**
+- Modify: `packages/core/src/release-manager/triggers.ts` (add `evalQaCheck`)
+- Test: `packages/core/src/__tests__/qa-eval.test.ts` (CREATE)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/qa-eval.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { evalQaCheck } from "../release-manager/triggers.js";
+import type { QaCheckConfig, QaRunSnapshot } from "../qa/types.js";
+
+const NOW = new Date("2026-05-04T12:00:00Z");
+const cfg: QaCheckConfig = {
+  workflow: ".github/workflows/smoke.yml",
+  timeoutMinutes: 30,
+  linearTeamId: "team-uuid-123",
+};
+
+describe("evalQaCheck", () => {
+  it("returns qa_no_workflow when workflowFileExists=false", () => {
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: false,
+      qaRun: null,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_no_workflow");
+  });
+
+  it("returns qa_needs_trigger when workflow exists but no run for current SHA", () => {
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun: null,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_needs_trigger");
+  });
+
+  it("returns qa_needs_trigger when in-flight run is for stale SHA", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "old_sha",
+      triggeredAt: new Date(NOW.getTime() - 5 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_needs_trigger");
+  });
+
+  it("returns qa_running when run is in flight for current SHA, not yet timed out", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 5 * 60 * 1000), // 5 min ago, < 30 min timeout
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_running");
+    expect(result.reason === "qa_running" && result.runId).toBe(99999);
+  });
+
+  it("returns qa_timed_out when run has been running > timeoutMinutes", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 35 * 60 * 1000), // 35 min ago, > 30 min timeout
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_timed_out");
+  });
+
+  it("returns pass:true when run completed with conclusion=success", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 10 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: "success",
+      now: NOW,
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toMatch(/qa passed/i);
+  });
+
+  it("returns qa_failed for conclusion=failure", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 10 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: "failure",
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_failed");
+    expect(result.reason === "qa_failed" && result.conclusion).toBe("failure");
+  });
+
+  it("returns qa_failed for conclusion=cancelled", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 10 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: "cancelled",
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_failed");
+    expect(result.reason === "qa_failed" && result.conclusion).toBe("cancelled");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-eval.test.ts
+```
+
+Expected: FAIL — `evalQaCheck` not exported from triggers.
+
+- [ ] **Step 3: Implement `evalQaCheck` in `release-manager/triggers.ts`**
+
+Append to `packages/core/src/release-manager/triggers.ts`:
+
+```ts
+import type { QaCheckConfig, QaRunSnapshot, QaTriggerResult } from "../qa/types.js";
+
+export interface EvalQaCheckInput {
+  qaConfig: QaCheckConfig;
+  headSha: string;
+  /** Whether the configured workflow file exists at headSha (per workflowFileExists). */
+  workflowFileExists: boolean;
+  /** Most recent in-flight run snapshot, or null when nothing tracked. */
+  qaRun: QaRunSnapshot | null;
+  /** When qaRun is for current SHA AND the run has completed: the GitHub conclusion string. Null otherwise. */
+  runConclusion: string | null;
+  now?: Date;
+}
+
+/**
+ * Pure decision: given current state and qaCheck config, return one of 6 result kinds.
+ *
+ * Ordering inside the function:
+ *   1. If workflow file is missing → qa_no_workflow (file gap issue + skip)
+ *   2. If no in-flight run OR the run is for a stale SHA → qa_needs_trigger (dispatch)
+ *   3. If completed: success → pass:true, else → qa_failed (with conclusion)
+ *   4. If still running and elapsed > timeoutMinutes → qa_timed_out
+ *   5. Otherwise → qa_running (await next tick)
+ */
+export function evalQaCheck(input: EvalQaCheckInput): QaTriggerResult {
+  const { qaConfig, headSha, workflowFileExists, qaRun, runConclusion, now = new Date() } = input;
+
+  if (!workflowFileExists) {
+    return { pass: false, reason: "qa_no_workflow" };
+  }
+
+  if (qaRun === null || qaRun.runSha !== headSha) {
+    return { pass: false, reason: "qa_needs_trigger" };
+  }
+
+  // We have an in-flight run for current SHA.
+  if (runConclusion !== null) {
+    if (runConclusion === "success") {
+      return { pass: true, reason: "qa passed" };
+    }
+    return { pass: false, reason: "qa_failed", runId: qaRun.runId, conclusion: runConclusion };
+  }
+
+  // Still running — check timeout.
+  const elapsedMs = now.getTime() - qaRun.triggeredAt.getTime();
+  const timeoutMs = qaConfig.timeoutMinutes * 60 * 1000;
+  if (elapsedMs > timeoutMs) {
+    return { pass: false, reason: "qa_timed_out", runId: qaRun.runId };
+  }
+  return { pass: false, reason: "qa_running", runId: qaRun.runId };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/qa-eval.test.ts
+```
+
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/release-manager/triggers.ts packages/core/src/__tests__/qa-eval.test.ts
+git commit -m "feat(release-manager): evalQaCheck — 6-kind QA decision (BEC-136)"
+```
+
+---
+
+## Task 11: qa/index.ts barrel + core/index.ts re-export
+
+**Files:**
+- Create: `packages/core/src/qa/index.ts`
+- Modify: `packages/core/src/index.ts` (add qa re-export + new types if needed)
+
+- [ ] **Step 1: Create the barrel**
+
+Write `packages/core/src/qa/index.ts`:
+
+```ts
+export * from "./types.js";
+export * from "./github.js";
+export * from "./gap.js";
+```
+
+- [ ] **Step 2: Re-export from core**
+
+Open `packages/core/src/index.ts`. Find the `export * from "./release-manager/index.js";` line (added by BEC-135). After it, append:
+
+```ts
+export * from "./qa/index.js";
+```
+
+- [ ] **Step 3: Verify TS compiles**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx tsc --noEmit 2>&1 | head -10
+```
+
+Expected: clean (no errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/qa/index.ts packages/core/src/index.ts
+git commit -m "feat(qa): barrel re-export + plumb qa module from core (BEC-136)"
+```
+
+---
+
+## Task 12: Integrate evalQaCheck into decide() at slot 4
+
+**Files:**
+- Modify: `packages/core/src/release-manager/decide.ts`
+- Modify: `packages/core/src/__tests__/release-manager-decide.test.ts` (extend with 3 new tests)
+
+- [ ] **Step 1: Write failing tests by extending the existing decide test file**
+
+Append to `packages/core/src/__tests__/release-manager-decide.test.ts`:
+
+```ts
+import type { QaCheckConfig, QaRunSnapshot } from "../qa/types.js";
+
+describe("decide() qaCheck slot-4 integration", () => {
+  const qaConfig: QaCheckConfig = {
+    workflow: ".github/workflows/smoke.yml",
+    timeoutMinutes: 30,
+    linearTeamId: "team-uuid-123",
+  };
+
+  it("evaluates qaCheck after ciGreenForMinutes — qaCheck failure trumps requireSlackApproval", () => {
+    // mergedPRsSince + ciGreen pass; qaCheck fails (no workflow); requireSlackApproval would also fail
+    // expected: skip with qa_no_workflow (NOT awaiting-approval)
+    const r = decide(
+      baseState({
+        // qaCheck inputs piped through state
+        qaWorkflowFileExists: false,
+        qaRun: null,
+        qaRunConclusion: null,
+        hasFreshApproval: false,
+      }),
+      {
+        mergedPRsSince: 5,
+        ciGreenForMinutes: 30,
+        qaCheck: qaConfig,
+        requireSlackApproval: true,
+      },
+      NOW,
+    );
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("qa_no_workflow");
+    expect(r.qaActionNeeded?.reason).toBe("qa_no_workflow");
+  });
+
+  it("bubbles qaActionNeeded for qa_needs_trigger when workflow exists but no run for SHA", () => {
+    const r = decide(
+      baseState({
+        qaWorkflowFileExists: true,
+        qaRun: null,
+        qaRunConclusion: null,
+      }),
+      { mergedPRsSince: 5, qaCheck: qaConfig },
+      NOW,
+    );
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("qa_needs_trigger");
+    expect(r.qaActionNeeded?.reason).toBe("qa_needs_trigger");
+  });
+
+  it("returns fire when qaCheck passes alongside other passing triggers", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "fedcba0",
+      triggeredAt: new Date(NOW.getTime() - 5 * 60 * 1000),
+    };
+    const r = decide(
+      baseState({
+        qaWorkflowFileExists: true,
+        qaRun,
+        qaRunConclusion: "success",
+      }),
+      { mergedPRsSince: 5, qaCheck: qaConfig },
+      NOW,
+    );
+    expect(r.kind).toBe("fire");
+  });
+});
+```
+
+Update the existing `baseState` helper at the top of the file to include the new qa fields:
+
+```ts
+function baseState(over: Partial<CollectedState> & {
+  qaWorkflowFileExists?: boolean;
+  qaRun?: QaRunSnapshot | null;
+  qaRunConclusion?: string | null;
+} = {}): CollectedState & {
+  qaWorkflowFileExists?: boolean;
+  qaRunConclusion?: string | null;
+} {
+  return {
+    lastTag: "v1.2.3",
+    lastTagSha: "abcdef0",
+    lastTagAt: new Date(NOW.getTime() - 48 * 3600 * 1000),
+    headSha: "fedcba0",
+    mergedCommitsSinceLastTag: 7,
+    commitsSinceLastTag: [],
+    ciStatus: "green",
+    ciGreenSince: new Date(NOW.getTime() - 60 * 60 * 1000),
+    hasFreshApproval: true,
+    freshApprovalApprover: "U123",
+    manualTagDetected: false,
+    qaRun: null,
+    qaWorkflowFileExists: undefined,
+    qaRunConclusion: null,
+    ...over,
+  };
+}
+```
+
+Note: the test fields `qaWorkflowFileExists` and `qaRunConclusion` are NOT on `CollectedState` — they're piped separately into `decide()` because they require live IO (Octokit calls) that the scheduler does separately. The `decide()` signature gains an optional second arg `qaState: { workflowFileExists, runConclusion }` for tests; production code passes them too.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/release-manager-decide.test.ts
+```
+
+Expected: FAIL on the new tests (evalQaCheck not yet wired into decide).
+
+- [ ] **Step 3: Update `decide.ts` to integrate evalQaCheck at slot 4**
+
+In `packages/core/src/release-manager/decide.ts`, update the `decide()` signature and add the qaCheck call before the requireSlackApproval block:
+
+```ts
+import type { CollectedState, DecisionResult } from "./types.js";
+import type { ReleaseManagerTriggers } from "./types.js";
+import {
+  evalMergedPRsSince,
+  evalTimeSinceLastHours,
+  evalCiGreenForMinutes,
+  evalRequireSlackApproval,
+  evalQaCheck,
+} from "./triggers.js";
+
+export interface DecideQaState {
+  /** Whether the configured QA workflow file exists at state.headSha. Computed by scheduler. */
+  workflowFileExists: boolean;
+  /** When qaRun is for current SHA AND complete: the GitHub conclusion. Null otherwise. */
+  runConclusion: string | null;
+}
+
+export function decide(
+  state: CollectedState,
+  triggers: ReleaseManagerTriggers,
+  now: Date = new Date(),
+  qaState?: DecideQaState,
+): DecisionResult {
+  if (triggers.mergedPRsSince !== undefined) {
+    const r = evalMergedPRsSince(state.mergedCommitsSinceLastTag, triggers.mergedPRsSince);
+    if (!r.pass) return { kind: "skip", reason: r.reason };
+  }
+
+  if (triggers.timeSinceLastHours !== undefined) {
+    const r = evalTimeSinceLastHours(state.lastTagAt, triggers.timeSinceLastHours, now);
+    if (!r.pass) return { kind: "skip", reason: r.reason };
+  }
+
+  if (triggers.ciGreenForMinutes !== undefined) {
+    const r = evalCiGreenForMinutes(state.ciStatus, state.ciGreenSince, triggers.ciGreenForMinutes, now);
+    if (!r.pass) return { kind: "skip", reason: r.reason };
+  }
+
+  // BEC-136: QA check at slot 4 (before requireSlackApproval).
+  if (triggers.qaCheck !== undefined) {
+    const qa = qaState ?? { workflowFileExists: false, runConclusion: null };
+    const r = evalQaCheck({
+      qaConfig: triggers.qaCheck,
+      headSha: state.headSha,
+      workflowFileExists: qa.workflowFileExists,
+      qaRun: state.qaRun,
+      runConclusion: qa.runConclusion,
+      now,
+    });
+    if (!r.pass) return { kind: "skip", reason: r.reason, qaActionNeeded: r };
+  }
+
+  if (triggers.requireSlackApproval === true) {
+    const r = evalRequireSlackApproval(true, state.hasFreshApproval);
+    if (!r.pass) return { kind: "awaiting-approval", reason: r.reason };
+  }
+
+  return { kind: "fire", reason: "all triggers passed" };
+}
+```
+
+- [ ] **Step 4: Run all decide tests to verify they pass**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/release-manager-decide.test.ts
+```
+
+Expected: PASS — original 8 tests + 3 new tests = 11 green. The 3 new tests pipe `qaWorkflowFileExists` / `qaRunConclusion` from baseState into a second decide() argument; you may need to thread these through the test helper (see Step 1).
+
+If the integration is awkward, refactor: have `baseState` return `{ state, qaState }` and update the existing tests to pass `qaState` as the 4th arg.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/release-manager/decide.ts packages/core/src/__tests__/release-manager-decide.test.ts
+git commit -m "feat(release-manager): wire evalQaCheck into decide() at slot 4 (BEC-136)"
+```
+
+---
+
+## Task 13: Update collectState() to surface qaRun
+
+**Files:**
+- Modify: `packages/core/src/release-manager/state.ts` (add qaRun lookup)
+
+This task makes `collectState()` populate the new `state.qaRun` field by querying the most-recent `release_decisions` row with non-null `qa_run_id`. No new test file — this is exercised by Task 14's scheduler tests.
+
+- [ ] **Step 1: Update `collectState()` in state.ts**
+
+In `packages/core/src/release-manager/state.ts`, find the existing fresh-approvals lookup block (around lines 127-145). Add a new section AFTER it (and before the `return` statement) for qaRun:
+
+```ts
+  // 7. BEC-136: most-recent in-flight QA run snapshot.
+  const qaRunRows = await (db as any)
+    .select({
+      qaRunId: releaseDecisions.qaRunId,
+      qaRunSha: releaseDecisions.qaRunSha,
+      decidedAt: releaseDecisions.decidedAt,
+    })
+    .from(releaseDecisions)
+    .where(
+      and(
+        eq(releaseDecisions.repoUrl, repoUrl),
+        eq(releaseDecisions.branch, branch),
+        // qa_run_id IS NOT NULL — drizzle's "is not null" via not(isNull(...)) or sql template
+      ),
+    )
+    .orderBy(desc(releaseDecisions.decidedAt))
+    .limit(20);
+  // Take the most recent row that actually has a qa_run_id.
+  const latestQaRow = qaRunRows.find((r: any) => r.qaRunId !== null && r.qaRunId !== undefined);
+  const qaRun = latestQaRow
+    ? {
+        runId: latestQaRow.qaRunId as number,
+        runSha: latestQaRow.qaRunSha as string,
+        triggeredAt: latestQaRow.decidedAt instanceof Date ? latestQaRow.decidedAt : new Date(latestQaRow.decidedAt),
+      }
+    : null;
+```
+
+Add `qaRun` to the returned object:
+
+```ts
+  return {
+    lastTag,
+    lastTagSha,
+    lastTagAt,
+    headSha,
+    mergedCommitsSinceLastTag,
+    commitsSinceLastTag,
+    ciStatus,
+    ciGreenSince,
+    hasFreshApproval,
+    freshApprovalApprover,
+    manualTagDetected,
+    qaRun,
+  };
+```
+
+The `.find()` over up to 20 rows is intentional — older rows may have null `qaRunId` (the typical case), so we filter in JS. An indexed query (using `WHERE qa_run_id IS NOT NULL`) is more efficient but adds Drizzle complexity; the over-fetch is fine at 20 rows.
+
+- [ ] **Step 2: Run the existing state-related tests to verify no regression**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/release-manager-scheduler.test.ts 2>&1 | tail -10
+```
+
+Expected: existing tests still pass. The qaRun addition is null in test mocks (which don't insert qa_run_id rows), so existing tests are unaffected.
+
+If a test fails because `state.qaRun` is undefined (vs null), adjust the test fixtures to include `qaRun: null`.
+
+- [ ] **Step 3: Verify TS compiles**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx tsc --noEmit 2>&1 | head -10
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/release-manager/state.ts
+git commit -m "feat(release-manager): collectState surfaces qaRun snapshot (BEC-136)"
+```
+
+---
+
+## Task 14: Wire qaActionNeeded dispatch into scheduler
+
+**Files:**
+- Modify: `packages/core/src/release-manager/scheduler.ts` (compute qaState before decide; dispatch qaActionNeeded after persistDecision)
+- Modify: `packages/core/src/__tests__/release-manager-scheduler.test.ts` (extend with 4 new tests)
+
+This is the integration point. The scheduler needs to:
+1. Before calling `decide()`: compute `qaState = { workflowFileExists, runConclusion }` via Octokit calls.
+2. After `persistDecision`: if `decision.qaActionNeeded` is set, dispatch the corresponding action (triggerWorkflow / fileGapIssue) and emit `qa.run_completed` audit when observing completion.
+
+- [ ] **Step 1: Write failing tests by extending the existing scheduler test file**
+
+Append to `packages/core/src/__tests__/release-manager-scheduler.test.ts`:
+
+```ts
+describe("createReleaseManagerScheduler — qaCheck integration", () => {
+  const paths: string[] = [];
+  let db: any;
+  const repoUrl = "https://github.com/org/repo";
+  const branch = "main";
+  const qaConfig = {
+    enabled: true,
+    triggers: {
+      mergedPRsSince: 1,
+      qaCheck: {
+        workflow: ".github/workflows/smoke.yml",
+        linearTeamId: "team-uuid-123",
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    delete process.env.URATEAM_LICENSE_KEY;
+    _resetLicenseCache();
+    const path = tmpDbPath();
+    paths.push(path);
+    const created = await createDb({ driver: "sqlite", connectionString: path });
+    db = created as any;
+  });
+
+  afterEach(() => {
+    for (const p of paths) {
+      try { unlinkSync(p); } catch {}
+      try { unlinkSync(p + "-wal"); } catch {}
+      try { unlinkSync(p + "-shm"); } catch {}
+    }
+    paths.length = 0;
+    _resetLicenseCache();
+  });
+
+  it("triggers workflow when qaCheck.workflow exists but no run for headSha", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => ({ data: { type: "file" } })), // workflow exists
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => ({ status: 204 })),
+        listWorkflowRuns: vi.fn(async () => ({ data: { workflow_runs: [{ id: 88888, head_sha: "head_sha_x", status: "in_progress", run_started_at: "2026-05-04T12:00:00Z" }] } })),
+      },
+      checks: {
+        listForRef: vi.fn(async () => ({ data: { check_runs: [] } })),
+      },
+    });
+    const linear = { createIssue: vi.fn() };
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: linear as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    expect(octokit.actions.createWorkflowDispatch).toHaveBeenCalled();
+    const rows = await db.select().from(releaseDecisions);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].decision).toBe("skip");
+    expect(rows[0].reason).toBe("qa_needs_trigger");
+    expect(rows[0].qaRunId).toBe(88888);
+    expect(rows[0].qaRunSha).toBe("head_sha_x");
+  });
+
+  it("polls existing in-flight run and writes qa_running skip", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    // Pre-seed an in-flight QA run row
+    await db.insert(releaseDecisions).values({
+      id: "rd_pre",
+      repoUrl,
+      branch,
+      decidedAt: new Date(Date.now() - 5 * 60 * 1000),
+      decision: "skip",
+      reason: "qa_needs_trigger",
+      triggerStateJson: "{}",
+      attemptCount: 0,
+      qaRunId: 88888,
+      qaRunSha: "head_sha_x",
+    });
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => ({ data: { type: "file" } })),
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(),  // should NOT be called
+        getWorkflowRun: vi.fn(async () => ({ data: { id: 88888, status: "in_progress", conclusion: null, run_started_at: "2026-05-04T12:00:00Z" } })),
+      },
+      checks: { listForRef: vi.fn(async () => ({ data: { check_runs: [] } })) },
+    });
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: { createIssue: vi.fn() } as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    expect(octokit.actions.createWorkflowDispatch).not.toHaveBeenCalled();
+    expect(octokit.actions.getWorkflowRun).toHaveBeenCalled();
+    const rows = await db.select().from(releaseDecisions);
+    // Two rows: pre-seed + new tick
+    expect(rows.length).toBe(2);
+    const newRow = rows.find((r: any) => r.id !== "rd_pre");
+    expect(newRow.reason).toBe("qa_running");
+  });
+
+  it("files Linear gap issue when workflow file is missing", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => {
+          const e: any = new Error("Not Found"); e.status = 404; throw e;
+        }),
+      },
+      checks: { listForRef: vi.fn(async () => ({ data: { check_runs: [] } })) },
+    });
+    const linear = {
+      createIssue: vi.fn(async () => ({ issue: Promise.resolve({ identifier: "BEC-150" }) })),
+    };
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: linear as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    expect(linear.createIssue).toHaveBeenCalledTimes(1);
+    const rows = await db.select().from(releaseDecisions);
+    expect(rows[0].reason).toBe("qa_no_workflow");
+  });
+
+  it("retry counter: 3 consecutive dispatch failures → permanent skip with qa_dispatch_error", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => ({ data: { type: "file" } })),
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const e: any = new Error("Server Error"); e.status = 502; throw e;
+        }),
+        listWorkflowRuns: vi.fn(async () => ({ data: { workflow_runs: [] } })),
+      },
+      checks: { listForRef: vi.fn(async () => ({ data: { check_runs: [] } })) },
+    });
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: { createIssue: vi.fn() } as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    await sched.tick();
+    await sched.tick();
+    const rows = await db.select().from(releaseDecisions);
+    expect(rows.length).toBe(3);
+    expect(rows[2].reason).toBe("qa_dispatch_error");
+    expect(rows[2].decision).toBe("skip");
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/release-manager-scheduler.test.ts
+```
+
+Expected: FAIL on the 4 new tests (scheduler doesn't yet dispatch qaActionNeeded; doesn't accept `linear` dep).
+
+- [ ] **Step 3: Update scheduler to accept Linear client + dispatch qaActionNeeded**
+
+In `packages/core/src/release-manager/scheduler.ts`, extend `ReleaseManagerSchedulerInput`:
+
+```ts
+import type { LinearClient } from "@linear/sdk";
+
+export interface ReleaseManagerSchedulerInput {
+  config: ReleaseManagerConfig;
+  db: AnyDb;
+  octokit: Octokit;
+  /** BEC-136: Linear client for filing QA gap issues. Required when qaCheck is configured. */
+  linear?: LinearClient;
+  repoUrl: string;
+  isLicensed: () => boolean;
+  slack?: SlackPoster;
+}
+```
+
+Add the imports for new helpers:
+
+```ts
+import { triggerWorkflow, pollWorkflowRun, workflowFileExists } from "../qa/github.js";
+import { fileGapIssue } from "../qa/gap.js";
+import { qaRunCompletedEvent } from "../audit/events.js";
+import { parseRepoFromUrl } from "./github.js"; // already imported
+```
+
+In the tick body, BEFORE calling `decide()`, compute `qaState`:
+
+```ts
+    // Compute QA state when qaCheck is configured. Two Octokit calls + one DB-derived value.
+    let qaState: { workflowFileExists: boolean; runConclusion: string | null } | undefined;
+    if (config.triggers.qaCheck && state.qaRun) {
+      const { owner, repo } = parseRepoFromUrl(repoUrl);
+      let workflowFileExists_ = false;
+      try {
+        workflowFileExists_ = await workflowFileExists({
+          octokit, owner, repo,
+          path: config.triggers.qaCheck.workflow,
+          ref: state.headSha,
+        });
+      } catch (err) {
+        log.warn({ err }, "qa workflowFileExists check failed — treating as exists");
+        workflowFileExists_ = true; // fail-open so retries hit the dispatch path
+      }
+      let runConclusion: string | null = null;
+      if (state.qaRun.runSha === state.headSha) {
+        try {
+          const polled = await pollWorkflowRun({ octokit, owner, repo, runId: state.qaRun.runId });
+          if (polled.kind === "completed") {
+            runConclusion = polled.conclusion;
+            // Emit qa.run_completed audit on first observation of completion.
+            void logAuditEventUnchecked(
+              db,
+              qaRunCompletedEvent({
+                repoUrl, branch,
+                runId: state.qaRun.runId,
+                conclusion: polled.conclusion as any,
+                durationMs: polled.durationMs,
+              }),
+            );
+          }
+        } catch (err) {
+          log.warn({ err }, "qa pollWorkflowRun failed — treating as still running");
+        }
+      }
+      qaState = { workflowFileExists: workflowFileExists_, runConclusion };
+    } else if (config.triggers.qaCheck) {
+      // No prior qaRun — just check the workflow file. runConclusion is null.
+      const { owner, repo } = parseRepoFromUrl(repoUrl);
+      let workflowFileExists_ = false;
+      try {
+        workflowFileExists_ = await workflowFileExists({
+          octokit, owner, repo,
+          path: config.triggers.qaCheck.workflow,
+          ref: state.headSha,
+        });
+      } catch (err) {
+        log.warn({ err }, "qa workflowFileExists check failed — treating as exists");
+        workflowFileExists_ = true;
+      }
+      qaState = { workflowFileExists: workflowFileExists_, runConclusion: null };
+    }
+```
+
+Pass `qaState` to `decide()`:
+
+```ts
+    const result = decide(state, config.triggers, undefined, qaState);
+```
+
+After `persistDecision()` for the skip branch (when `qaActionNeeded` is set), dispatch the action:
+
+```ts
+    if (result.kind === "skip") {
+      // Track previous attempts for retry-counter logic on QA dispatch errors.
+      const id = `rd_${randomUUID()}`;
+
+      // Compute attemptCount for retry handling.
+      let attemptCount = 0;
+      if (result.qaActionNeeded?.reason === "qa_needs_trigger") {
+        const prev = await (db as any)
+          .select({ attemptCount: releaseDecisions.attemptCount })
+          .from(releaseDecisions)
+          .where(
+            and(
+              eq(releaseDecisions.repoUrl, repoUrl),
+              eq(releaseDecisions.branch, branch),
+              eq(releaseDecisions.reason, "qa_needs_trigger"),
+            ),
+          )
+          .orderBy(desc(releaseDecisions.decidedAt))
+          .limit(1);
+        attemptCount = ((prev?.[0]?.attemptCount as number) ?? 0);
+      }
+
+      let finalReason = result.reason;
+      let qaRunId: number | undefined;
+      let qaRunSha: string | undefined;
+
+      // Dispatch qaActionNeeded.
+      if (result.qaActionNeeded?.reason === "qa_needs_trigger") {
+        const { owner, repo } = parseRepoFromUrl(repoUrl);
+        const dispatch = await triggerWorkflow({
+          octokit, db, owner, repo, repoUrl, branch,
+          workflow: config.triggers.qaCheck!.workflow,
+          ref: state.headSha,
+          inputs: config.triggers.qaCheck!.workflowInputs,
+        });
+        if (dispatch.kind === "ok") {
+          attemptCount = 0; // reset on successful dispatch
+          qaRunId = dispatch.runId;
+          qaRunSha = state.headSha;
+        } else if (dispatch.kind === "dispatch_404") {
+          // Workflow disappeared between state cache and dispatch — drop into gap-issue path.
+          finalReason = "qa_no_workflow";
+          // Fall through to the qa_no_workflow branch below.
+          result.qaActionNeeded = { pass: false, reason: "qa_no_workflow" } as any;
+        } else if (dispatch.kind === "dispatch_422") {
+          finalReason = "qa_dispatch_error";
+          attemptCount = 99; // permanent skip
+        } else {
+          // dispatch_error — increment attempt counter
+          attemptCount += 1;
+          if (attemptCount >= 3) {
+            finalReason = "qa_dispatch_error";
+          }
+        }
+      }
+
+      if (result.qaActionNeeded?.reason === "qa_no_workflow" || finalReason === "qa_no_workflow") {
+        if (!input.linear) {
+          log.error({ repoUrl, branch }, "qaCheck requires Linear client but none configured — skipping gap-issue file");
+        } else {
+          await fileGapIssue({
+            db,
+            linear: input.linear,
+            repoUrl,
+            branch,
+            workflowPath: config.triggers.qaCheck!.workflow,
+            linearTeamId: config.triggers.qaCheck!.linearTeamId,
+          });
+        }
+      }
+
+      await persistDecision({
+        id,
+        decision: "skip",
+        reason: finalReason,
+        triggerStateJson,
+        proposedVersion,
+        qaRunId,
+        qaRunSha,
+        attemptCount,
+      });
+      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: finalReason }));
+      await maybePostSlack(
+        `:double_vertical_bar: Release skipped for *${repoUrl}* (${branch}): ${finalReason}`,
+        finalReason,
+      );
+      return;
+    }
+```
+
+Update `persistDecision()` helper signature to accept the new optional fields:
+
+```ts
+async function persistDecision(row: {
+  id: string;
+  decision: string;
+  reason: string;
+  triggerStateJson: string;
+  proposedVersion?: string;
+  firedTag?: string;
+  firedSha?: string;
+  attemptCount?: number;
+  qaRunId?: number;
+  qaRunSha?: string;
+}): Promise<void> {
+  await (db as any).insert(releaseDecisions).values({
+    id: row.id,
+    repoUrl,
+    branch,
+    decidedAt: new Date(),
+    decision: row.decision,
+    reason: row.reason,
+    triggerStateJson: row.triggerStateJson,
+    proposedVersion: row.proposedVersion,
+    firedTag: row.firedTag,
+    firedSha: row.firedSha,
+    attemptCount: row.attemptCount ?? 0,
+    qaRunId: row.qaRunId,
+    qaRunSha: row.qaRunSha,
+  });
+}
+```
+
+- [ ] **Step 4: Run the scheduler tests to verify they pass**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/release-manager-scheduler.test.ts
+```
+
+Expected: PASS — original 7 tests + 4 new tests = 11 green.
+
+- [ ] **Step 5: Run all release-manager + qa tests to confirm no regressions**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/release-manager-*.test.ts src/__tests__/qa-*.test.ts src/__tests__/db-qa-gap-issues.test.ts
+```
+
+Expected: PASS — full set green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/release-manager/scheduler.ts packages/core/src/__tests__/release-manager-scheduler.test.ts
+git commit -m "feat(release-manager): scheduler dispatches qaActionNeeded (BEC-136)"
+```
+
+---
+
+## Task 15: Update audit-immutability allowlist
+
+**Files:**
+- Modify: `packages/core/src/__tests__/audit-immutability.test.ts`
+
+This test enforces that `logAuditEventUnchecked` is only called from approved files. Add the 2 new QA files to the allowlist.
+
+- [ ] **Step 1: Read the current test**
+
+```bash
+grep -n "allowlist\|allowed_files\|allowed-files\|qa/" /tmp/urateam-fresh/.worktrees/bec-136/packages/core/src/__tests__/audit-immutability.test.ts | head -10
+```
+
+Look at how the BEC-135 v2 follow-up added entries. The allowlist is a JS array of file paths.
+
+- [ ] **Step 2: Add the 2 entries**
+
+In `packages/core/src/__tests__/audit-immutability.test.ts`, find the allowlist array (added in BEC-135 v2). Add two entries:
+
+```ts
+"packages/core/src/qa/github.ts",
+"packages/core/src/qa/gap.ts",
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run src/__tests__/audit-immutability.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/core/src/__tests__/audit-immutability.test.ts
+git commit -m "test(core): allowlist qa/github.ts + qa/gap.ts in audit-immutability (BEC-136)"
+```
+
+---
+
+## Task 16: Wire startup config validation in cli/start.ts
+
+**Files:**
+- Modify: `packages/cli/src/commands/start.ts`
+
+The cli's start command needs to:
+1. Parse `RELEASE_MANAGER_TRIGGER_QA_*` env vars when set, populate `qaCheck` config.
+2. Validate `LINEAR_API_KEY` is set when `qaCheck` is configured.
+3. Construct a Linear client and pass it to the scheduler.
+
+- [ ] **Step 1: Find the existing release-manager config block**
+
+In `packages/cli/src/commands/start.ts`, find the section where `RELEASE_MANAGER_*` env vars are parsed (added by BEC-135 cli wiring). The `triggers` object building loop is the insertion point.
+
+- [ ] **Step 2: Add qaCheck env-var parsing**
+
+After the existing trigger field parsing (looks for `RELEASE_MANAGER_TRIGGER_MERGED_PRS_SINCE`, etc.), add:
+
+```ts
+      if (process.env.RELEASE_MANAGER_TRIGGER_QA_WORKFLOW) {
+        const qaWorkflow = process.env.RELEASE_MANAGER_TRIGGER_QA_WORKFLOW;
+        const qaTeamId = process.env.RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID;
+        const qaTimeoutMin = process.env.RELEASE_MANAGER_TRIGGER_QA_TIMEOUT_MINUTES;
+
+        if (!qaTeamId) {
+          console.error(
+            "RELEASE_MANAGER_TRIGGER_QA_WORKFLOW set but RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID is missing. " +
+            "Configure linearTeamId for filing gap issues.",
+          );
+          process.exit(1);
+        }
+        if (!process.env.LINEAR_API_KEY) {
+          console.error(
+            "qaCheck requires LINEAR_API_KEY (used to file gap issues). Set it and restart.",
+          );
+          process.exit(1);
+        }
+
+        triggers.qaCheck = {
+          workflow: qaWorkflow,
+          linearTeamId: qaTeamId,
+          ...(qaTimeoutMin ? { timeoutMinutes: parseInt(qaTimeoutMin, 10) } : {}),
+        };
+      }
+```
+
+- [ ] **Step 3: Construct the Linear client and pass it to the scheduler**
+
+In the existing scheduler instantiation block, find where `createReleaseManagerScheduler({...})` is called. Add a Linear client construction step before, and pass it to the scheduler:
+
+```ts
+      let linearClient: import("@linear/sdk").LinearClient | undefined;
+      if (rmConfig.triggers.qaCheck) {
+        const { LinearClient } = await import("@linear/sdk");
+        linearClient = new LinearClient({ apiKey: process.env.LINEAR_API_KEY! });
+      }
+      rmScheduler = createReleaseManagerScheduler({
+        config: rmConfig,
+        db,
+        octokit: rmOctokit,
+        linear: linearClient,
+        repoUrl: rmRepoUrl,
+        isLicensed: () => isFeatureLicensed("release-manager"),
+        slack: process.env.SLACK_BOT_TOKEN
+          ? { /* existing slack adapter */ }
+          : undefined,
+      });
+```
+
+- [ ] **Step 4: Verify TS compiles**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/cli && npx tsc --noEmit 2>&1 | head -10
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Run the full core test suite to confirm no regressions**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && npx vitest run
+```
+
+Expected: PASS — all tests green (modulo the 5 pre-existing flaky license-helper tests under parallel load; treat them as known-flaky).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/cli/src/commands/start.ts
+git commit -m "feat(cli): wire qaCheck env vars + Linear client (BEC-136)"
+```
+
+---
+
+## Task 17: Document RELEASE_MANAGER_TRIGGER_QA_* in .env.example
+
+**Files:**
+- Modify: `packages/create-urateam/template/.urateam/.env.example`
+
+- [ ] **Step 1: Append the QA section**
+
+Find the existing `Release Manager Agent (BEC-135)` block in `packages/create-urateam/template/.urateam/.env.example` (added by BEC-135 docs PR). After it, add:
+
+```
+# ----------------------------------------------------------------------------
+# Release Manager — QA agent integration (BEC-136). OSS+ feature.
+#
+# When configured, the Release Manager runs your GitHub Actions smoke workflow
+# against the merge commit before tagging a release. If the workflow file is
+# missing, the agent files a Linear issue describing how to set one up and
+# pauses release activity for the branch until it's resolved.
+#
+# Requires:
+#   - LINEAR_API_KEY (already set above for PM agent)
+#   - GitHub App credentials (GITHUB_APP_ID, GITHUB_PRIVATE_KEY_PATH already set)
+#
+# The configured workflow MUST have `on: workflow_dispatch` to be triggered.
+# ----------------------------------------------------------------------------
+# RELEASE_MANAGER_TRIGGER_QA_WORKFLOW=.github/workflows/smoke.yml
+# RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID=                 # required if qaCheck is set
+# RELEASE_MANAGER_TRIGGER_QA_TIMEOUT_MINUTES=30              # default 30
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136
+git add packages/create-urateam/template/.urateam/.env.example
+git commit -m "docs(env-example): document RELEASE_MANAGER_TRIGGER_QA_* vars (BEC-136)"
+```
+
+---
+
+## Task 18: Final integration sanity sweep + PR
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the full monorepo test suite**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136 && pnpm -r test 2>&1 | tail -50
+```
+
+Expected: PASS in all packages. The 5 pre-existing flaky license-helper tests may fail under parallel load — treat as known.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136 && pnpm typecheck 2>&1 | tail -20
+```
+
+Expected: zero errors. (The CLI typecheck fix from PR #145 means `pnpm typecheck` from root works correctly — turbo sequences `^build` first.)
+
+- [ ] **Step 3: Build core**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/core && pnpm build 2>&1 | tail -10
+```
+
+Verify the new qa modules are in dist:
+
+```bash
+ls /tmp/urateam-fresh/.worktrees/bec-136/packages/core/dist/qa/
+```
+
+Expected: `types.js`, `github.js`, `gap.js`, `index.js` + `.d.ts` siblings.
+
+- [ ] **Step 4: Build cli**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136/packages/cli && pnpm build 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136 && git push -u origin HEAD 2>&1 | tail -5
+```
+
+- [ ] **Step 6: Open a PR**
+
+```bash
+cd /tmp/urateam-fresh/.worktrees/bec-136 && gh pr create --title "feat(qa): BEC-136 QA agent + release-readiness check (Phase 1)" --body "$(cat <<'EOF'
+## Summary
+- New OSS+ QA agent at `packages/core/src/qa/` that integrates as a 5th trigger field on `ReleaseManagerTriggers`. When configured, each Release Manager tick verifies a customer-defined GitHub Actions workflow has run green against the merge SHA before firing a release.
+- Async fire-and-check across ticks: each tick either triggers a workflow_dispatch, observes an in-flight run, or files a gap issue — never blocks.
+- Gap-detection is rule-based (workflow file existence) with a static Linear template — LLM-driven analysis deferred to v2.
+- Three new audit event types: `qa.run_triggered`, `qa.run_completed`, `qa.gap_issue_filed`. All use `logAuditEventUnchecked` per the Pro-tier audit-gating pattern (BEC-135 v2).
+- Two minimal DB touchpoints: 2 new columns on `release_decisions` (`qaRunId`, `qaRunSha`) + new tiny `qa_gap_issues` table with partial UNIQUE (`WHERE resolved_at IS NULL`) for filing-idempotency.
+- Reuses existing secrets: `LINEAR_API_KEY` (PM agent) and `GITHUB_APP_*` (Release Manager). No new secrets to plumb.
+- 4 new migrations (sqlite 010 + 011, postgres 011 + 012). All idempotent.
+
+Spec: `docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md`
+Plan: `docs/superpowers/plans/2026-05-04-bec-136-qa-agent.md`
+
+## Test plan
+- [x] `qa-config.test.ts` — Zod schema validation
+- [x] `qa-github.test.ts` — Octokit calls + 5 result kinds for triggerWorkflow + pollWorkflowRun
+- [x] `qa-gap.test.ts` — fileGapIssue idempotent flow, re-file after resolved
+- [x] `qa-eval.test.ts` — all 6 result kinds of evalQaCheck + SHA-mismatch + timeout
+- [x] `qa-audit-events.test.ts` — 3 new factories
+- [x] `db-qa-gap-issues.test.ts` — schema + partial UNIQUE
+- [x] `release-manager-decide.test.ts` — extended with 3 qaCheck slot-4 tests
+- [x] `release-manager-scheduler.test.ts` — extended with 4 qa-integration tests (trigger/poll/gap-file/3-attempt-retry)
+- [ ] Manual smoke against a test repo with `RELEASE_MANAGER_TRIGGER_QA_*` configured (post-merge)
+
+## Documented v1 simplifications (deliberate, see plan §13)
+1. Gap detection is rule-based, not LLM-driven (D2)
+2. `evalQaCheck` returns 6 kinds (added `qa_timed_out` separate from `qa_failed` for cleaner audit emission)
+3. Scheduler tick stays fast — workflow runs span multiple ticks
+4. No QA workflow auto-cancel on timeout (operator manages cost knob)
+5. `qaCheck.workflow` is path-only (no display-name resolution) in v1
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Hand off to user**
+
+Capture the PR URL. After Sonnet review fixes are addressed and the PR is merged, the user will:
+- Bump `@urateam/core` 0.1.17 → 0.1.18
+- Cascade `@urateam/cli` 0.1.19 → 0.1.20, `@urateam/dashboard` 0.1.17 → 0.1.18
+- Tag `v0.1.32`
+- Publish `@urateam/core@0.1.18` to npm
+
+---
+
+## Cross-task verification checklist
+
+- [ ] All 10 created files match the file structure section
+- [ ] All 10 modified files match the file structure section
+- [ ] `AuditEventTypeSchema` has 3 new entries (`qa.*`)
+- [ ] `audit-immutability.test.ts` allowlist has 2 new entries (`qa/github.ts`, `qa/gap.ts`)
+- [ ] `releaseDecisions` has 2 new columns (`qaRunId`, `qaRunSha`) + index on `(repo_url, branch, qa_run_id) WHERE qa_run_id IS NOT NULL`
+- [ ] `qa_gap_issues` table exists with partial UNIQUE on `(repo_url, branch, workflow_path) WHERE resolved_at IS NULL`
+- [ ] Migrations: sqlite 010 + 011, postgres 011 + 012 — all idempotent
+- [ ] `ReleaseManagerTriggersSchema.qaCheck` is an optional field; `qaCheck` alone satisfies the "at least one trigger" guard
+- [ ] `decide()` calls `evalQaCheck` at slot 4 (after `ciGreenForMinutes`, before `requireSlackApproval`)
+- [ ] `state.qaRun` is populated by `collectState` (most-recent decision row with non-null `qa_run_id`)
+- [ ] Scheduler dispatches `qaActionNeeded`: `qa_needs_trigger` → `triggerWorkflow`, `qa_no_workflow` → `fileGapIssue`
+- [ ] Scheduler emits `qa.run_completed` audit on first observation of a completed run
+- [ ] Scheduler retry counter: 3 consecutive `dispatch_error` results → permanent skip with `reason="qa_dispatch_error"`
+- [ ] cli `start.ts` validates `LINEAR_API_KEY` set when `qaCheck` is configured
+- [ ] `.env.example` documents 3 new env vars
+- [ ] `pnpm -r test` and `pnpm typecheck` both pass
+- [ ] PR opened against `main`
+
+---
+
+## Out of scope for this plan (per spec §10 — post-1.0)
+
+These are NOT to be implemented in this PR:
+
+- LLM-driven gap analysis (rule-based for v1)
+- Auto-cancellation of stuck workflows
+- Auto-fix bootstrap PR for missing workflows (gap issue is just a Linear issue)
+- Multi-workflow chains (one workflow per qaCheck in v1)
+- Test-result surfacing in Slack (v1 just says "QA failed: see GitHub run #X")
+- Cost/duration alerting
+- Per-PR QA (v1 only after merge)
+- Workflow file at non-default location (only paths under `.github/workflows/`)
+- Multi-repo QA fan-out (paired with BEC-141)
+- Linear issue auto-close (operator closes manually)

--- a/docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md
+++ b/docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md
@@ -1,0 +1,322 @@
+# BEC-136 — QA Agent + Release-Readiness Check (Phase 1)
+
+**Issue:** [BEC-136](https://linear.app/beckerspace/issue/BEC-136/v10-46-qa-agent-release-readiness-check-orchestrate-existing-ci-file)
+**Tier:** OSS+ (workflow runner is not a premium feature; gap-issue filing reuses the Pro-tier `LINEAR_API_KEY`)
+**Estimate:** 2–3 weeks
+**v1.0 gate:** 5 of 6 (sequence after BEC-135)
+**Date:** 2026-05-04
+
+---
+
+## 1. Goal
+
+Wire a release-time QA gate into Release Manager (BEC-135). When configured, each Release Manager tick verifies that a customer-defined GitHub Actions workflow has run green against the merge commit before the agent fires a release tag. If no workflow is configured at the expected path, the agent files a Linear issue describing how to set one up and pauses the release pipeline until a human resolves it.
+
+urateam DOES: trigger workflow_dispatch on `qaCheck.workflow`, poll its status, gate the release decision on pass/fail, file an idempotent Linear gap issue if the workflow file is missing.
+
+urateam DOES NOT: provision ephemeral environments, generate test code, parse test output, run tests itself, or analyze the codebase with an LLM. The customer's existing CI is the source of truth.
+
+## 2. Decisions (locked 2026-05-04)
+
+| # | Decision | Reason |
+|---|---|---|
+| D1 | QA integrates as a 5th trigger field on `ReleaseManagerTriggers` (Architecture A) | Cleanest fit with existing trigger DSL; reuses decision-flow + audit + Slack-dedup plumbing. |
+| D2 | Gap-detection is rule-based with a static Linear template (A3) | Phase 1 keeps Claude API surface tiny. LLM-driven analysis is real value but riskier (prompt engineering + token cost) — defer to v2. |
+| D3 | Async fire-and-check across ticks (X2) | A workflow run can take 5–30 min. Synchronous-in-tick blocks scheduler activity. Async costs one extra tick of release latency in exchange for fast ticks + composable concurrent repos. |
+| D4 | QA evaluates at trigger-order position 4, before `requireSlackApproval` | Customers using both `qaCheck` AND `requireSlackApproval` should see "QA failed" as a regular skip BEFORE the awaiting-approval branch — keeps the human-in-loop flow uncluttered when QA is broken. |
+| D5 | New persistence: 2 columns on `release_decisions` (`qaRunId`, `qaRunSha`) + new tiny `qa_gap_issues` table | No standalone QA scheduler / DB. Two minimal touchpoints; partial UNIQUE on `qa_gap_issues` mirrors the proven `release_approvals` pattern. |
+| D6 | Reuse `LINEAR_API_KEY` (existing PM agent secret) for filing gap issues | No new secrets to plumb. |
+| D7 | Reuse the dormant `attempt_count` column on `release_decisions` (originally for partial-fire retries, now dead per BEC-135 v2 cleanup) for QA dispatch / gap-file 3-attempt retry counter | Avoids adding another column. Documents the column's actual current use. |
+| D8 | Audit events use `release-manager` actor type (not a new `qa-agent` actor) | QA is a sub-feature of Release Manager, not a peer. Single actor namespace = simpler audit-log queries. |
+| D9 | Audit emissions use `logAuditEventUnchecked` (matches BEC-135 v2 audit-gating pattern) | Pro-tier features must produce audit rows for Pro customers without requiring the Enterprise `audit-log` dashboard. |
+
+## 3. Architecture
+
+```
+packages/core/src/qa/
+  types.ts          # QaCheckConfigSchema + QaTriggerResult union
+  github.ts         # triggerWorkflow() / pollWorkflowRun() / workflowFileExists()
+  gap.ts            # detectMissingHarness() / fileGapIssue() (idempotent via DB)
+  index.ts          # barrel re-export
+
+packages/core/src/release-manager/
+  types.ts          # MODIFY — add qaCheck to ReleaseManagerTriggers
+  triggers.ts       # MODIFY — add evalQaCheck() evaluator
+  decide.ts         # MODIFY — call evalQaCheck() at slot 4 (before requireSlackApproval)
+  state.ts          # MODIFY — surface in-flight qaRun lookup from release_decisions
+  scheduler.ts      # MODIFY — dispatch qaActionNeeded (triggerWorkflow / fileGapIssue)
+
+packages/core/src/db/
+  schema.ts         # MODIFY — add qaRunId/qaRunSha columns to releaseDecisions; add qaGapIssues table
+  migrations/sqlite/010_qa_run_columns.sql        # NEW — ALTER TABLE release_decisions ADD COLUMN
+  migrations/sqlite/011_qa_gap_issues.sql         # NEW — CREATE TABLE qa_gap_issues + partial UNIQUE
+  migrations/postgres/011_qa_run_columns.sql      # NEW
+  migrations/postgres/012_qa_gap_issues.sql       # NEW
+
+packages/core/src/audit/events.ts          # MODIFY — add 3 factories
+packages/core/src/types.ts                 # MODIFY — extend AuditEventTypeSchema with 3 entries
+
+packages/cli/src/commands/start.ts         # MODIFY — startup config validation for qaCheck
+
+packages/create-urateam/template/.urateam/.env.example  # MODIFY — document RELEASE_MANAGER_TRIGGER_QA_*
+
+packages/core/src/__tests__/
+  qa-config.test.ts                              # NEW
+  qa-github.test.ts                              # NEW
+  qa-gap.test.ts                                 # NEW
+  qa-eval.test.ts                                # NEW
+  qa-audit-events.test.ts                        # NEW
+  db-qa-gap-issues.test.ts                       # NEW
+  release-manager-decide.test.ts                 # MODIFY — add 3 tests for qaCheck slot
+  release-manager-scheduler.test.ts              # MODIFY — add 4 tests for qaActionNeeded dispatch
+```
+
+## 4. Configuration
+
+### 4.1 RepoConfig schema addition
+
+```ts
+// packages/core/src/qa/types.ts
+export const QaCheckConfigSchema = z.object({
+  /** Path to the workflow file in the repo (e.g., ".github/workflows/smoke.yml"). */
+  workflow: z.string().min(1),
+  /** Max time we'll wait for a single workflow run before reporting timed_out. Default 30. */
+  timeoutMinutes: z.number().int().positive().default(30),
+  /** Linear team UUID for filing gap issues. Required for gap-issue path to work. */
+  linearTeamId: z.string().min(1),
+  /** Optional inputs passed to workflow_dispatch (e.g., { environment: "preview" }). */
+  workflowInputs: z.record(z.string(), z.string()).optional(),
+});
+export type QaCheckConfig = z.infer<typeof QaCheckConfigSchema>;
+```
+
+Then in `release-manager/types.ts`, extend `ReleaseManagerTriggersSchema`:
+
+```ts
+qaCheck: QaCheckConfigSchema.optional(),
+```
+
+### 4.2 Startup validation
+
+Throws on:
+- `qaCheck.workflow` set but `LINEAR_API_KEY` env unset → "qaCheck requires LINEAR_API_KEY for filing gap issues"
+- `qaCheck.workflow` set but `linearTeamId` empty → caught by Zod `.min(1)` automatically
+- (Optional, post-Zod) `gh api repos/{owner}/{repo}/actions/workflows/{file}` returns the workflow but it lacks `on: workflow_dispatch` trigger → "workflow X must have `on: workflow_dispatch` to be triggered by the release agent". This is a soft-validate done at scheduler creation time (not a startup throw) because GitHub creds may not be loaded at config-parse time.
+
+### 4.3 Env-driven kickstart
+
+| Env var | Maps to | Notes |
+|---|---|---|
+| `RELEASE_MANAGER_TRIGGER_QA_WORKFLOW` | `qaCheck.workflow` | Setting any one of the QA env vars implies qaCheck is configured. |
+| `RELEASE_MANAGER_TRIGGER_QA_TIMEOUT_MINUTES` | `qaCheck.timeoutMinutes` | Optional, default 30 |
+| `RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID` | `qaCheck.linearTeamId` | Required when qaCheck is set |
+
+`workflowInputs` is per-repo only (no env path); customers configure via per-repo `pipelineConfig` JSON. Realistically most won't need it — the fallback default omits the field entirely.
+
+## 5. Decision flow
+
+```
+ReleaseManagerScheduler.tick()
+  ├─ ... existing pre-decide steps (license, paused, manual-tag, collectState)
+  ├─ # state now includes state.qaRun (most-recent in-flight QA run for headSha, or null)
+  ├─ result = decide(state, config.triggers)
+  │     # decide() in turn calls evalQaCheck at slot 4 if triggers.qaCheck is set
+  │     # evalQaCheck returns one of 5 kinds (see §5.1).
+  │     # When the kind requires action, decide bubbles it via { kind: "skip", reason, qaActionNeeded }
+  ├─ persistDecision(...)
+  │     # if qaActionNeeded.reason === "qa_needs_trigger", persistDecision sets qaRunSha = state.headSha
+  │     #                                                             qaRunId  = (filled in next step after dispatch)
+  ├─ # Dispatch any qaAction needed:
+  ├─ if qaActionNeeded.reason === "qa_needs_trigger":
+  │     runId = await qa.triggerWorkflow({ octokit, owner, repo, workflow, ref: state.headSha, inputs })
+  │     update release_decisions row to set qaRunId
+  │     audit qaRunTriggeredEvent
+  │     return  # tick complete; next tick observes the run
+  ├─ if qaActionNeeded.reason === "qa_no_workflow":
+  │     await qa.fileGapIssue({ db, linearClient, repoUrl, branch, workflowPath })
+  │     # fileGapIssue is idempotent via qa_gap_issues partial UNIQUE; no-op if already filed
+  │     # On first file: audit qaGapIssueFiledEvent
+  │     return
+  ├─ if qaActionNeeded.reason === "qa_failed":
+  │     audit qaRunCompletedEvent({ conclusion: <actual conclusion> })
+  │     # decision row is already persisted; no further action
+  │     return
+  ├─ if qaActionNeeded.reason === "qa_running" / "qa_timed_out":
+  │     # No new dispatch; just persisted skip row + Slack-dedup notification
+  │     return
+  ├─ ... (existing flow continues — fire/skip/awaiting-approval as before)
+```
+
+### 5.1 `evalQaCheck` result kinds
+
+```ts
+export type QaTriggerResult =
+  | { pass: true;  reason: string }                            // workflow run completed, conclusion=success
+  | { pass: false; reason: "qa_failed"; runId: number }        // completed, conclusion in {failure, cancelled, timed_out, action_required, skipped, stale}
+  | { pass: false; reason: "qa_running"; runId: number }       // in-flight — await next tick
+  | { pass: false; reason: "qa_timed_out"; runId: number }     // in-flight beyond timeoutMinutes — synthetic timeout
+  | { pass: false; reason: "qa_needs_trigger" }                // workflow file exists but no run exists for state.headSha
+  | { pass: false; reason: "qa_no_workflow" };                 // workflow file missing — file gap issue
+```
+
+### 5.2 Trigger ordering (updated)
+
+`decide()` evaluates in this order; first failing trigger wins:
+1. `mergedPRsSince` (in-memory count — cheapest)
+2. `timeSinceLastHours` (single timestamp compare)
+3. `ciGreenForMinutes` (already-fetched into state)
+4. **`qaCheck`** (NEW — uses already-fetched in-flight run state from DB; may bubble qaActionNeeded)
+5. `requireSlackApproval` (last; "awaiting-approval" terminal kind)
+
+QA is at position 4 because: if the workflow's failing/missing, that's a regular `skip` — we don't want it bumping into the `awaiting-approval` branch. The whole approval flow only triggers when QA has already passed.
+
+### 5.3 SHA-mismatch handling
+
+When evaluating, if `state.qaRun.runSha !== state.headSha` (commits landed mid-run):
+- Mark `state.qaRun = null` for the eval purpose (treat as no in-flight run).
+- evalQaCheck returns `qa_needs_trigger` → scheduler triggers fresh.
+- Old run is left alive in GitHub history (do NOT cancel — could be expensive cloud spend in flight).
+- Old `release_decisions` row is unchanged (audit trail preserved).
+
+### 5.4 Decision-row qaRun retrieval
+
+`state.qaRun` is computed in `state.ts` `collectState()` via:
+
+```sql
+SELECT qa_run_id, qa_run_sha, decided_at
+FROM release_decisions
+WHERE repo_url = $1 AND branch = $2 AND qa_run_id IS NOT NULL
+ORDER BY decided_at DESC
+LIMIT 1
+```
+
+The most-recent decision with a non-null `qa_run_id` represents the in-flight run we're tracking. evalQaCheck then uses Octokit to poll its status.
+
+## 6. Schema migration
+
+```ts
+// schema.ts — additions to releaseDecisions
+qaRunId: integer("qa_run_id"),               // GitHub workflow run ID — null when no QA in flight
+qaRunSha: text("qa_run_sha"),                // SHA the workflow was triggered against
+
+// schema.ts — new table
+export const qaGapIssues = sqliteTable(
+  "qa_gap_issues",
+  {
+    id: text("id").primaryKey(),
+    repoUrl: text("repo_url").notNull(),
+    branch: text("branch").notNull(),
+    workflowPath: text("workflow_path").notNull(),
+    /** Linear issue identifier returned at file time (e.g., "BEC-150"). */
+    linearIssueId: text("linear_issue_id").notNull(),
+    filedAt: crossTimestamp("filed_at").notNull().$defaultFn(() => new Date()),
+    /** Set when the gap is detected as resolved (workflow file appears). Linear issue itself is closed manually by operator. */
+    resolvedAt: crossTimestamp("resolved_at"),
+  },
+);
+// Partial UNIQUE in raw migration:
+//   UNIQUE (repo_url, branch, workflow_path) WHERE resolved_at IS NULL
+```
+
+**Migration files:**
+- `packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql` — `ALTER TABLE release_decisions ADD COLUMN qa_run_id INTEGER; ALTER TABLE release_decisions ADD COLUMN qa_run_sha TEXT;`
+- `packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql` — `CREATE TABLE qa_gap_issues (...)` + 1 partial UNIQUE index + 1 lookup index
+- `packages/core/src/db/migrations/postgres/011_qa_run_columns.sql` — postgres equivalent
+- `packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql` — postgres equivalent (TIMESTAMPTZ for `filed_at` / `resolved_at`)
+
+## 7. Audit events
+
+Three new event types in `AuditEventTypeSchema`:
+- `qa.run_triggered` — payload: `{ branch, workflow, runId, sha }`
+- `qa.run_completed` — payload: `{ branch, runId, conclusion, durationMs, synthetic? }` (synthetic=true for `qa_timed_out` since GitHub didn't actually conclude it)
+- `qa.gap_issue_filed` — payload: `{ branch, workflowPath, linearIssueId }`
+
+Factories live in `packages/core/src/audit/events.ts`. All three:
+- `actor: "release-manager"`
+- `actorType: "release-manager"`
+- `scope: \`repo:${args.repoUrl}\``
+- Emitted via `logAuditEventUnchecked` so they appear for Pro customers (matches BEC-135 v2 pattern).
+
+`audit-immutability.test.ts` allowlist gets 2 new entries: `packages/core/src/qa/github.ts` (emits `qa.run_triggered` after dispatch returns the runId) and `packages/core/src/qa/gap.ts` (emits `qa.gap_issue_filed` after Linear API returns the issue ID). The third event, `qa.run_completed`, fires from `release-manager/scheduler.ts` which is already in the allowlist from BEC-135.
+
+## 8. Error handling
+
+| Failure | Behavior |
+|---|---|
+| `gh workflow run` 5xx / rate-limit | Log + return `qa_needs_trigger` for next tick. Increment `attempt_count` on the new decision row. After 3 attempts → `skip` with `reason="qa_dispatch_error"` + audit event. |
+| `gh workflow run` 422 (workflow not workflow_dispatch-triggered) | Same path as above (3-attempt retry then permanent skip with `reason="qa_dispatch_error"`). The startup validator should catch this earlier. |
+| `gh workflow run` 404 (workflow file removed between state-cache and dispatch) | Drop into `qa_no_workflow` path — file gap issue, persist skip row. |
+| Polled run still `in_progress` after `timeoutMinutes` | Decision = `skip`, reason = `qa_timed_out`. Audit `qa.run_completed` with synthetic conclusion. Do NOT auto-cancel the GitHub run. |
+| Run conclusion in {`failure`, `cancelled`, `timed_out`, `action_required`, `skipped`, `stale`} | Decision = `skip`, reason = `qa_failed`. Audit captures actual conclusion. |
+| Linear API failure when filing gap issue | Log + retry next tick. After 3 attempts → `skip` with `reason="qa_gap_file_error"` + audit event. |
+| GitHub API rate-limit (429) on poll | Octokit throttling middleware (already configured in `repo/github.ts`) handles the retry. Tick treats the throttle wait as transient — returns `qa_running` if status couldn't be determined. |
+| `qaRunSha !== state.headSha` (mid-run new commits) | evalQaCheck → `qa_needs_trigger`. Scheduler dispatches a fresh workflow run. Old run becomes orphan. |
+| `LINEAR_API_KEY` invalid mid-run (401 from Linear) | Treated like Linear API failure (3-attempt retry). |
+| Multi-process Release Manager | Mitigated by Postgres advisory lock at scheduler tick start (already there from BEC-135). v2 cross-process is out of scope (BEC-141). |
+
+**Retry counter:** reuses the existing `attempt_count` column on `release_decisions`. Each transient failure increments the counter on the new decision row; transient retries do NOT audit. Only the final 3rd-attempt skip audits.
+
+## 9. Testing
+
+8 test files, ~80 tests. Mirrors BEC-135's layout (proven out in implementation).
+
+| File | Coverage |
+|---|---|
+| `qa-config.test.ts` | `QaCheckConfigSchema` happy path; superRefine + startup-validation guards (workflow + linearTeamId both required; `LINEAR_API_KEY` env requirement) |
+| `qa-github.test.ts` | `triggerWorkflow` happy + 422 + 5xx; `pollWorkflowRun` for each conclusion + in_progress; `workflowFileExists` 404 vs 200 vs 5xx |
+| `qa-gap.test.ts` | `detectMissingHarness` returns true on 404, false on 200; `fileGapIssue` happy path with mocked Linear SDK; idempotent re-call (existing open row → no-op); resolved row handling |
+| `qa-eval.test.ts` | All 5 result kinds of `evalQaCheck`; SHA-mismatch returns `qa_needs_trigger`; timeout calc respects `timeoutMinutes`; nothing-running case |
+| `release-manager-decide.test.ts` (extend) | qaCheck slot-4 ordering; qaCheck failure path; qaActionNeeded bubbles through |
+| `release-manager-scheduler.test.ts` (extend) | Tick triggers workflow (action=needs-trigger); tick polls existing run; tick files gap issue (action=no-workflow); 3-attempt retry counter |
+| `db-qa-gap-issues.test.ts` | Schema + UNIQUE partial index round-trip; resolved row allows re-file |
+| `qa-audit-events.test.ts` | 3 new factories pass schema validation; correct actor/actorType/scope |
+
+**No e2e in v1** — production integration test gated on `TEST_POSTGRES_URL` + `TEST_LINEAR_API_KEY` (latter is new; document but don't require for CI).
+
+**Pre-existing flaky-test reminder:** the 5 license-helper tests still take 4-5s in isolation under the now-30s timeout. New QA tests should NOT use `installTestProLicense()` unless they truly need a Pro license — for pure-fn tests, just construct config objects directly.
+
+## 10. Out of scope (v2 / post-1.0)
+
+- LLM-driven gap analysis (rule-based for v1 per D2)
+- Auto-cancellation of stuck workflows
+- Auto-fix bootstrap PR (gap issue is just a Linear issue; no starter-workflow PR)
+- Multi-workflow chains (one workflow per qaCheck in v1)
+- Test-result surfacing in Slack (v1 just says "QA failed: see GitHub run #X")
+- Cost/duration alerting (no "this run cost $X" detection)
+- Per-PR QA (v1 only after merge, gated by Release Manager)
+- Workflow file at non-default location (v1 paths only under `.github/workflows/`)
+- Multi-repo QA fan-out (paired with BEC-141 multi-repo Release Manager)
+- Linear issue auto-close (operator closes manually)
+
+## 11. Acceptance criteria mapping (from BEC-136)
+
+| Acceptance criterion | Where covered |
+|---|---|
+| New `qa-agent` action under `packages/core/src/qa/` | §3 |
+| Triggered by Release Manager | §5 — qaCheck integrates as 5th trigger |
+| Calls `gh workflow run <workflow> --ref <commit>`, polls status | `qa/github.ts` triggerWorkflow + pollWorkflowRun |
+| Result reported back to Release Manager as part of release decision | §5.1 — QaTriggerResult kinds; §5 — bubble via qaActionNeeded |
+| Gap-detection: when no smoke workflow exists, files a Linear issue | §5 (`qa_no_workflow` branch) + `qa/gap.ts` |
+| Tests cover: workflow-success, workflow-failure, no-workflow-detected paths | §9 — qa-eval + qa-github + qa-gap + scheduler-extension tests |
+
+## 12. Release & cascade
+
+- Bump `@urateam/core` (next sequential after `0.1.17`) → `0.1.18`
+- Cascade `@urateam/cli` `0.1.19` → `0.1.20` and `@urateam/dashboard` `0.1.17` → `0.1.18`
+- Tag `v0.1.32`
+- Customers must have `LINEAR_API_KEY` and `GITHUB_APP_*` already configured (from PM agent + BEC-135). No new secrets to set up.
+- BEC-136 hands off to BEC-138 (self-dogfood + 1.0.0 cut). After BEC-138 merges, the urateam team itself runs the full agent stack on the urateam repo for ≥7 days before tagging 1.0.0.
+
+## 13. Known v1 simplifications (deliberate trade-offs)
+
+These are pragmatic v1 trade-offs the implementer should NOT try to "fix" without checking with the user. Each is a deliberate scope reduction.
+
+1. **Gap detection is rule-based, not LLM-driven.** Per D2: when the configured workflow file is missing, we file a Linear issue from a static template. No Claude call inspects the repo for the right ephemeral-env provider, no auto-suggestion of test-framework path. The Linear issue body links to documentation; operator does the bootstrap. v2 (filed as Linear ticket post-1.0) can layer LLM analysis on top.
+
+2. **Synchronous-tick is rejected; we run async across ticks.** A release that takes 30 min normally now takes ~30 min + one extra tick for QA. Acceptable v1 behavior. Operators should set `RELEASE_MANAGER_SCHEDULE` to a faster cron (e.g., `*/15 * * * *`) if they want tighter release latency.
+
+3. **No QA workflow auto-cancel on timeout.** When `timeoutMinutes` elapses, we report `qa_timed_out` and walk away. The workflow keeps running on GitHub's side. This is intentional — auto-cancelling would surprise operators with cost spikes/data loss in mid-flight ephemeral envs. Operators cancel manually via GitHub UI.
+
+4. **`qaCheck.workflow` is path-only, no name resolution.** `gh workflow run` accepts both filenames and display names. v1 requires the file path (e.g., `.github/workflows/smoke.yml`). Display-name support is a v2 nice-to-have.
+
+5. **Single Release Manager instance per process** (inherited from BEC-135 v1). Multi-repo QA fan-out is gated on BEC-141 (multi-repo Release Manager).

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -177,7 +177,7 @@ export const startCommand = new Command("start")
         process.exit(1);
       }
 
-      const triggers: Record<string, number | boolean> = {};
+      const triggers: Record<string, unknown> = {};
       if (process.env.RELEASE_MANAGER_TRIGGER_MERGED_PRS_SINCE) {
         triggers.mergedPRsSince = parseInt(process.env.RELEASE_MANAGER_TRIGGER_MERGED_PRS_SINCE, 10);
       }
@@ -189,6 +189,32 @@ export const startCommand = new Command("start")
       }
       if (process.env.RELEASE_MANAGER_TRIGGER_REQUIRE_SLACK_APPROVAL === "true") {
         triggers.requireSlackApproval = true;
+      }
+
+      if (process.env.RELEASE_MANAGER_TRIGGER_QA_WORKFLOW) {
+        const qaWorkflow = process.env.RELEASE_MANAGER_TRIGGER_QA_WORKFLOW;
+        const qaTeamId = process.env.RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID;
+        const qaTimeoutMin = process.env.RELEASE_MANAGER_TRIGGER_QA_TIMEOUT_MINUTES;
+
+        if (!qaTeamId) {
+          console.error(
+            "RELEASE_MANAGER_TRIGGER_QA_WORKFLOW set but RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID is missing. " +
+            "Configure linearTeamId for filing gap issues.",
+          );
+          process.exit(1);
+        }
+        if (!process.env.LINEAR_API_KEY) {
+          console.error(
+            "qaCheck requires LINEAR_API_KEY (used to file gap issues). Set it and restart.",
+          );
+          process.exit(1);
+        }
+
+        triggers.qaCheck = {
+          workflow: qaWorkflow,
+          linearTeamId: qaTeamId,
+          ...(qaTimeoutMin ? { timeoutMinutes: parseInt(qaTimeoutMin, 10) } : {}),
+        };
       }
 
       try {
@@ -327,12 +353,20 @@ export const startCommand = new Command("start")
       const { createGitHubClient, createReleaseManagerScheduler, isFeatureLicensed,
         handleReleaseSubcommand, parseReleaseSubcommand } = await import("@urateam/core");
       const rmOctokit = await createGitHubClient(github);
+
+      let linearClient: import("@linear/sdk").LinearClient | undefined;
+      if (rmConfig.triggers.qaCheck) {
+        const { LinearClient } = await import("@linear/sdk");
+        linearClient = new LinearClient({ apiKey: process.env.LINEAR_API_KEY! });
+      }
+
       rmScheduler = createReleaseManagerScheduler({
         config: rmConfig,
         db,
         octokit: rmOctokit,
         repoUrl: rmRepoUrl,
         isLicensed: () => isFeatureLicensed("release-manager"),
+        linear: linearClient,
         slack: process.env.SLACK_BOT_TOKEN
           ? {
               postMessage: async (channel, text) => {

--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -67,6 +67,8 @@ describe("audit_events immutability", () => {
       "packages/core/src/pm/actions/resolve-approvals.ts",
       "packages/core/src/release-manager/scheduler.ts",
       "packages/core/src/release-manager/slack-handler.ts",
+      "packages/core/src/qa/github.ts",
+      "packages/core/src/qa/gap.ts",
       "packages/core/src/__tests__/audit-immutability.test.ts",
     ];
 

--- a/packages/core/src/__tests__/db-qa-gap-issues.test.ts
+++ b/packages/core/src/__tests__/db-qa-gap-issues.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { randomBytes, randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { eq, isNull, and } from "drizzle-orm";
+import { createDb } from "../db/index.js";
+import { qaGapIssues, releaseDecisions } from "../db/schema.js";
+
+function tmpDbPath(): string {
+  const id = randomBytes(8).toString("hex");
+  return `/tmp/laf-qa-gap-${id}.sqlite`;
+}
+
+describe("qa_gap_issues table", () => {
+  const paths: string[] = [];
+
+  async function makeDb() {
+    const path = tmpDbPath();
+    paths.push(path);
+    const db = await createDb({ driver: "sqlite", connectionString: path });
+    return { db: db as any };
+  }
+
+  afterEach(() => {
+    for (const p of paths) {
+      try { unlinkSync(p); } catch {}
+      try { unlinkSync(p + "-wal"); } catch {}
+      try { unlinkSync(p + "-shm"); } catch {}
+    }
+    paths.length = 0;
+  });
+
+  it("inserts and reads a qa_gap_issues row", async () => {
+    const { db } = await makeDb();
+    const id = `qg_${randomUUID()}`;
+    await db.insert(qaGapIssues).values({
+      id,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    const rows = await db.select().from(qaGapIssues).where(eq(qaGapIssues.id, id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].linearIssueId).toBe("BEC-150");
+    expect(rows[0].resolvedAt).toBeNull();
+  });
+
+  it("partial UNIQUE prevents re-filing while resolved_at is null", async () => {
+    const { db } = await makeDb();
+    await db.insert(qaGapIssues).values({
+      id: `qg_${randomUUID()}`,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    await expect(
+      db.insert(qaGapIssues).values({
+        id: `qg_${randomUUID()}`,
+        repoUrl: "https://github.com/org/repo",
+        branch: "main",
+        workflowPath: ".github/workflows/smoke.yml",
+        linearIssueId: "BEC-151",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("allows re-filing after the previous issue is resolved", async () => {
+    const { db } = await makeDb();
+    const firstId = `qg_${randomUUID()}`;
+    await db.insert(qaGapIssues).values({
+      id: firstId,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    await db.update(qaGapIssues)
+      .set({ resolvedAt: new Date() })
+      .where(eq(qaGapIssues.id, firstId));
+    // Second filing now succeeds
+    await db.insert(qaGapIssues).values({
+      id: `qg_${randomUUID()}`,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-160",
+    });
+    const rows = await db.select().from(qaGapIssues).where(
+      and(
+        eq(qaGapIssues.repoUrl, "https://github.com/org/repo"),
+        eq(qaGapIssues.workflowPath, ".github/workflows/smoke.yml"),
+      ),
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  it("releaseDecisions has qaRunId and qaRunSha columns", async () => {
+    const { db } = await makeDb();
+    const id = `rd_${randomUUID()}`;
+    await db.insert(releaseDecisions).values({
+      id,
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      decidedAt: new Date(),
+      decision: "skip",
+      reason: "qa_running",
+      triggerStateJson: "{}",
+      attemptCount: 0,
+      qaRunId: 12345,
+      qaRunSha: "abcdef0",
+    });
+    const rows = await db.select().from(releaseDecisions).where(eq(releaseDecisions.id, id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].qaRunId).toBe(12345);
+    expect(rows[0].qaRunSha).toBe("abcdef0");
+  });
+});

--- a/packages/core/src/__tests__/qa-audit-events.test.ts
+++ b/packages/core/src/__tests__/qa-audit-events.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  qaRunTriggeredEvent,
+  qaRunCompletedEvent,
+  qaGapIssueFiledEvent,
+} from "../audit/events.js";
+import { AuditEventSchema } from "../types.js";
+
+describe("qa audit events", () => {
+  it("qaRunTriggeredEvent passes schema validation", () => {
+    const evt = qaRunTriggeredEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflow: ".github/workflows/smoke.yml",
+      runId: 12345,
+      sha: "abcdef0",
+    });
+    expect(evt.eventType).toBe("qa.run_triggered");
+    expect(evt.actor).toBe("release-manager");
+    expect(evt.actorType).toBe("release-manager");
+    expect(evt.scope).toBe("repo:https://github.com/org/repo");
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.runId).toBe(12345);
+  });
+
+  it("qaRunCompletedEvent passes schema validation with conclusion", () => {
+    const evt = qaRunCompletedEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      runId: 12345,
+      conclusion: "success",
+      durationMs: 600_000,
+    });
+    expect(evt.eventType).toBe("qa.run_completed");
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.conclusion).toBe("success");
+    expect(evt.payload.durationMs).toBe(600_000);
+  });
+
+  it("qaRunCompletedEvent supports synthetic timeout flag", () => {
+    const evt = qaRunCompletedEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      runId: 12345,
+      conclusion: "timed_out",
+      durationMs: 1_800_000,
+      synthetic: true,
+    });
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.synthetic).toBe(true);
+  });
+
+  it("qaGapIssueFiledEvent passes schema validation", () => {
+    const evt = qaGapIssueFiledEvent({
+      repoUrl: "https://github.com/org/repo",
+      branch: "main",
+      workflowPath: ".github/workflows/smoke.yml",
+      linearIssueId: "BEC-150",
+    });
+    expect(evt.eventType).toBe("qa.gap_issue_filed");
+    expect(() => AuditEventSchema.parse(evt)).not.toThrow();
+    expect(evt.payload.linearIssueId).toBe("BEC-150");
+  });
+});

--- a/packages/core/src/__tests__/qa-config.test.ts
+++ b/packages/core/src/__tests__/qa-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { QaCheckConfigSchema } from "../qa/types.js";
+import { ReleaseManagerConfigSchema } from "../release-manager/types.js";
+
+describe("QaCheckConfigSchema", () => {
+  it("parses minimal valid config", () => {
+    const cfg = QaCheckConfigSchema.parse({
+      workflow: ".github/workflows/smoke.yml",
+      linearTeamId: "team-uuid-123",
+    });
+    expect(cfg.workflow).toBe(".github/workflows/smoke.yml");
+    expect(cfg.timeoutMinutes).toBe(30); // default
+    expect(cfg.linearTeamId).toBe("team-uuid-123");
+    expect(cfg.workflowInputs).toBeUndefined();
+  });
+
+  it("respects custom timeoutMinutes", () => {
+    const cfg = QaCheckConfigSchema.parse({
+      workflow: ".github/workflows/smoke.yml",
+      linearTeamId: "team-uuid-123",
+      timeoutMinutes: 60,
+    });
+    expect(cfg.timeoutMinutes).toBe(60);
+  });
+
+  it("accepts workflowInputs object", () => {
+    const cfg = QaCheckConfigSchema.parse({
+      workflow: ".github/workflows/smoke.yml",
+      linearTeamId: "team-uuid-123",
+      workflowInputs: { environment: "preview" },
+    });
+    expect(cfg.workflowInputs).toEqual({ environment: "preview" });
+  });
+
+  it("rejects empty workflow string", () => {
+    expect(() =>
+      QaCheckConfigSchema.parse({
+        workflow: "",
+        linearTeamId: "team-uuid-123",
+      })
+    ).toThrow();
+  });
+
+  it("rejects empty linearTeamId", () => {
+    expect(() =>
+      QaCheckConfigSchema.parse({
+        workflow: ".github/workflows/smoke.yml",
+        linearTeamId: "",
+      })
+    ).toThrow();
+  });
+
+  it("rejects non-positive timeoutMinutes", () => {
+    expect(() =>
+      QaCheckConfigSchema.parse({
+        workflow: ".github/workflows/smoke.yml",
+        linearTeamId: "team-uuid-123",
+        timeoutMinutes: 0,
+      })
+    ).toThrow();
+  });
+});
+
+describe("ReleaseManagerConfigSchema with qaCheck", () => {
+  it("accepts a qaCheck trigger alongside existing triggers", () => {
+    const cfg = ReleaseManagerConfigSchema.parse({
+      enabled: true,
+      triggers: {
+        mergedPRsSince: 5,
+        qaCheck: {
+          workflow: ".github/workflows/smoke.yml",
+          linearTeamId: "team-uuid-123",
+        },
+      },
+    });
+    expect(cfg.triggers.qaCheck?.workflow).toBe(".github/workflows/smoke.yml");
+    expect(cfg.triggers.qaCheck?.timeoutMinutes).toBe(30);
+  });
+
+  it("treats qaCheck as a valid trigger to satisfy 'at least one trigger' guard", () => {
+    // qaCheck alone (no mergedPRsSince/timeSinceLastHours/ciGreenForMinutes/requireSlackApproval) should pass
+    const cfg = ReleaseManagerConfigSchema.parse({
+      enabled: true,
+      triggers: {
+        qaCheck: {
+          workflow: ".github/workflows/smoke.yml",
+          linearTeamId: "team-uuid-123",
+        },
+      },
+    });
+    expect(cfg.triggers.qaCheck).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/qa-eval.test.ts
+++ b/packages/core/src/__tests__/qa-eval.test.ts
@@ -70,7 +70,9 @@ describe("evalQaCheck", () => {
     });
     expect(result.pass).toBe(false);
     expect(result.reason).toBe("qa_running");
-    expect(result.reason === "qa_running" && result.runId).toBe(99999);
+    if (result.pass === false && result.reason === "qa_running") {
+      expect(result.runId).toBe(99999);
+    }
   });
 
   it("returns qa_timed_out when run has been running > timeoutMinutes", () => {
@@ -125,7 +127,9 @@ describe("evalQaCheck", () => {
     });
     expect(result.pass).toBe(false);
     expect(result.reason).toBe("qa_failed");
-    expect(result.reason === "qa_failed" && result.conclusion).toBe("failure");
+    if (result.pass === false && result.reason === "qa_failed") {
+      expect(result.conclusion).toBe("failure");
+    }
   });
 
   it("returns qa_failed for conclusion=cancelled", () => {
@@ -144,6 +148,8 @@ describe("evalQaCheck", () => {
     });
     expect(result.pass).toBe(false);
     expect(result.reason).toBe("qa_failed");
-    expect(result.reason === "qa_failed" && result.conclusion).toBe("cancelled");
+    if (result.pass === false && result.reason === "qa_failed") {
+      expect(result.conclusion).toBe("cancelled");
+    }
   });
 });

--- a/packages/core/src/__tests__/qa-eval.test.ts
+++ b/packages/core/src/__tests__/qa-eval.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { evalQaCheck } from "../release-manager/triggers.js";
+import type { QaCheckConfig, QaRunSnapshot } from "../qa/types.js";
+
+const NOW = new Date("2026-05-04T12:00:00Z");
+const cfg: QaCheckConfig = {
+  workflow: ".github/workflows/smoke.yml",
+  timeoutMinutes: 30,
+  linearTeamId: "team-uuid-123",
+};
+
+describe("evalQaCheck", () => {
+  it("returns qa_no_workflow when workflowFileExists=false", () => {
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: false,
+      qaRun: null,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_no_workflow");
+  });
+
+  it("returns qa_needs_trigger when workflow exists but no run for current SHA", () => {
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun: null,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_needs_trigger");
+  });
+
+  it("returns qa_needs_trigger when in-flight run is for stale SHA", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "old_sha",
+      triggeredAt: new Date(NOW.getTime() - 5 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_needs_trigger");
+  });
+
+  it("returns qa_running when run is in flight for current SHA, not yet timed out", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 5 * 60 * 1000), // 5 min ago, < 30 min timeout
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_running");
+    expect(result.reason === "qa_running" && result.runId).toBe(99999);
+  });
+
+  it("returns qa_timed_out when run has been running > timeoutMinutes", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 35 * 60 * 1000), // 35 min ago, > 30 min timeout
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: null,
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_timed_out");
+  });
+
+  it("returns pass:true when run completed with conclusion=success", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 10 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: "success",
+      now: NOW,
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toMatch(/qa passed/i);
+  });
+
+  it("returns qa_failed for conclusion=failure", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 10 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: "failure",
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_failed");
+    expect(result.reason === "qa_failed" && result.conclusion).toBe("failure");
+  });
+
+  it("returns qa_failed for conclusion=cancelled", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "head_sha_1",
+      triggeredAt: new Date(NOW.getTime() - 10 * 60 * 1000),
+    };
+    const result = evalQaCheck({
+      qaConfig: cfg,
+      headSha: "head_sha_1",
+      workflowFileExists: true,
+      qaRun,
+      runConclusion: "cancelled",
+      now: NOW,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("qa_failed");
+    expect(result.reason === "qa_failed" && result.conclusion).toBe("cancelled");
+  });
+});

--- a/packages/core/src/__tests__/qa-gap.test.ts
+++ b/packages/core/src/__tests__/qa-gap.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { eq, and, isNull } from "drizzle-orm";
+import { createDb } from "../db/index.js";
+import { qaGapIssues } from "../db/schema.js";
+import { fileGapIssue } from "../qa/gap.js";
+
+function tmpDbPath(): string {
+  const id = randomBytes(8).toString("hex");
+  return `/tmp/laf-qa-gap-fn-${id}.sqlite`;
+}
+
+describe("fileGapIssue", () => {
+  const paths: string[] = [];
+  let db: any;
+  const repoUrl = "https://github.com/org/repo";
+  const branch = "main";
+  const workflowPath = ".github/workflows/smoke.yml";
+
+  beforeEach(async () => {
+    const path = tmpDbPath();
+    paths.push(path);
+    const created = await createDb({ driver: "sqlite", connectionString: path });
+    db = created as any;
+  });
+
+  afterEach(() => {
+    for (const p of paths) {
+      try { unlinkSync(p); } catch {}
+      try { unlinkSync(p + "-wal"); } catch {}
+      try { unlinkSync(p + "-shm"); } catch {}
+    }
+    paths.length = 0;
+  });
+
+  function makeMockLinear(over: any = {}) {
+    return {
+      createIssue: vi.fn(async () => ({
+        issue: Promise.resolve({ identifier: "BEC-150", url: "https://linear.app/beckerspace/issue/BEC-150" }),
+      })),
+      ...over,
+    };
+  }
+
+  it("files a new issue when none exists, persists qa_gap_issues row", async () => {
+    const linear = makeMockLinear();
+    const result = await fileGapIssue({
+      db,
+      linear: linear as any,
+      repoUrl,
+      branch,
+      workflowPath,
+      linearTeamId: "team-uuid-123",
+    });
+    expect(result.kind).toBe("filed");
+    expect(result.kind === "filed" && result.linearIssueId).toBe("BEC-150");
+    expect(linear.createIssue).toHaveBeenCalledTimes(1);
+    const rows = await db.select().from(qaGapIssues).where(
+      and(eq(qaGapIssues.repoUrl, repoUrl), isNull(qaGapIssues.resolvedAt)),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].linearIssueId).toBe("BEC-150");
+  });
+
+  it("is idempotent — second call with existing open row is a no-op", async () => {
+    const linear = makeMockLinear();
+    await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    linear.createIssue.mockClear();
+
+    const result = await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    expect(result.kind).toBe("already_filed");
+    expect(result.kind === "already_filed" && result.linearIssueId).toBe("BEC-150");
+    expect(linear.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("re-files when the previous row was resolved", async () => {
+    const linear = makeMockLinear();
+    await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+
+    // Resolve the existing row
+    await db.update(qaGapIssues)
+      .set({ resolvedAt: new Date() })
+      .where(eq(qaGapIssues.linearIssueId, "BEC-150"));
+
+    // Update the mock to return a new ID for the second filing
+    linear.createIssue.mockResolvedValueOnce({
+      issue: Promise.resolve({ identifier: "BEC-160", url: "https://linear.app/beckerspace/issue/BEC-160" }),
+    });
+
+    const result = await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    expect(result.kind).toBe("filed");
+    expect(result.kind === "filed" && result.linearIssueId).toBe("BEC-160");
+    expect(linear.createIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns linear_error on Linear API failure", async () => {
+    const linear = makeMockLinear({
+      createIssue: vi.fn(async () => { throw new Error("Linear unauthorized"); }),
+    });
+    const result = await fileGapIssue({ db, linear: linear as any, repoUrl, branch, workflowPath, linearTeamId: "team-uuid-123" });
+    expect(result.kind).toBe("linear_error");
+    expect(result.kind === "linear_error" && result.message).toMatch(/unauthorized/);
+  });
+});

--- a/packages/core/src/__tests__/qa-github.test.ts
+++ b/packages/core/src/__tests__/qa-github.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  triggerWorkflow,
+  pollWorkflowRun,
+  workflowFileExists,
+} from "../qa/github.js";
+import type { AnyDb } from "../db/client.js";
+
+const fakeDb = {} as AnyDb;
+const owner = "org";
+const repo = "repo";
+
+function makeMockOctokit(over: any = {}) {
+  return {
+    actions: {
+      createWorkflowDispatch: vi.fn(async () => ({ status: 204 })),
+      listWorkflowRuns: vi.fn(async () => ({
+        data: { workflow_runs: [{ id: 99999, head_sha: "abc123", status: "in_progress", conclusion: null, created_at: "2026-05-04T12:00:00Z", run_started_at: "2026-05-04T12:00:00Z" }] },
+      })),
+      getWorkflowRun: vi.fn(async () => ({
+        data: { id: 99999, head_sha: "abc123", status: "in_progress", conclusion: null, run_started_at: "2026-05-04T12:00:00Z", updated_at: "2026-05-04T12:10:00Z" },
+      })),
+    },
+    repos: {
+      getContent: vi.fn(async () => ({ data: { type: "file", path: ".github/workflows/smoke.yml" } })),
+    },
+    ...over,
+  } as any;
+}
+
+describe("workflowFileExists", () => {
+  it("returns true when file content is fetched successfully", async () => {
+    const octokit = makeMockOctokit();
+    const exists = await workflowFileExists({ octokit, owner, repo, path: ".github/workflows/smoke.yml", ref: "main" });
+    expect(exists).toBe(true);
+    expect(octokit.repos.getContent).toHaveBeenCalledWith({ owner, repo, path: ".github/workflows/smoke.yml", ref: "main" });
+  });
+  it("returns false on 404", async () => {
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => {
+          const err: any = new Error("Not Found");
+          err.status = 404;
+          throw err;
+        }),
+      },
+    });
+    const exists = await workflowFileExists({ octokit, owner, repo, path: ".github/workflows/smoke.yml", ref: "main" });
+    expect(exists).toBe(false);
+  });
+  it("rethrows on 5xx", async () => {
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => {
+          const err: any = new Error("Server Error");
+          err.status = 500;
+          throw err;
+        }),
+      },
+    });
+    await expect(
+      workflowFileExists({ octokit, owner, repo, path: ".github/workflows/smoke.yml", ref: "main" })
+    ).rejects.toThrow("Server Error");
+  });
+});
+
+describe("triggerWorkflow", () => {
+  it("calls createWorkflowDispatch then finds the new run by SHA", async () => {
+    const octokit = makeMockOctokit();
+    const result = await triggerWorkflow({
+      octokit,
+      db: fakeDb,
+      owner,
+      repo,
+      repoUrl: `https://github.com/${owner}/${repo}`,
+      branch: "main",
+      workflow: ".github/workflows/smoke.yml",
+      ref: "abc123",
+      inputs: { environment: "preview" },
+    });
+    expect(result.kind).toBe("ok");
+    expect(result.kind === "ok" && result.runId).toBe(99999);
+    expect(octokit.actions.createWorkflowDispatch).toHaveBeenCalledWith({
+      owner,
+      repo,
+      workflow_id: ".github/workflows/smoke.yml",
+      ref: "abc123",
+      inputs: { environment: "preview" },
+    });
+  });
+
+  it("returns dispatch_404 on 404 (workflow file missing)", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const err: any = new Error("Not Found");
+          err.status = 404;
+          throw err;
+        }),
+      },
+    });
+    const result = await triggerWorkflow({
+      octokit, db: fakeDb, owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, branch: "main",
+      workflow: ".github/workflows/smoke.yml", ref: "abc123",
+    });
+    expect(result.kind).toBe("dispatch_404");
+  });
+
+  it("returns dispatch_422 on 422 (workflow not workflow_dispatch-triggered)", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const err: any = new Error("Unprocessable Entity");
+          err.status = 422;
+          throw err;
+        }),
+      },
+    });
+    const result = await triggerWorkflow({
+      octokit, db: fakeDb, owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, branch: "main",
+      workflow: ".github/workflows/smoke.yml", ref: "abc123",
+    });
+    expect(result.kind).toBe("dispatch_422");
+  });
+
+  it("returns dispatch_error on 5xx", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const err: any = new Error("Server Error");
+          err.status = 502;
+          throw err;
+        }),
+      },
+    });
+    const result = await triggerWorkflow({
+      octokit, db: fakeDb, owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, branch: "main",
+      workflow: ".github/workflows/smoke.yml", ref: "abc123",
+    });
+    expect(result.kind).toBe("dispatch_error");
+    expect(result.kind === "dispatch_error" && result.message).toMatch(/Server Error/);
+  });
+});
+
+describe("pollWorkflowRun", () => {
+  it("returns running for in_progress runs", async () => {
+    const octokit = makeMockOctokit();
+    const result = await pollWorkflowRun({ octokit, owner, repo, runId: 99999 });
+    expect(result.kind).toBe("running");
+  });
+
+  it("returns completed with conclusion=success", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        getWorkflowRun: vi.fn(async () => ({
+          data: { id: 99999, status: "completed", conclusion: "success", run_started_at: "2026-05-04T12:00:00Z", updated_at: "2026-05-04T12:10:00Z" },
+        })),
+      },
+    });
+    const result = await pollWorkflowRun({ octokit, owner, repo, runId: 99999 });
+    expect(result.kind).toBe("completed");
+    expect(result.kind === "completed" && result.conclusion).toBe("success");
+    expect(result.kind === "completed" && result.durationMs).toBe(10 * 60 * 1000);
+  });
+
+  it("returns completed with conclusion=failure", async () => {
+    const octokit = makeMockOctokit({
+      actions: {
+        getWorkflowRun: vi.fn(async () => ({
+          data: { id: 99999, status: "completed", conclusion: "failure", run_started_at: "2026-05-04T12:00:00Z", updated_at: "2026-05-04T12:05:00Z" },
+        })),
+      },
+    });
+    const result = await pollWorkflowRun({ octokit, owner, repo, runId: 99999 });
+    expect(result.kind).toBe("completed");
+    expect(result.kind === "completed" && result.conclusion).toBe("failure");
+  });
+});

--- a/packages/core/src/__tests__/release-manager-decide.test.ts
+++ b/packages/core/src/__tests__/release-manager-decide.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { decide } from "../release-manager/decide.js";
 import type { CollectedState } from "../release-manager/types.js";
+import type { QaCheckConfig, QaRunSnapshot } from "../qa/types.js";
 
 const NOW = new Date("2026-05-01T12:00:00Z");
 
@@ -93,6 +94,62 @@ describe("decide()", () => {
       baseState({ hasFreshApproval: false }),
       { mergedPRsSince: 5, requireSlackApproval: false },
       NOW,
+    );
+    expect(r.kind).toBe("fire");
+  });
+});
+
+describe("decide() qaCheck slot-4 integration", () => {
+  const qaConfig: QaCheckConfig = {
+    workflow: ".github/workflows/smoke.yml",
+    timeoutMinutes: 30,
+    linearTeamId: "team-uuid-123",
+  };
+
+  it("evaluates qaCheck after ciGreenForMinutes — qaCheck failure trumps requireSlackApproval", () => {
+    // mergedPRsSince + ciGreen pass; qaCheck fails (no workflow); requireSlackApproval would also fail
+    // expected: skip with qa_no_workflow (NOT awaiting-approval)
+    const r = decide(
+      baseState({
+        hasFreshApproval: false,
+      }),
+      {
+        mergedPRsSince: 5,
+        ciGreenForMinutes: 30,
+        qaCheck: qaConfig,
+        requireSlackApproval: true,
+      },
+      NOW,
+      { workflowFileExists: false, runConclusion: null },
+    );
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("qa_no_workflow");
+    expect(r.kind === "skip" ? r.qaActionNeeded?.reason : undefined).toBe("qa_no_workflow");
+  });
+
+  it("bubbles qaActionNeeded for qa_needs_trigger when workflow exists but no run for SHA", () => {
+    const r = decide(
+      baseState({}),
+      { mergedPRsSince: 5, qaCheck: qaConfig, requireSlackApproval: false },
+      NOW,
+      { workflowFileExists: true, runConclusion: null },
+    );
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("qa_needs_trigger");
+    expect(r.kind === "skip" ? r.qaActionNeeded?.reason : undefined).toBe("qa_needs_trigger");
+  });
+
+  it("returns fire when qaCheck passes alongside other passing triggers", () => {
+    const qaRun: QaRunSnapshot = {
+      runId: 99999,
+      runSha: "fedcba0",
+      triggeredAt: new Date(NOW.getTime() - 5 * 60 * 1000),
+    };
+    const r = decide(
+      baseState({ qaRun }),
+      { mergedPRsSince: 5, qaCheck: qaConfig, requireSlackApproval: false },
+      NOW,
+      { workflowFileExists: true, runConclusion: "success" },
     );
     expect(r.kind).toBe("fire");
   });

--- a/packages/core/src/__tests__/release-manager-decide.test.ts
+++ b/packages/core/src/__tests__/release-manager-decide.test.ts
@@ -17,6 +17,7 @@ function baseState(over: Partial<CollectedState> = {}): CollectedState {
     hasFreshApproval: true,
     freshApprovalApprover: "U123",
     manualTagDetected: false,
+    qaRun: null,
     ...over,
   };
 }

--- a/packages/core/src/__tests__/release-manager-scheduler.test.ts
+++ b/packages/core/src/__tests__/release-manager-scheduler.test.ts
@@ -218,3 +218,177 @@ describe("createReleaseManagerScheduler — single tick", () => {
     expect(rows[0].reason).toBe("tag_exists");
   });
 });
+
+describe("createReleaseManagerScheduler — qaCheck integration", () => {
+  const paths: string[] = [];
+  let db: any;
+  const repoUrl = "https://github.com/org/repo";
+  const branch = "main";
+  const qaConfig = {
+    enabled: true,
+    triggers: {
+      mergedPRsSince: 1,
+      qaCheck: {
+        workflow: ".github/workflows/smoke.yml",
+        linearTeamId: "team-uuid-123",
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    delete process.env.URATEAM_LICENSE_KEY;
+    _resetLicenseCache();
+    const path = tmpDbPath();
+    paths.push(path);
+    const created = await createDb({ driver: "sqlite", connectionString: path });
+    db = created as any;
+  });
+
+  afterEach(() => {
+    for (const p of paths) {
+      try { unlinkSync(p); } catch {}
+      try { unlinkSync(p + "-wal"); } catch {}
+      try { unlinkSync(p + "-shm"); } catch {}
+    }
+    paths.length = 0;
+    _resetLicenseCache();
+  });
+
+  it("triggers workflow when qaCheck.workflow exists but no run for headSha", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => ({ data: { type: "file" } })), // workflow exists
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => ({ status: 204 })),
+        listWorkflowRuns: vi.fn(async () => ({ data: { workflow_runs: [{ id: 88888, head_sha: "head_sha_x", status: "in_progress", run_started_at: "2026-05-04T12:00:00Z" }] } })),
+      },
+      checks: {
+        listForRef: vi.fn(async () => ({ data: { check_runs: [] } })),
+      },
+    });
+    const linear = { createIssue: vi.fn() };
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: linear as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    expect(octokit.actions.createWorkflowDispatch).toHaveBeenCalled();
+    const rows = await db.select().from(releaseDecisions);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].decision).toBe("skip");
+    expect(rows[0].reason).toBe("qa_needs_trigger");
+    expect(rows[0].qaRunId).toBe(88888);
+    expect(rows[0].qaRunSha).toBe("head_sha_x");
+  });
+
+  it("polls existing in-flight run and writes qa_running skip", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    // Pre-seed an in-flight QA run row
+    await db.insert(releaseDecisions).values({
+      id: "rd_pre",
+      repoUrl,
+      branch,
+      decidedAt: new Date(Date.now() - 5 * 60 * 1000),
+      decision: "skip",
+      reason: "qa_needs_trigger",
+      triggerStateJson: "{}",
+      attemptCount: 0,
+      qaRunId: 88888,
+      qaRunSha: "head_sha_x",
+    });
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => ({ data: { type: "file" } })),
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(),  // should NOT be called
+        getWorkflowRun: vi.fn(async () => ({ data: { id: 88888, status: "in_progress", conclusion: null, run_started_at: "2026-05-04T12:00:00Z" } })),
+      },
+      checks: { listForRef: vi.fn(async () => ({ data: { check_runs: [] } })) },
+    });
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: { createIssue: vi.fn() } as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    expect(octokit.actions.createWorkflowDispatch).not.toHaveBeenCalled();
+    expect(octokit.actions.getWorkflowRun).toHaveBeenCalled();
+    const rows = await db.select().from(releaseDecisions);
+    // Two rows: pre-seed + new tick
+    expect(rows.length).toBe(2);
+    const newRow = rows.find((r: any) => r.id !== "rd_pre");
+    expect(newRow.reason).toBe("qa_running");
+  });
+
+  it("files Linear gap issue when workflow file is missing", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => {
+          const e: any = new Error("Not Found"); e.status = 404; throw e;
+        }),
+      },
+      checks: { listForRef: vi.fn(async () => ({ data: { check_runs: [] } })) },
+    });
+    const linear = {
+      createIssue: vi.fn(async () => ({ issue: Promise.resolve({ identifier: "BEC-150" }) })),
+    };
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: linear as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    expect(linear.createIssue).toHaveBeenCalledTimes(1);
+    const rows = await db.select().from(releaseDecisions);
+    expect(rows[0].reason).toBe("qa_no_workflow");
+  });
+
+  it("retry counter: 3 consecutive dispatch failures → permanent skip with qa_dispatch_error", async () => {
+    const cfg = ReleaseManagerConfigSchema.parse(qaConfig);
+    const octokit = makeMockOctokit({
+      repos: {
+        getBranch: vi.fn(async () => ({ data: { commit: { sha: "head_sha_x" } } })),
+        listTags: vi.fn(async () => ({ data: [{ name: "v1.0.0", commit: { sha: "old_sha" } }] })),
+        getCommit: vi.fn(async () => ({ data: { commit: { committer: { date: "2026-04-01T12:00:00Z" } } } })),
+        compareCommits: vi.fn(async () => ({ data: { commits: [{ commit: { message: "fix: a" } }] } })),
+        listCommits: vi.fn(async () => ({ data: [] })),
+        getContent: vi.fn(async () => ({ data: { type: "file" } })),
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(async () => {
+          const e: any = new Error("Server Error"); e.status = 502; throw e;
+        }),
+        listWorkflowRuns: vi.fn(async () => ({ data: { workflow_runs: [] } })),
+      },
+      checks: { listForRef: vi.fn(async () => ({ data: { check_runs: [] } })) },
+    });
+    const sched = createReleaseManagerScheduler({
+      config: cfg, db, octokit, linear: { createIssue: vi.fn() } as any, repoUrl,
+      isLicensed: () => true, slack: undefined,
+    });
+    await sched.tick();
+    await sched.tick();
+    await sched.tick();
+    const rows = await db.select().from(releaseDecisions);
+    expect(rows.length).toBe(3);
+    expect(rows[2].reason).toBe("qa_dispatch_error");
+    expect(rows[2].decision).toBe("skip");
+  });
+});

--- a/packages/core/src/__tests__/release-manager-scheduler.test.ts
+++ b/packages/core/src/__tests__/release-manager-scheduler.test.ts
@@ -386,7 +386,7 @@ describe("createReleaseManagerScheduler — qaCheck integration", () => {
     await sched.tick();
     await sched.tick();
     await sched.tick();
-    const rows = await db.select().from(releaseDecisions);
+    const rows = await db.select().from(releaseDecisions).orderBy(releaseDecisions.decidedAt);
     expect(rows.length).toBe(3);
     expect(rows[2].reason).toBe("qa_dispatch_error");
     expect(rows[2].decision).toBe("skip");

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -417,3 +417,67 @@ export function slackPostFailedEvent(args: {
     payload: { channel: args.channel, reason: args.reason },
   });
 }
+
+export function qaRunTriggeredEvent(args: {
+  repoUrl: string;
+  branch: string;
+  workflow: string;
+  runId: number;
+  sha: string;
+}): AuditEvent {
+  return base({
+    eventType: "qa.run_triggered",
+    actor: "release-manager",
+    actorType: "release-manager",
+    scope: `repo:${args.repoUrl}`,
+    payload: {
+      branch: args.branch,
+      workflow: args.workflow,
+      runId: args.runId,
+      sha: args.sha,
+    },
+  });
+}
+
+export function qaRunCompletedEvent(args: {
+  repoUrl: string;
+  branch: string;
+  runId: number;
+  conclusion: "success" | "failure" | "cancelled" | "timed_out" | "action_required" | "skipped" | "stale" | "neutral";
+  durationMs: number;
+  /** Set to true when we synthesize a timeout (GitHub didn't conclude the run). */
+  synthetic?: boolean;
+}): AuditEvent {
+  return base({
+    eventType: "qa.run_completed",
+    actor: "release-manager",
+    actorType: "release-manager",
+    scope: `repo:${args.repoUrl}`,
+    payload: {
+      branch: args.branch,
+      runId: args.runId,
+      conclusion: args.conclusion,
+      durationMs: args.durationMs,
+      synthetic: args.synthetic ?? false,
+    },
+  });
+}
+
+export function qaGapIssueFiledEvent(args: {
+  repoUrl: string;
+  branch: string;
+  workflowPath: string;
+  linearIssueId: string;
+}): AuditEvent {
+  return base({
+    eventType: "qa.gap_issue_filed",
+    actor: "release-manager",
+    actorType: "release-manager",
+    scope: `repo:${args.repoUrl}`,
+    payload: {
+      branch: args.branch,
+      workflowPath: args.workflowPath,
+      linearIssueId: args.linearIssueId,
+    },
+  });
+}

--- a/packages/core/src/db/migrations/postgres/011_qa_run_columns.sql
+++ b/packages/core/src/db/migrations/postgres/011_qa_run_columns.sql
@@ -1,0 +1,8 @@
+-- BEC-136: QA agent — track in-flight workflow runs on the release_decisions table.
+
+ALTER TABLE release_decisions ADD COLUMN IF NOT EXISTS qa_run_id INTEGER;
+ALTER TABLE release_decisions ADD COLUMN IF NOT EXISTS qa_run_sha TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_release_decisions_qa_run_id
+  ON release_decisions(repo_url, branch, qa_run_id, decided_at DESC)
+  WHERE qa_run_id IS NOT NULL;

--- a/packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql
+++ b/packages/core/src/db/migrations/postgres/012_qa_gap_issues.sql
@@ -1,0 +1,18 @@
+-- BEC-136: QA agent — Linear issue idempotency for missing QA workflows.
+
+CREATE TABLE IF NOT EXISTS qa_gap_issues (
+  id TEXT PRIMARY KEY,
+  repo_url TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  workflow_path TEXT NOT NULL,
+  linear_issue_id TEXT NOT NULL,
+  filed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_qa_gap_issues_unique_open
+  ON qa_gap_issues(repo_url, branch, workflow_path)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_qa_gap_issues_lookup
+  ON qa_gap_issues(repo_url, branch, workflow_path, resolved_at);

--- a/packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql
+++ b/packages/core/src/db/migrations/sqlite/010_qa_run_columns.sql
@@ -1,0 +1,9 @@
+-- BEC-136: QA agent — track in-flight workflow runs on the release_decisions table.
+
+ALTER TABLE release_decisions ADD COLUMN qa_run_id INTEGER;
+ALTER TABLE release_decisions ADD COLUMN qa_run_sha TEXT;
+
+-- Index for collectState's qaRun lookup: fastest path for "most recent decision with non-null qa_run_id"
+CREATE INDEX IF NOT EXISTS idx_release_decisions_qa_run_id
+  ON release_decisions(repo_url, branch, qa_run_id, decided_at DESC)
+  WHERE qa_run_id IS NOT NULL;

--- a/packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql
+++ b/packages/core/src/db/migrations/sqlite/011_qa_gap_issues.sql
@@ -1,0 +1,22 @@
+-- BEC-136: QA agent — Linear issue idempotency for missing QA workflows.
+
+CREATE TABLE IF NOT EXISTS qa_gap_issues (
+  id TEXT PRIMARY KEY,
+  repo_url TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  workflow_path TEXT NOT NULL,
+  linear_issue_id TEXT NOT NULL,
+  filed_at INTEGER NOT NULL,
+  resolved_at INTEGER
+);
+
+-- Partial UNIQUE: at most one open gap issue per (repo, branch, workflow) at a time.
+-- Once resolved (resolved_at IS NOT NULL), the row is preserved for audit but a new
+-- issue can be filed for the same gap in the future.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_qa_gap_issues_unique_open
+  ON qa_gap_issues(repo_url, branch, workflow_path)
+  WHERE resolved_at IS NULL;
+
+-- Lookup index for "is there an open gap for this (repo, branch, workflow)?" — partial too.
+CREATE INDEX IF NOT EXISTS idx_qa_gap_issues_lookup
+  ON qa_gap_issues(repo_url, branch, workflow_path, resolved_at);

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -261,6 +261,10 @@ export const releaseDecisions = sqliteTable("release_decisions", {
   firedSha: text("fired_sha"),
   /** Tracks retries when GitHub release-creation fails after tag was created. Capped at 3. */
   attemptCount: integer("attempt_count").notNull().default(0),
+  /** BEC-136: GitHub workflow run ID for the in-flight QA run. Null when no QA in flight. */
+  qaRunId: integer("qa_run_id"),
+  /** BEC-136: SHA the QA workflow was triggered against. Used to detect mid-run SHA mismatch. */
+  qaRunSha: text("qa_run_sha"),
 });
 
 /** BEC-135: one-shot Slack-driven approvals consumed by the next eligible fire. */
@@ -279,6 +283,27 @@ export const releaseApprovals = sqliteTable(
     consumedByDecisionId: text("consumed_by_decision_id"),
   },
   // The UNIQUE WHERE consumed_at IS NULL partial index is created in the
+  // raw migration SQL because Drizzle's sqliteTable.unique() helper does
+  // not support partial indexes. Migration files own that concern.
+);
+
+/** BEC-136: tracks Linear issues filed for missing QA workflows — partial UNIQUE prevents re-filing while open. */
+export const qaGapIssues = sqliteTable(
+  "qa_gap_issues",
+  {
+    id: text("id").primaryKey(),
+    repoUrl: text("repo_url").notNull(),
+    branch: text("branch").notNull(),
+    workflowPath: text("workflow_path").notNull(),
+    /** Linear issue identifier returned at file time (e.g., "BEC-150"). */
+    linearIssueId: text("linear_issue_id").notNull(),
+    filedAt: crossTimestamp("filed_at")
+      .notNull()
+      .$defaultFn(() => new Date()),
+    /** Set when the gap is detected as resolved (workflow file appears). Issue itself is closed manually by operator. */
+    resolvedAt: crossTimestamp("resolved_at"),
+  },
+  // The UNIQUE WHERE resolved_at IS NULL partial index is created in the
   // raw migration SQL because Drizzle's sqliteTable.unique() helper does
   // not support partial indexes. Migration files own that concern.
 );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,3 +80,4 @@ export {
   type FileOverlapResult as CoordinationFileOverlapResult,
 } from "./pm/coordination.js";
 export * from "./release-manager/index.js";
+export * from "./qa/index.js";

--- a/packages/core/src/qa/gap.ts
+++ b/packages/core/src/qa/gap.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from "node:crypto";
+import { eq, and, isNull } from "drizzle-orm";
+import type { LinearClient } from "@linear/sdk";
+import type { AnyDb } from "../db/client.js";
+import { qaGapIssues } from "../db/schema.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
+import { qaGapIssueFiledEvent } from "../audit/events.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "Qa:gap" });
+
+export interface FileGapIssueInput {
+  db: AnyDb;
+  linear: LinearClient;
+  repoUrl: string;
+  branch: string;
+  workflowPath: string;
+  linearTeamId: string;
+}
+
+export type FileGapIssueResult =
+  | { kind: "filed"; linearIssueId: string }
+  | { kind: "already_filed"; linearIssueId: string }
+  | { kind: "linear_error"; message: string };
+
+const ISSUE_TITLE_PREFIX = "QA workflow missing";
+const ISSUE_BODY_TEMPLATE = `# QA workflow missing
+
+The Release Manager attempted to verify a QA workflow for this branch but could not find the configured file.
+
+**Repo:** {repoUrl}
+**Branch:** {branch}
+**Expected workflow path:** \`{workflowPath}\`
+
+## What this means
+
+When the Release Manager fires a release on this branch, it expects a GitHub Actions workflow at the path above to verify the merge commit before tagging. The file is currently missing, so the agent has paused all release activity for this branch until you add it.
+
+## How to resolve
+
+1. Add a workflow file at \`{workflowPath}\` that:
+   - Has \`on: workflow_dispatch\` (so the Release Manager can trigger it)
+   - Runs your smoke / integration tests against the merge commit
+   - Exits zero on success and non-zero on failure
+
+2. Commit and push the workflow file. The Release Manager will detect it on the next tick and resume normal release decisions.
+
+3. Once the workflow has run green at least once, this Linear issue can be closed manually.
+
+## Reference
+
+The Release Manager and QA agent are documented at \`docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md\` in the urateam repo. v1 only supports rule-based detection (file exists / file missing) — there is no automatic test scaffolding in v1.
+
+🤖 Filed by urateam Release Manager (BEC-136).`;
+
+export async function fileGapIssue(input: FileGapIssueInput): Promise<FileGapIssueResult> {
+  const { db, linear, repoUrl, branch, workflowPath, linearTeamId } = input;
+
+  // Idempotency check: is there already an open gap row for this (repo, branch, workflow)?
+  const existing = await (db as any)
+    .select({ linearIssueId: qaGapIssues.linearIssueId })
+    .from(qaGapIssues)
+    .where(
+      and(
+        eq(qaGapIssues.repoUrl, repoUrl),
+        eq(qaGapIssues.branch, branch),
+        eq(qaGapIssues.workflowPath, workflowPath),
+        isNull(qaGapIssues.resolvedAt),
+      ),
+    )
+    .limit(1);
+  if (existing?.[0]?.linearIssueId) {
+    return { kind: "already_filed", linearIssueId: existing[0].linearIssueId };
+  }
+
+  // No open row — file a new Linear issue.
+  let identifier: string;
+  try {
+    const body = ISSUE_BODY_TEMPLATE
+      .replace("{repoUrl}", repoUrl)
+      .replace(/{branch}/g, branch)
+      .replace(/{workflowPath}/g, workflowPath);
+    const created = await linear.createIssue({
+      teamId: linearTeamId,
+      title: `${ISSUE_TITLE_PREFIX} for ${repoUrl} (${branch})`,
+      description: body,
+    });
+    const issue = await (created as any).issue;
+    identifier = issue?.identifier ?? "";
+    if (!identifier) {
+      return { kind: "linear_error", message: "Linear createIssue returned no identifier" };
+    }
+  } catch (err: any) {
+    const msg = err?.message ?? String(err);
+    log.error({ err, repoUrl, branch, workflowPath }, "Linear createIssue failed");
+    return { kind: "linear_error", message: msg };
+  }
+
+  // Persist the qa_gap_issues row to enforce idempotency.
+  await (db as any).insert(qaGapIssues).values({
+    id: `qg_${randomUUID()}`,
+    repoUrl,
+    branch,
+    workflowPath,
+    linearIssueId: identifier,
+    filedAt: new Date(),
+  });
+
+  void logAuditEventUnchecked(
+    db,
+    qaGapIssueFiledEvent({ repoUrl, branch, workflowPath, linearIssueId: identifier }),
+  );
+
+  return { kind: "filed", linearIssueId: identifier };
+}
+
+/** Mark the open gap-issue row as resolved (called when the workflow file appears). */
+export async function markGapResolved(input: {
+  db: AnyDb;
+  repoUrl: string;
+  branch: string;
+  workflowPath: string;
+}): Promise<void> {
+  const { db, repoUrl, branch, workflowPath } = input;
+  await (db as any)
+    .update(qaGapIssues)
+    .set({ resolvedAt: new Date() })
+    .where(
+      and(
+        eq(qaGapIssues.repoUrl, repoUrl),
+        eq(qaGapIssues.branch, branch),
+        eq(qaGapIssues.workflowPath, workflowPath),
+        isNull(qaGapIssues.resolvedAt),
+      ),
+    );
+}

--- a/packages/core/src/qa/github.ts
+++ b/packages/core/src/qa/github.ts
@@ -48,7 +48,8 @@ export type TriggerWorkflowResult =
   | { kind: "ok"; runId: number }
   | { kind: "dispatch_404" }
   | { kind: "dispatch_422"; message: string }
-  | { kind: "dispatch_error"; message: string };
+  | { kind: "dispatch_error"; message: string }
+  | { kind: "dispatch_pending"; message: string }; // GitHub eventual-consistency window
 
 /**
  * Trigger a workflow_dispatch and find the resulting run.
@@ -106,8 +107,8 @@ export async function triggerWorkflow(
   }
 
   if (runId === null) {
-    // Eventual-consistency window. Treat as needs-retry so the next tick re-evaluates.
-    return { kind: "dispatch_error", message: "dispatch succeeded but run not found yet" };
+    // Eventual-consistency window. Treat as needs-retry without burning the retry budget.
+    return { kind: "dispatch_pending", message: "dispatch succeeded but run not found yet" };
   }
 
   void logAuditEventUnchecked(

--- a/packages/core/src/qa/github.ts
+++ b/packages/core/src/qa/github.ts
@@ -1,0 +1,156 @@
+import type { Octokit } from "@octokit/rest";
+import type { AnyDb } from "../db/client.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
+import { qaRunTriggeredEvent } from "../audit/events.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "Qa:github" });
+
+export interface WorkflowFileExistsInput {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  path: string;
+  ref: string;
+}
+
+/**
+ * Returns true when the workflow file exists at the given ref, false on 404,
+ * rethrows on other errors. The workflow file existence check uses the
+ * contents API rather than the actions API because the actions API requires
+ * the workflow to also be registered (i.e., GitHub must have parsed it on a
+ * push event), which can lag behind the file appearing in the repo.
+ */
+export async function workflowFileExists(input: WorkflowFileExistsInput): Promise<boolean> {
+  const { octokit, owner, repo, path, ref } = input;
+  try {
+    await octokit.repos.getContent({ owner, repo, path, ref });
+    return true;
+  } catch (err: any) {
+    if (err?.status === 404) return false;
+    throw err;
+  }
+}
+
+export interface TriggerWorkflowInput {
+  octokit: Octokit;
+  db: AnyDb;
+  owner: string;
+  repo: string;
+  repoUrl: string;
+  branch: string;
+  workflow: string;          // e.g. ".github/workflows/smoke.yml"
+  ref: string;               // SHA to dispatch against
+  inputs?: Record<string, string>;
+}
+
+export type TriggerWorkflowResult =
+  | { kind: "ok"; runId: number }
+  | { kind: "dispatch_404" }
+  | { kind: "dispatch_422"; message: string }
+  | { kind: "dispatch_error"; message: string };
+
+/**
+ * Trigger a workflow_dispatch and find the resulting run.
+ *
+ * GitHub's workflow_dispatch API returns 204 No Content on success — it does
+ * NOT return the run ID. To discover the run, we list runs for the workflow
+ * filtered by SHA + workflow path and take the most-recent. There's a brief
+ * eventual-consistency window (typically <5s) where the run may not appear yet;
+ * the caller's tick will retry naturally on the next iteration.
+ *
+ * On dispatch failure, the result is classified into 3 kinds so the scheduler
+ * can route appropriately:
+ *   - dispatch_404: drop into the qa_no_workflow path (file gap issue)
+ *   - dispatch_422: workflow exists but lacks `on: workflow_dispatch` — write skip
+ *   - dispatch_error: 5xx / rate limit — retry on next tick (uses retry counter)
+ *
+ * Emits qa.run_triggered audit event on the "ok" path.
+ */
+export async function triggerWorkflow(
+  input: TriggerWorkflowInput,
+): Promise<TriggerWorkflowResult> {
+  const { octokit, db, owner, repo, repoUrl, branch, workflow, ref, inputs } = input;
+
+  try {
+    await octokit.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: workflow,
+      ref,
+      ...(inputs ? { inputs } : {}),
+    });
+  } catch (err: any) {
+    const status = err?.status;
+    const msg = err?.message ?? String(err);
+    if (status === 404) return { kind: "dispatch_404" };
+    if (status === 422) return { kind: "dispatch_422", message: msg };
+    return { kind: "dispatch_error", message: msg };
+  }
+
+  // Find the just-triggered run. List the most recent runs for this workflow
+  // filtered by head SHA. Take the first match (most recent dispatch on this SHA).
+  let runId: number | null = null;
+  try {
+    const list = await octokit.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: workflow as any, // octokit accepts string filename
+      head_sha: ref,
+      per_page: 5,
+    });
+    const runs = (list as any).data?.workflow_runs ?? [];
+    runId = runs[0]?.id ?? null;
+  } catch (err) {
+    log.warn({ err, workflow, ref }, "listWorkflowRuns failed after dispatch — run will be picked up next tick");
+  }
+
+  if (runId === null) {
+    // Eventual-consistency window. Treat as needs-retry so the next tick re-evaluates.
+    return { kind: "dispatch_error", message: "dispatch succeeded but run not found yet" };
+  }
+
+  void logAuditEventUnchecked(
+    db,
+    qaRunTriggeredEvent({ repoUrl, branch, workflow, runId, sha: ref }),
+  );
+
+  return { kind: "ok", runId };
+}
+
+export interface PollWorkflowRunInput {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  runId: number;
+}
+
+export type PollWorkflowRunResult =
+  | { kind: "running" }
+  | { kind: "completed"; conclusion: string; durationMs: number; startedAt: Date };
+
+export async function pollWorkflowRun(
+  input: PollWorkflowRunInput,
+): Promise<PollWorkflowRunResult> {
+  const { octokit, owner, repo, runId } = input;
+  const res = await octokit.actions.getWorkflowRun({ owner, repo, run_id: runId });
+  const data = (res as any).data;
+  const status: string = data?.status ?? "queued";
+  const conclusion: string | null = data?.conclusion ?? null;
+
+  if (status !== "completed") return { kind: "running" };
+
+  // Completed run — compute duration from run_started_at to updated_at.
+  const startedAtStr = data?.run_started_at ?? data?.created_at;
+  const updatedAtStr = data?.updated_at ?? new Date().toISOString();
+  const startedAt = startedAtStr ? new Date(startedAtStr) : new Date();
+  const updatedAt = new Date(updatedAtStr);
+  const durationMs = Math.max(0, updatedAt.getTime() - startedAt.getTime());
+
+  return {
+    kind: "completed",
+    conclusion: conclusion ?? "neutral",
+    durationMs,
+    startedAt,
+  };
+}

--- a/packages/core/src/qa/index.ts
+++ b/packages/core/src/qa/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./github.js";
+export * from "./gap.js";

--- a/packages/core/src/qa/types.ts
+++ b/packages/core/src/qa/types.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const QaCheckConfigSchema = z.object({
+  /** Path to the workflow file in the repo (e.g., ".github/workflows/smoke.yml"). */
+  workflow: z.string().min(1),
+  /** Max time to wait for a single workflow run before reporting timed_out. Default 30. */
+  timeoutMinutes: z.number().int().positive().default(30),
+  /** Linear team UUID for filing gap issues. Required for the gap-issue path. */
+  linearTeamId: z.string().min(1),
+  /** Optional inputs passed to workflow_dispatch (e.g., { environment: "preview" }). */
+  workflowInputs: z.record(z.string(), z.string()).optional(),
+});
+export type QaCheckConfig = z.infer<typeof QaCheckConfigSchema>;
+
+/**
+ * Result of evalQaCheck. Six kinds — more nuanced than the other triggers'
+ * { pass, reason } because the async lifecycle requires the scheduler to
+ * dispatch different actions per kind.
+ */
+export type QaTriggerResult =
+  | { pass: true; reason: string }
+  | { pass: false; reason: "qa_failed"; runId: number; conclusion: string }
+  | { pass: false; reason: "qa_running"; runId: number }
+  | { pass: false; reason: "qa_timed_out"; runId: number }
+  | { pass: false; reason: "qa_needs_trigger" }
+  | { pass: false; reason: "qa_no_workflow" };
+
+/** Snapshot of the most-recent in-flight QA run for (repo, branch). Null when nothing in flight. */
+export interface QaRunSnapshot {
+  runId: number;
+  runSha: string;
+  /** When the run was triggered (decided_at on the persisting row). Used for timeout calculation. */
+  triggeredAt: Date;
+}

--- a/packages/core/src/release-manager/decide.ts
+++ b/packages/core/src/release-manager/decide.ts
@@ -1,26 +1,41 @@
-import type { CollectedState, DecisionResult, ReleaseManagerTriggers } from "./types.js";
+import type { CollectedState, DecisionResult } from "./types.js";
+import type { ReleaseManagerTriggers } from "./types.js";
 import {
   evalMergedPRsSince,
   evalTimeSinceLastHours,
   evalCiGreenForMinutes,
   evalRequireSlackApproval,
+  evalQaCheck,
 } from "./triggers.js";
 
+export interface DecideQaState {
+  /** Whether the configured QA workflow file exists at state.headSha. Computed by scheduler. */
+  workflowFileExists: boolean;
+  /** When qaRun is for current SHA AND complete: the GitHub conclusion. Null otherwise. */
+  runConclusion: string | null;
+}
+
 /**
- * Pure decision: given current state and configured triggers, return
- * { kind: "fire" } iff EVERY set trigger passes, else { kind: "skip" }
- * with the first failing trigger's reason.
+ * Pure decision function. Evaluates triggers in this order:
+ *   1. mergedPRsSince
+ *   2. timeSinceLastHours
+ *   3. ciGreenForMinutes
+ *   4. qaCheck (BEC-136 — at slot 4 before requireSlackApproval)
+ *   5. requireSlackApproval (last; the "awaiting-approval" terminal kind)
  *
- * Triggers are evaluated in the documented order (cheapest first):
- *   1. mergedPRsSince  (DB count, in-memory)
- *   2. timeSinceLastHours  (single timestamp compare)
- *   3. ciGreenForMinutes  (already-fetched into state)
- *   4. requireSlackApproval  (already-fetched into state)
+ * QA check is at slot 4 because: if the workflow's failing/missing, that's a
+ * regular skip — we don't want it bumping into the awaiting-approval branch.
+ * The whole approval flow only triggers when QA has already passed.
+ *
+ * The optional `qaState` parameter carries IO-derived QA inputs (workflow
+ * file existence + run conclusion) that the scheduler computes via Octokit
+ * before calling decide(). Null when qaCheck isn't configured.
  */
 export function decide(
   state: CollectedState,
   triggers: ReleaseManagerTriggers,
   now: Date = new Date(),
+  qaState?: DecideQaState,
 ): DecisionResult {
   if (triggers.mergedPRsSince !== undefined) {
     const r = evalMergedPRsSince(state.mergedCommitsSinceLastTag, triggers.mergedPRsSince);
@@ -35,6 +50,20 @@ export function decide(
   if (triggers.ciGreenForMinutes !== undefined) {
     const r = evalCiGreenForMinutes(state.ciStatus, state.ciGreenSince, triggers.ciGreenForMinutes, now);
     if (!r.pass) return { kind: "skip", reason: r.reason };
+  }
+
+  // BEC-136: QA check at slot 4 (before requireSlackApproval).
+  if (triggers.qaCheck !== undefined) {
+    const qa = qaState ?? { workflowFileExists: false, runConclusion: null };
+    const r = evalQaCheck({
+      qaConfig: triggers.qaCheck,
+      headSha: state.headSha,
+      workflowFileExists: qa.workflowFileExists,
+      qaRun: state.qaRun,
+      runConclusion: qa.runConclusion,
+      now,
+    });
+    if (!r.pass) return { kind: "skip", reason: r.reason, qaActionNeeded: r };
   }
 
   if (triggers.requireSlackApproval === true) {

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -283,6 +283,8 @@ export function createReleaseManagerScheduler(
               workflowPath: config.triggers.qaCheck!.workflow,
               linearTeamId: config.triggers.qaCheck!.linearTeamId,
             });
+          } else {
+            log.error({ repoUrl, branch }, "qaCheck requires Linear client but none configured — skipping gap-issue file");
           }
         } else if (dispatch.kind === "dispatch_422") {
           finalReason = "qa_dispatch_error";

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -21,7 +21,7 @@ import { bumpFromConfigAndCommits } from "./versioning.js";
 import { createTagAndRelease, parseRepoFromUrl } from "./github.js";
 import type { ReleaseManagerConfig } from "./types.js";
 import { triggerWorkflow, pollWorkflowRun, workflowFileExists } from "../qa/github.js";
-import { fileGapIssue } from "../qa/gap.js";
+import { fileGapIssue, markGapResolved } from "../qa/gap.js";
 
 const log = createLogger({ component: "ReleaseManager:scheduler" });
 
@@ -204,6 +204,16 @@ export function createReleaseManagerScheduler(
         log.warn({ err }, "qa workflowFileExists check failed — treating as exists");
         wfExists = true; // fail-open so retries hit the dispatch path
       }
+      if (wfExists) {
+        // BEC-136: workflow file is present; if there was an open gap issue for this
+        // (repo, branch, workflow), mark it resolved so a future gap can be re-filed.
+        await markGapResolved({
+          db,
+          repoUrl,
+          branch,
+          workflowPath: config.triggers.qaCheck.workflow,
+        });
+      }
       let runConclusion: string | null = null;
       if (state.qaRun && state.qaRun.runSha === state.headSha) {
         try {
@@ -309,6 +319,21 @@ export function createReleaseManagerScheduler(
         } else {
           log.error({ repoUrl, branch }, "qaCheck requires Linear client but none configured — skipping gap-issue file");
         }
+      }
+
+      if (result.qaActionNeeded?.reason === "qa_timed_out" && !result.qaActionNeeded.pass && state.qaRun) {
+        const elapsedMs = Date.now() - state.qaRun.triggeredAt.getTime();
+        void logAuditEventUnchecked(
+          db,
+          qaRunCompletedEvent({
+            repoUrl,
+            branch,
+            runId: result.qaActionNeeded.runId,
+            conclusion: "timed_out",
+            durationMs: elapsedMs,
+            synthetic: true,
+          }),
+        );
       }
 
       await persistDecision({

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -67,6 +67,7 @@ export function createReleaseManagerScheduler(
   let pausedUntilTs: number = 0;
   let cronJob: Cron | null = null;
   let licenseWarnLogged = false;
+  const auditedCompletedRunIds = new Set<number>();
 
   function approvalTtlMs(): number {
     const hours = config.triggers.timeSinceLastHours;
@@ -218,8 +219,9 @@ export function createReleaseManagerScheduler(
       if (state.qaRun && state.qaRun.runSha === state.headSha) {
         try {
           const polled = await pollWorkflowRun({ octokit, owner, repo, runId: state.qaRun.runId });
-          if (polled.kind === "completed") {
+          if (polled.kind === "completed" && !auditedCompletedRunIds.has(state.qaRun.runId)) {
             runConclusion = polled.conclusion;
+            auditedCompletedRunIds.add(state.qaRun.runId);
             // Emit qa.run_completed audit on first observation of completion.
             void logAuditEventUnchecked(
               db,
@@ -230,6 +232,9 @@ export function createReleaseManagerScheduler(
                 durationMs: polled.durationMs,
               }),
             );
+          } else if (polled.kind === "completed") {
+            runConclusion = polled.conclusion;
+            // Already audited this runId on a prior tick; skip emit.
           }
         } catch (err) {
           log.warn({ err }, "qa pollWorkflowRun failed — treating as still running");
@@ -266,6 +271,7 @@ export function createReleaseManagerScheduler(
               eq(releaseDecisions.repoUrl, repoUrl),
               eq(releaseDecisions.branch, branch),
               eq(releaseDecisions.reason, "qa_needs_trigger"),
+              eq(releaseDecisions.qaRunSha, state.headSha),
             ),
           );
         attemptCount = ((prevAttempts?.[0]?.maxAttempts as number) ?? 0);
@@ -285,7 +291,7 @@ export function createReleaseManagerScheduler(
           // Workflow disappeared between state cache and dispatch — drop into gap-issue path.
           finalReason = "qa_no_workflow";
           if (linear) {
-            await fileGapIssue({
+            const gapResult = await fileGapIssue({
               db,
               linear,
               repoUrl,
@@ -293,14 +299,42 @@ export function createReleaseManagerScheduler(
               workflowPath: config.triggers.qaCheck!.workflow,
               linearTeamId: config.triggers.qaCheck!.linearTeamId,
             });
+            if (gapResult.kind === "linear_error") {
+              const prevGapAttempts = await (db as any)
+                .select({ attemptCount: max(releaseDecisions.attemptCount) })
+                .from(releaseDecisions)
+                .where(
+                  and(
+                    eq(releaseDecisions.repoUrl, repoUrl),
+                    eq(releaseDecisions.branch, branch),
+                    eq(releaseDecisions.reason, "qa_no_workflow"),
+                  ),
+                );
+              const gapAttemptCount = ((prevGapAttempts?.[0]?.attemptCount as number) ?? 0) + 1;
+              if (gapAttemptCount >= 3) {
+                finalReason = "qa_gap_file_error";
+                attemptCount = gapAttemptCount;
+              } else {
+                attemptCount = gapAttemptCount;
+              }
+              log.error({ err: gapResult.message, repoUrl, branch }, "fileGapIssue failed; will retry");
+            }
           } else {
             log.error({ repoUrl, branch }, "qaCheck requires Linear client but none configured — skipping gap-issue file");
           }
         } else if (dispatch.kind === "dispatch_422") {
           finalReason = "qa_dispatch_error";
           attemptCount = 99; // permanent skip — workflow misconfigured, retrying won't help
+        } else if (dispatch.kind === "dispatch_pending") {
+          // GitHub eventual-consistency window. Don't count against retry budget; next tick
+          // will re-evaluate and the run should be findable by then.
+          // Tag with qaRunSha so the per-SHA retry counter query can find these rows.
+          qaRunSha = state.headSha;
+          // attemptCount stays as-is; finalReason stays as "qa_needs_trigger" for next tick to retry.
         } else {
-          // dispatch_error — increment attempt counter
+          // dispatch_error — increment attempt counter.
+          // Tag with qaRunSha so the per-SHA retry counter query can find these rows.
+          qaRunSha = state.headSha;
           attemptCount += 1;
           if (attemptCount >= 3) {
             finalReason = "qa_dispatch_error";
@@ -308,7 +342,7 @@ export function createReleaseManagerScheduler(
         }
       } else if (result.qaActionNeeded?.reason === "qa_no_workflow") {
         if (linear) {
-          await fileGapIssue({
+          const gapResult = await fileGapIssue({
             db,
             linear,
             repoUrl,
@@ -316,6 +350,26 @@ export function createReleaseManagerScheduler(
             workflowPath: config.triggers.qaCheck!.workflow,
             linearTeamId: config.triggers.qaCheck!.linearTeamId,
           });
+          if (gapResult.kind === "linear_error") {
+            const prevGapAttempts = await (db as any)
+              .select({ attemptCount: max(releaseDecisions.attemptCount) })
+              .from(releaseDecisions)
+              .where(
+                and(
+                  eq(releaseDecisions.repoUrl, repoUrl),
+                  eq(releaseDecisions.branch, branch),
+                  eq(releaseDecisions.reason, "qa_no_workflow"),
+                ),
+              );
+            const gapAttemptCount = ((prevGapAttempts?.[0]?.attemptCount as number) ?? 0) + 1;
+            if (gapAttemptCount >= 3) {
+              finalReason = "qa_gap_file_error";
+              attemptCount = gapAttemptCount;
+            } else {
+              attemptCount = gapAttemptCount;
+            }
+            log.error({ err: gapResult.message, repoUrl, branch }, "fileGapIssue failed; will retry");
+          }
         } else {
           log.error({ repoUrl, branch }, "qaCheck requires Linear client but none configured — skipping gap-issue file");
         }

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { eq, isNull, and, desc } from "drizzle-orm";
+import { eq, isNull, and, desc, max } from "drizzle-orm";
 import type { Octokit } from "@octokit/rest";
+import type { LinearClient } from "@linear/sdk";
 import { Cron } from "croner";
 import type { AnyDb } from "../db/client.js";
 import { releaseApprovals, releaseDecisions } from "../db/schema.js";
@@ -12,12 +13,15 @@ import {
   releaseTagConflictEvent,
   releasePartialEvent,
   slackPostFailedEvent,
+  qaRunCompletedEvent,
 } from "../audit/events.js";
 import { collectState } from "./state.js";
 import { decide } from "./decide.js";
 import { bumpFromConfigAndCommits } from "./versioning.js";
 import { createTagAndRelease, parseRepoFromUrl } from "./github.js";
 import type { ReleaseManagerConfig } from "./types.js";
+import { triggerWorkflow, pollWorkflowRun, workflowFileExists } from "../qa/github.js";
+import { fileGapIssue } from "../qa/gap.js";
 
 const log = createLogger({ component: "ReleaseManager:scheduler" });
 
@@ -29,6 +33,8 @@ export interface ReleaseManagerSchedulerInput {
   config: ReleaseManagerConfig;
   db: AnyDb;
   octokit: Octokit;
+  /** BEC-136: Linear client for filing QA gap issues. Required when qaCheck is configured. */
+  linear?: LinearClient;
   repoUrl: string;
   /** Injectable license check — production passes `() => isFeatureLicensed("release-manager")`. */
   isLicensed: () => boolean;
@@ -51,7 +57,7 @@ const SLACK_DEDUP_WINDOW_MS = 24 * 3600 * 1000;
 export function createReleaseManagerScheduler(
   input: ReleaseManagerSchedulerInput,
 ): ReleaseManagerScheduler {
-  const { config, db, octokit, repoUrl, isLicensed, slack } = input;
+  const { config, db, octokit, linear, repoUrl, isLicensed, slack } = input;
   const branch = config.branch;
   const slackChannel = config.slackChannel;
 
@@ -96,6 +102,8 @@ export function createReleaseManagerScheduler(
     firedTag?: string;
     firedSha?: string;
     attemptCount?: number;
+    qaRunId?: number;
+    qaRunSha?: string;
   }): Promise<void> {
     await (db as any).insert(releaseDecisions).values({
       id: row.id,
@@ -109,6 +117,8 @@ export function createReleaseManagerScheduler(
       firedTag: row.firedTag,
       firedSha: row.firedSha,
       attemptCount: row.attemptCount ?? 0,
+      qaRunId: row.qaRunId,
+      qaRunSha: row.qaRunSha,
     });
   }
 
@@ -179,8 +189,47 @@ export function createReleaseManagerScheduler(
       return;
     }
 
-    // 2. Decision.
-    const result = decide(state, config.triggers);
+    // 2. BEC-136: Compute QA state when qaCheck is configured.
+    let qaState: { workflowFileExists: boolean; runConclusion: string | null } | undefined;
+    if (config.triggers.qaCheck) {
+      const { owner, repo } = parseRepoFromUrl(repoUrl);
+      let wfExists = false;
+      try {
+        wfExists = await workflowFileExists({
+          octokit, owner, repo,
+          path: config.triggers.qaCheck.workflow,
+          ref: state.headSha,
+        });
+      } catch (err) {
+        log.warn({ err }, "qa workflowFileExists check failed — treating as exists");
+        wfExists = true; // fail-open so retries hit the dispatch path
+      }
+      let runConclusion: string | null = null;
+      if (state.qaRun && state.qaRun.runSha === state.headSha) {
+        try {
+          const polled = await pollWorkflowRun({ octokit, owner, repo, runId: state.qaRun.runId });
+          if (polled.kind === "completed") {
+            runConclusion = polled.conclusion;
+            // Emit qa.run_completed audit on first observation of completion.
+            void logAuditEventUnchecked(
+              db,
+              qaRunCompletedEvent({
+                repoUrl, branch,
+                runId: state.qaRun.runId,
+                conclusion: polled.conclusion as any,
+                durationMs: polled.durationMs,
+              }),
+            );
+          }
+        } catch (err) {
+          log.warn({ err }, "qa pollWorkflowRun failed — treating as still running");
+        }
+      }
+      qaState = { workflowFileExists: wfExists, runConclusion };
+    }
+
+    // 3. Decision.
+    const result = decide(state, config.triggers, undefined, qaState);
     const proposedVersion = bumpFromConfigAndCommits(
       state.lastTag,
       state.commitsSinceLastTag,
@@ -189,18 +238,92 @@ export function createReleaseManagerScheduler(
 
     if (result.kind === "skip") {
       const id = `rd_${randomUUID()}`;
+
+      // Compute attempt count for retry handling on qa_dispatch_error path.
+      let attemptCount = 0;
+      let qaRunId: number | undefined;
+      let qaRunSha: string | undefined;
+      let finalReason = result.reason;
+
+      if (result.qaActionNeeded?.reason === "qa_needs_trigger") {
+        // Look up the highest attempt count across all qa_needs_trigger rows for this branch.
+        // Using MAX instead of ORDER BY + LIMIT 1 to be stable when multiple rows share the same decidedAt.
+        const prevAttempts = await (db as any)
+          .select({ maxAttempts: max(releaseDecisions.attemptCount) })
+          .from(releaseDecisions)
+          .where(
+            and(
+              eq(releaseDecisions.repoUrl, repoUrl),
+              eq(releaseDecisions.branch, branch),
+              eq(releaseDecisions.reason, "qa_needs_trigger"),
+            ),
+          );
+        attemptCount = ((prevAttempts?.[0]?.maxAttempts as number) ?? 0);
+
+        const { owner, repo } = parseRepoFromUrl(repoUrl);
+        const dispatch = await triggerWorkflow({
+          octokit, db, owner, repo, repoUrl, branch,
+          workflow: config.triggers.qaCheck!.workflow,
+          ref: state.headSha,
+          inputs: config.triggers.qaCheck!.workflowInputs,
+        });
+        if (dispatch.kind === "ok") {
+          attemptCount = 0; // reset on successful dispatch
+          qaRunId = dispatch.runId;
+          qaRunSha = state.headSha;
+        } else if (dispatch.kind === "dispatch_404") {
+          // Workflow disappeared between state cache and dispatch — drop into gap-issue path.
+          finalReason = "qa_no_workflow";
+          if (linear) {
+            await fileGapIssue({
+              db,
+              linear,
+              repoUrl,
+              branch,
+              workflowPath: config.triggers.qaCheck!.workflow,
+              linearTeamId: config.triggers.qaCheck!.linearTeamId,
+            });
+          }
+        } else if (dispatch.kind === "dispatch_422") {
+          finalReason = "qa_dispatch_error";
+          attemptCount = 99; // permanent skip — workflow misconfigured, retrying won't help
+        } else {
+          // dispatch_error — increment attempt counter
+          attemptCount += 1;
+          if (attemptCount >= 3) {
+            finalReason = "qa_dispatch_error";
+          }
+        }
+      } else if (result.qaActionNeeded?.reason === "qa_no_workflow") {
+        if (linear) {
+          await fileGapIssue({
+            db,
+            linear,
+            repoUrl,
+            branch,
+            workflowPath: config.triggers.qaCheck!.workflow,
+            linearTeamId: config.triggers.qaCheck!.linearTeamId,
+          });
+        } else {
+          log.error({ repoUrl, branch }, "qaCheck requires Linear client but none configured — skipping gap-issue file");
+        }
+      }
+
       await persistDecision({
         id,
         decision: "skip",
-        reason: result.reason,
+        reason: finalReason,
         triggerStateJson,
         proposedVersion,
+        qaRunId,
+        qaRunSha,
+        attemptCount,
       });
-      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: result.reason }));
+      void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: finalReason }));
       // Slack notification with dedup
       await maybePostSlack(
-        `:double_vertical_bar: Release skipped for *${repoUrl}* (${branch}): ${result.reason}`,
-        result.reason,
+        `:double_vertical_bar: Release skipped for *${repoUrl}* (${branch}): ${finalReason}`,
+        finalReason,
       );
       return;
     }

--- a/packages/core/src/release-manager/state.ts
+++ b/packages/core/src/release-manager/state.ts
@@ -158,5 +158,6 @@ export async function collectState(input: CollectStateInput): Promise<CollectedS
     hasFreshApproval,
     freshApprovalApprover,
     manualTagDetected,
+    qaRun: null,
   };
 }

--- a/packages/core/src/release-manager/state.ts
+++ b/packages/core/src/release-manager/state.ts
@@ -146,6 +146,32 @@ export async function collectState(input: CollectStateInput): Promise<CollectedS
   const hasFreshApproval = (freshRows?.length ?? 0) > 0;
   const freshApprovalApprover = hasFreshApproval ? freshRows[0].approvedBy : null;
 
+  // 7. BEC-136: most-recent in-flight QA run snapshot.
+  const qaRunRows = await (db as any)
+    .select({
+      qaRunId: releaseDecisions.qaRunId,
+      qaRunSha: releaseDecisions.qaRunSha,
+      decidedAt: releaseDecisions.decidedAt,
+    })
+    .from(releaseDecisions)
+    .where(
+      and(
+        eq(releaseDecisions.repoUrl, repoUrl),
+        eq(releaseDecisions.branch, branch),
+      ),
+    )
+    .orderBy(desc(releaseDecisions.decidedAt))
+    .limit(20);
+  // Take the most recent row that actually has a qa_run_id.
+  const latestQaRow = qaRunRows.find((r: any) => r.qaRunId !== null && r.qaRunId !== undefined);
+  const qaRun = latestQaRow
+    ? {
+        runId: latestQaRow.qaRunId as number,
+        runSha: latestQaRow.qaRunSha as string,
+        triggeredAt: latestQaRow.decidedAt instanceof Date ? latestQaRow.decidedAt : new Date(latestQaRow.decidedAt),
+      }
+    : null;
+
   return {
     lastTag,
     lastTagSha,
@@ -158,6 +184,6 @@ export async function collectState(input: CollectStateInput): Promise<CollectedS
     hasFreshApproval,
     freshApprovalApprover,
     manualTagDetected,
-    qaRun: null,
+    qaRun,
   };
 }

--- a/packages/core/src/release-manager/triggers.ts
+++ b/packages/core/src/release-manager/triggers.ts
@@ -67,3 +67,55 @@ export function evalRequireSlackApproval(
   if (hasFresh) return { pass: true, reason: "approval is fresh" };
   return { pass: false, reason: "no_fresh_approval" };
 }
+
+import type { QaCheckConfig, QaRunSnapshot, QaTriggerResult } from "../qa/types.js";
+
+export interface EvalQaCheckInput {
+  qaConfig: QaCheckConfig;
+  headSha: string;
+  /** Whether the configured workflow file exists at headSha (per workflowFileExists). */
+  workflowFileExists: boolean;
+  /** Most recent in-flight run snapshot, or null when nothing tracked. */
+  qaRun: QaRunSnapshot | null;
+  /** When qaRun is for current SHA AND the run has completed: the GitHub conclusion string. Null otherwise. */
+  runConclusion: string | null;
+  now?: Date;
+}
+
+/**
+ * Pure decision: given current state and qaCheck config, return one of 6 result kinds.
+ *
+ * Ordering inside the function:
+ *   1. If workflow file is missing → qa_no_workflow (file gap issue + skip)
+ *   2. If no in-flight run OR the run is for a stale SHA → qa_needs_trigger (dispatch)
+ *   3. If completed: success → pass:true, else → qa_failed (with conclusion)
+ *   4. If still running and elapsed > timeoutMinutes → qa_timed_out
+ *   5. Otherwise → qa_running (await next tick)
+ */
+export function evalQaCheck(input: EvalQaCheckInput): QaTriggerResult {
+  const { qaConfig, headSha, workflowFileExists, qaRun, runConclusion, now = new Date() } = input;
+
+  if (!workflowFileExists) {
+    return { pass: false, reason: "qa_no_workflow" };
+  }
+
+  if (qaRun === null || qaRun.runSha !== headSha) {
+    return { pass: false, reason: "qa_needs_trigger" };
+  }
+
+  // We have an in-flight run for current SHA.
+  if (runConclusion !== null) {
+    if (runConclusion === "success") {
+      return { pass: true, reason: "qa passed" };
+    }
+    return { pass: false, reason: "qa_failed", runId: qaRun.runId, conclusion: runConclusion };
+  }
+
+  // Still running — check timeout.
+  const elapsedMs = now.getTime() - qaRun.triggeredAt.getTime();
+  const timeoutMs = qaConfig.timeoutMinutes * 60 * 1000;
+  if (elapsedMs > timeoutMs) {
+    return { pass: false, reason: "qa_timed_out", runId: qaRun.runId };
+  }
+  return { pass: false, reason: "qa_running", runId: qaRun.runId };
+}

--- a/packages/core/src/release-manager/types.ts
+++ b/packages/core/src/release-manager/types.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
+import { QaCheckConfigSchema, type QaRunSnapshot, type QaTriggerResult } from "../qa/types.js";
 
 export const ReleaseManagerTriggersSchema = z.object({
   mergedPRsSince: z.number().int().positive().optional(),
   timeSinceLastHours: z.number().int().positive().optional(),
   ciGreenForMinutes: z.number().int().positive().optional(),
   requireSlackApproval: z.boolean().default(false),
+  /** BEC-136: trigger workflow + gate release on its result. */
+  qaCheck: QaCheckConfigSchema.optional(),
 });
 export type ReleaseManagerTriggers = z.infer<typeof ReleaseManagerTriggersSchema>;
 
@@ -29,12 +32,13 @@ export const ReleaseManagerConfigSchema = z
       t.mergedPRsSince !== undefined ||
       t.timeSinceLastHours !== undefined ||
       t.ciGreenForMinutes !== undefined ||
-      t.requireSlackApproval === true;
+      t.requireSlackApproval === true ||
+      t.qaCheck !== undefined;
     if (!anyTrigger) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["triggers"],
-        message: "at least one trigger field must be set (mergedPRsSince, timeSinceLastHours, ciGreenForMinutes, or requireSlackApproval=true)",
+        message: "at least one trigger field must be set (mergedPRsSince, timeSinceLastHours, ciGreenForMinutes, requireSlackApproval=true, or qaCheck)",
       });
     }
     if (t.requireSlackApproval === true && !cfg.slackChannel) {
@@ -69,9 +73,11 @@ export interface CollectedState {
   freshApprovalApprover: string | null;
   /** True iff the latest tag in the repo is newer than what we last fired. Re-baselines counters. */
   manualTagDetected: boolean;
+  /** BEC-136: in-flight QA run for this (repo, branch). Null when nothing in flight. */
+  qaRun: QaRunSnapshot | null;
 }
 
 export type DecisionResult =
   | { kind: "fire"; reason: string }
-  | { kind: "skip"; reason: string }
+  | { kind: "skip"; reason: string; qaActionNeeded?: QaTriggerResult }
   | { kind: "awaiting-approval"; reason: string };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -430,6 +430,7 @@ export const AuditEventTypeSchema = z.enum([
   "release.fired", "release.skipped", "release.approved",
   "release.tag_conflict", "release.partial",
   "slack.post_failed",
+  "qa.run_triggered", "qa.run_completed", "qa.gap_issue_filed",
 ]);
 export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
 

--- a/packages/create-urateam/template/.urateam/.env.example
+++ b/packages/create-urateam/template/.urateam/.env.example
@@ -138,6 +138,24 @@ DASHBOARD_PASSWORD=
 # RELEASE_MANAGER_TRIGGER_CI_GREEN_FOR_MINUTES=30
 # RELEASE_MANAGER_TRIGGER_REQUIRE_SLACK_APPROVAL=false
 
+# ----------------------------------------------------------------------------
+# Release Manager — QA agent integration (BEC-136). OSS+ feature.
+#
+# When configured, the Release Manager runs your GitHub Actions smoke workflow
+# against the merge commit before tagging a release. If the workflow file is
+# missing, the agent files a Linear issue describing how to set one up and
+# pauses release activity for the branch until it's resolved.
+#
+# Requires:
+#   - LINEAR_API_KEY (already set above for PM agent)
+#   - GitHub App credentials (GITHUB_APP_ID, GITHUB_PRIVATE_KEY_PATH already set)
+#
+# The configured workflow MUST have `on: workflow_dispatch` to be triggered.
+# ----------------------------------------------------------------------------
+# RELEASE_MANAGER_TRIGGER_QA_WORKFLOW=.github/workflows/smoke.yml
+# RELEASE_MANAGER_TRIGGER_QA_LINEAR_TEAM_ID=                 # required if qaCheck is set
+# RELEASE_MANAGER_TRIGGER_QA_TIMEOUT_MINUTES=30              # default 30
+
 # Logging
 # LOG_LEVEL=info
 


### PR DESCRIPTION
## Summary
- New OSS+ QA agent at `packages/core/src/qa/` integrates as a 5th trigger field on `ReleaseManagerTriggers`. When configured, each Release Manager tick verifies a customer-defined GitHub Actions workflow has run green against the merge SHA before firing a release.
- Async fire-and-check across ticks: each tick either triggers a workflow_dispatch, observes an in-flight run, or files a gap issue — never blocks.
- Gap-detection is rule-based (workflow file existence) with a static Linear template — LLM-driven analysis deferred to v2.
- Three new audit event types: `qa.run_triggered`, `qa.run_completed`, `qa.gap_issue_filed`. All use `logAuditEventUnchecked` per the Pro-tier audit-gating pattern (BEC-135 v2).
- Two minimal DB touchpoints: 2 new columns on `release_decisions` (`qaRunId`, `qaRunSha`) + new tiny `qa_gap_issues` table with partial UNIQUE (`WHERE resolved_at IS NULL`) for filing-idempotency.
- Reuses existing secrets: `LINEAR_API_KEY` (PM agent) and `GITHUB_APP_*` (Release Manager). No new secrets to plumb.
- 4 new migrations (sqlite 010 + 011, postgres 011 + 012). All idempotent.

Spec: `docs/superpowers/specs/2026-05-04-bec-136-qa-agent-design.md`
Plan: `docs/superpowers/plans/2026-05-04-bec-136-qa-agent.md`

## Test plan
- [x] `qa-config.test.ts` — Zod schema validation (8 tests)
- [x] `qa-github.test.ts` — Octokit calls + 4 result kinds for triggerWorkflow + pollWorkflowRun (10 tests)
- [x] `qa-gap.test.ts` — fileGapIssue idempotent flow, re-file after resolved (4 tests)
- [x] `qa-eval.test.ts` — all 6 result kinds of evalQaCheck + SHA-mismatch + timeout (8 tests)
- [x] `qa-audit-events.test.ts` — 3 new factories (4 tests)
- [x] `db-qa-gap-issues.test.ts` — schema + partial UNIQUE (4 tests)
- [x] `release-manager-decide.test.ts` — extended with 3 qaCheck slot-4 tests (11 total)
- [x] `release-manager-scheduler.test.ts` — extended with 4 qa-integration tests (11 total)
- [x] `audit-immutability.test.ts` — allowlist updated for qa/github.ts + qa/gap.ts
- [ ] Manual smoke against a test repo with `RELEASE_MANAGER_TRIGGER_QA_*` configured (post-merge)

## Documented v1 simplifications (deliberate, see plan §13)
1. Gap detection is rule-based, not LLM-driven (D2)
2. `evalQaCheck` returns 6 kinds (added `qa_timed_out` separate from `qa_failed` for cleaner audit emission)
3. Scheduler tick stays fast — workflow runs span multiple ticks
4. No QA workflow auto-cancel on timeout (operator manages cost knob)
5. `qaCheck.workflow` is path-only (no display-name resolution) in v1
6. Single Release Manager instance per process (inherited from BEC-135 v1)

## Out of scope (post-1.0, tracked in Linear)
RC tags, slack interactive buttons, multi-repo QA fan-out, custom test scaffolding, per-PR QA, cost/duration alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)