### PR TITLE
feat(bec-138): claude-code CLI in dogfood image + OAuth volume

### DIFF
--- a/.env.dogfood.example
+++ b/.env.dogfood.example
@@ -30,6 +30,13 @@ SLACK_CHANNEL=#urateam-dogfood
 
 # === Model providers ===
 OPENROUTER_API_KEY=
+# ANTHROPIC_API_KEY is OPTIONAL. urateam's executor uses @anthropic-ai/claude-agent-sdk,
+# which falls back to Claude Code OAuth credentials (~/.claude/credentials.json) when
+# ANTHROPIC_API_KEY is unset. The dogfood Dockerfile installs the `claude` CLI; after
+# the container starts, run `docker compose exec -it urateam-dogfood claude login` to
+# authenticate via your subscription. Tokens persist in the urateam-dogfood-claude
+# named volume across restarts. Set this var only if you prefer billed API quota over
+# subscription-counted usage.
 ANTHROPIC_API_KEY=
 
 # === Release Manager triggers ===

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,19 @@ ARG URATEAM_DASHBOARD_VERSION=0.1.18
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \
       @urateam/core@${URATEAM_CORE_VERSION} \
-      @urateam/dashboard@${URATEAM_DASHBOARD_VERSION}
+      @urateam/dashboard@${URATEAM_DASHBOARD_VERSION} \
+      @anthropic-ai/claude-code
 
 # Non-root runtime user
 RUN addgroup -S ura && adduser -S -G ura ura
 USER ura
 WORKDIR /home/ura
 
-VOLUME ["/home/ura/data", "/home/ura/work"]
+# /home/ura/.claude holds Claude Code OAuth credentials (credentials.json) so
+# the executor's auth-check can pass without ANTHROPIC_API_KEY. Mounted as a
+# named volume in compose so credentials persist across container restarts;
+# `docker compose exec urateam-dogfood claude login` is the one-time setup step.
+VOLUME ["/home/ura/data", "/home/ura/work", "/home/ura/.claude"]
 EXPOSE 3001
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ RUN apk add --no-cache git openssh-client tini python3 make g++
 ARG URATEAM_CORE_VERSION=0.1.18
 ARG URATEAM_CLI_VERSION=0.1.20
 ARG URATEAM_DASHBOARD_VERSION=0.1.18
+ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \
       @urateam/core@${URATEAM_CORE_VERSION} \
       @urateam/dashboard@${URATEAM_DASHBOARD_VERSION} \
-      @anthropic-ai/claude-code
+      @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 # Non-root runtime user
 RUN addgroup -S ura && adduser -S -G ura ura

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -6,6 +6,7 @@ services:
         URATEAM_CORE_VERSION: 0.1.18
         URATEAM_CLI_VERSION: 0.1.20
         URATEAM_DASHBOARD_VERSION: 0.1.18
+        CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped
     env_file: .env.dogfood

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - urateam-dogfood-data:/home/ura/data
       - urateam-dogfood-work:/home/ura/work
+      - urateam-dogfood-claude:/home/ura/.claude
     ports:
       # localhost-only — remote access via SSH tunnel during soak
       - "127.0.0.1:3001:3001"
@@ -19,3 +20,4 @@ services:
 volumes:
   urateam-dogfood-data:
   urateam-dogfood-work:
+  urateam-dogfood-claude:

--- a/docs/superpowers/runbooks/2026-05-04-bec-138-dogfood-soak.md
+++ b/docs/superpowers/runbooks/2026-05-04-bec-138-dogfood-soak.md
@@ -30,6 +30,23 @@ Boot success indicators in the log:
 
 If any are missing, fix the env file, then `docker compose -f docker-compose.dogfood.yml up -d --force-recreate`.
 
