### PR TITLE
fix(dashboard): BEC-156 — synthesize admin user for basic-auth on Enterprise

### DIFF
--- a/packages/dashboard/src/__tests__/server.test.ts
+++ b/packages/dashboard/src/__tests__/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createDashboard, type DashboardConfig } from "../server.js";
 import type { Db } from "@urateam/core";
+import { installTestProLicense, restoreLicense } from "./helpers/license.js";
 
 /**
  * Build a mock Db whose chainable query-builder methods (.select(), .from(),
@@ -508,5 +509,61 @@ describe("createDashboard — basePath navigation links", () => {
         createDashboard({ db: mockDb, pipelineConfigs: {}, repoConfigs: {} })
       ).not.toThrow();
     });
+  });
+});
+
+// BEC-156: on Enterprise tier with basic auth (no SSO), the RBAC middleware
+// looked for c.user — which only the SSO middleware sets — and 401'd every
+// request even after basicAuth had verified the credentials. The fix
+// synthesizes a user object after basicAuth succeeds so RBAC has something
+// to check.
+describe("createDashboard — Enterprise tier + basic auth (BEC-156)", () => {
+  let app: ReturnType<typeof createDashboard>;
+
+  beforeEach(async () => {
+    await installTestProLicense("enterprise");
+    app = createDashboard({
+      db: createMockDb(),
+      pipelineConfigs: {},
+      repoConfigs: {},
+      auth: { username: "admin", password: "secret" },
+    });
+  });
+
+  afterEach(async () => {
+    await restoreLicense();
+  });
+
+  it("serves the runs page at / with valid basic-auth credentials", async () => {
+    const res = await app.request("/", {
+      headers: { Authorization: basicAuthHeader("admin", "secret") },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("serves the coordination page with valid basic-auth credentials", async () => {
+    const res = await app.request("/coordination", {
+      headers: { Authorization: basicAuthHeader("admin", "secret") },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("serves the tokens page (RBAC-gated) with valid basic-auth credentials", async () => {
+    const res = await app.request("/tokens", {
+      headers: { Authorization: basicAuthHeader("admin", "secret") },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("still rejects unauthenticated requests with 401", async () => {
+    const res = await app.request("/");
+    expect(res.status).toBe(401);
+  });
+
+  it("still rejects wrong-password requests with 401", async () => {
+    const res = await app.request("/", {
+      headers: { Authorization: basicAuthHeader("admin", "wrongpassword") },
+    });
+    expect(res.status).toBe(401);
   });
 });

--- a/packages/dashboard/src/__tests__/server.test.ts
+++ b/packages/dashboard/src/__tests__/server.test.ts
@@ -555,6 +555,16 @@ describe("createDashboard — Enterprise tier + basic auth (BEC-156)", () => {
     expect(res.status).toBe(200);
   });
 
+  it("serves the config page (admin-only RBAC gate) with valid basic-auth credentials", async () => {
+    // /config requires `config.view` which is admin-only. This test verifies
+    // the synthetic role MUST be `admin` — a future regression that downgrades
+    // it to `viewer` would silently fail this gate.
+    const res = await app.request("/config", {
+      headers: { Authorization: basicAuthHeader("admin", "secret") },
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("still rejects unauthenticated requests with 401", async () => {
     const res = await app.request("/");
     expect(res.status).toBe(401);

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -218,11 +218,21 @@ export function createDashboard(config: DashboardConfig): Hono {
     // every dashboard route. SSO is the path for differentiated multi-user
     // permissions; basic-auth-authenticated requests get implicit-admin
     // access (they already proved knowledge of the shared DASHBOARD_PASSWORD).
+    //
+    // This middleware only runs when basicAuth's await-next() chain is
+    // reached — basicAuth throws HTTPException(401) on failed credentials,
+    // which short-circuits the chain before this middleware fires. Safe to
+    // grant admin unconditionally here.
+    //
+    // The synthetic email uses an explicit `@basic-auth.local` suffix so audit
+    // rows (audit-log Enterprise feature) record `actorEmail` as a clearly
+    // non-real-user value rather than a bare username string that could be
+    // mistaken for a malformed real email.
     const basicAuthUsername = config.auth.username;
     app.use("*", async (c, next) => {
       c.set("user" as never, {
         id: `basic-auth:${basicAuthUsername}`,
-        email: basicAuthUsername,
+        email: `${basicAuthUsername}@basic-auth.local`,
         role: "admin" as const,
       } as never);
       await next();

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -212,6 +212,21 @@ export function createDashboard(config: DashboardConfig): Hono {
         password: config.auth.password,
       }),
     );
+    // BEC-156: synthesize an admin user after basicAuth verifies credentials.
+    // Without this, the RBAC middleware (`requirePermission`) on Enterprise
+    // tier looks for c.user — which only the SSO middleware sets — and 401's
+    // every dashboard route. SSO is the path for differentiated multi-user
+    // permissions; basic-auth-authenticated requests get implicit-admin
+    // access (they already proved knowledge of the shared DASHBOARD_PASSWORD).
+    const basicAuthUsername = config.auth.username;
+    app.use("*", async (c, next) => {
+      c.set("user" as never, {
+        id: `basic-auth:${basicAuthUsername}`,
+        email: basicAuthUsername,
+        role: "admin" as const,
+      } as never);
+      await next();
+    });
   } else {
     app.use("*", async (c) => {
       return c.text(


### PR DESCRIPTION
## Summary
On Enterprise tier with basic auth (no SSO), the RBAC middleware (`packages/dashboard/src/middleware/rbac.ts:17`) returns 401 "Unauthorized" because it looks for `c.user` — which only the SSO middleware sets. Basic auth verifies credentials but doesn't bind a user object, so RBAC always fails and every dashboard route is locked out.

Closes BEC-156.

## Why

The bug is invisible to operators: the 401 doesn't include a `WWW-Authenticate` header (because it's NOT from Hono's basicAuth — it's from RBAC's plain `c.text()` 401), so browsers never prompt for credentials and operators see "Unauthorized" with no clue. Surfaced from BEC-138 dogfood when ngrok'ing the dashboard.

## Fix

After basicAuth verifies credentials, install a second middleware that sets a synthetic `c.user` with `role: "admin"`. Operators using basic auth get full dashboard access (they already proved knowledge of the shared DASHBOARD_PASSWORD); SSO is the path for differentiated multi-user permissions.

## Test plan
- [x] 5 new tests in `packages/dashboard/src/__tests__/server.test.ts` under "createDashboard — Enterprise tier + basic auth (BEC-156)"
- [x] All 216 dashboard tests pass; typecheck clean
- [ ] CI run on this PR passes
- [ ] (Post-merge): redeploy BEC-138 dogfood with the new dashboard version and confirm \`curl -u admin:<password> http://localhost:3001/\` returns 200

## Notes for SSO deployments

Unaffected. SSO middleware (when active) binds c.user to the WorkOS-authenticated user, so RBAC continues to enforce per-user roles. The new fallback middleware only fires when basic-auth is the active scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)