+## One-time: authenticate Claude Code OAuth
+
+Required when `ANTHROPIC_API_KEY` is unset (the default). The dogfood image installs `@anthropic-ai/claude-code`; OAuth tokens persist in the `urateam-dogfood-claude` named volume across restarts.
+
+```bash
+docker compose -f docker-compose.dogfood.yml exec -it urateam-dogfood claude login
+```
+
+Follow the OAuth flow (URL → browser → paste returned token). After login, verify:
+
+```bash
+docker compose -f docker-compose.dogfood.yml exec urateam-dogfood claude auth status
+```
+Expected: `Authenticated as <your account>`. If this fails, the executor's `auth-check` will reject runs with `"Claude auth credentials are invalid or expired"` and no agent work will happen.
+
+**Subscription quota note:** every dogfood agent run (PM, review, RM, QA) counts against your Claude Max/Team quota. If quota saturates mid-soak, set `ANTHROPIC_API_KEY` in `.env.dogfood`, recreate the container, and the SDK will switch to billed API.
+
 ## Verify boot (run these from your laptop after deploy)
 
 ```bash

--- a/docs/superpowers/runbooks/2026-05-04-bec-138-dogfood-soak.md
+++ b/docs/superpowers/runbooks/2026-05-04-bec-138-dogfood-soak.md
@@ -9,7 +9,7 @@
 - [ ] Enterprise JWT for `dogfood@urateams.com` minted; valid ≥1 year; copied to `.env.dogfood`
 - [ ] GitHub `urateam-dogfood-bot` account (or fine-grained PAT) has `repo` + `workflow` on `JonB32/urateam`
 - [ ] Linear API key under dogfood-bot account; copied to `.env.dogfood`
-- [ ] OpenRouter + Anthropic keys present in `.env.dogfood`
+- [ ] `OPENROUTER_API_KEY` present in `.env.dogfood`. `ANTHROPIC_API_KEY` is optional (see "One-time: authenticate Claude Code OAuth" below — default is OAuth via the bundled `claude` CLI)
 - [ ] PR with Dockerfile + compose + ci.yml workflow_dispatch is merged to `main`
 
 ## Deploy
@@ -46,6 +46,8 @@ docker compose -f docker-compose.dogfood.yml exec urateam-dogfood claude auth st
 Expected: `Authenticated as <your account>`. If this fails, the executor's `auth-check` will reject runs with `"Claude auth credentials are invalid or expired"` and no agent work will happen.
 
 **Subscription quota note:** every dogfood agent run (PM, review, RM, QA) counts against your Claude Max/Team quota. If quota saturates mid-soak, set `ANTHROPIC_API_KEY` in `.env.dogfood`, recreate the container, and the SDK will switch to billed API.
+
+**Volume preservation warning:** `docker compose down` preserves the named volume `urateam-dogfood-claude` (intentional — keeps OAuth credentials across restarts). `docker compose down --volumes` (or `-v`) deletes it, which silently wipes the OAuth tokens. If auth suddenly breaks after a teardown, re-run `claude login`.
 
 ## Verify boot (run these from your laptop after deploy)
 


### PR DESCRIPTION
## Summary
PR #150 (BEC-138 Phase 1) shipped the dogfood Docker artifact assuming `ANTHROPIC_API_KEY` would be set, but urateam's executor uses `@anthropic-ai/claude-agent-sdk` and pre-flights with `claude auth status` (`packages/core/src/executor/auth-check.ts`). Without the `claude` CLI installed and authenticated, the dogfood container would fail every agent run with "Claude auth credentials are invalid or expired."

Four small additive changes wire up the Claude Code OAuth path so the dogfood can run on a Claude Max/Team subscription instead of requiring a billed API key:

- **Dockerfile**: install pinned `@anthropic-ai/claude-code@2.1.128` globally; declare `/home/ura/.claude` as a VOLUME so OAuth credentials persist across restarts
- **docker-compose.dogfood.yml**: add named volume `urateam-dogfood-claude` mapped to `/home/ura/.claude`; matching `CLAUDE_CODE_VERSION` build arg
- **.env.dogfood.example**: mark `ANTHROPIC_API_KEY` as OPTIONAL with comment pointing to `claude login` as the default
- **soak runbook**: pre-flight checklist updated (ANTHROPIC_API_KEY is optional); new "One-time: authenticate Claude Code OAuth" section; volume-preservation warning for `down -v`

## Why now (vs. v2 follow-up)

Discovered during BEC-138 Phase 3 walkthrough — the user has Claude Code subscription on the deploy host but no separate Anthropic API key. Without this PR, dogfood deploy is blocked. `ANTHROPIC_API_KEY` remains a supported fallback (e.g., if subscription quota saturates mid-soak).

## After this lands

Dogfood deploy flow becomes:
1. `docker compose -f docker-compose.dogfood.yml up -d --build`
2. `docker compose -f docker-compose.dogfood.yml exec -it urateam-dogfood claude login`
3. Agent runs use OAuth subscription; no API key needed

## Test plan
- [x] Dockerfile static lint: all instructions valid; `@anthropic-ai/claude-code` is the published Anthropic CLI package; alpine-musl native binary auto-resolved by package's optional dep
- [x] docker-compose.dogfood.yml parses; volume mount + named volume both reference matching name `urateam-dogfood-claude`
- [x] .env.dogfood.example: 14 env entries preserved; comment block on ANTHROPIC_API_KEY reads correctly
- [x] Runbook: pre-flight + OAuth section accurate; verification command matches `auth-check.ts` invocation
- [x] CI run on initial commit: 3/3 green
- [ ] CI run on fix-up `00187e3` passes
- [ ] (Out of scope here, will run on host post-merge): `docker build`, `claude --version` inside container, `claude login` OAuth flow, and `claude auth status` verification

## Sonnet review (resolved)
- Pin `@anthropic-ai/claude-code` for build reproducibility — fixed in `00187e3`
- Pre-flight checklist contradicted the new optional ANTHROPIC_API_KEY — fixed in `00187e3`
- Volume preservation warning for `docker compose down -v` — added in `00187e3` (originally minor; included since it's a real foot-gun)
- Image size 243 MB and PR-body wording — accepted / editorial only

🤖 Generated with [Claude Code](https://claude.com/claude-code)