### PR TITLE
feat(pipeline): BEC-157 — filter agent scratchpad files from auto-commit

### DIFF
--- a/packages/core/src/__tests__/auto-commit-scratchpad.test.ts
+++ b/packages/core/src/__tests__/auto-commit-scratchpad.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { autoCommitChanges } from "../repo/git.js";
+import { autoCommitChanges, isScratchpadPath } from "../repo/git.js";
 
 /**
  * BEC-157: pipeline auto-commit must filter agent scratchpad files (e.g.,
@@ -127,5 +127,91 @@ describe("autoCommitChanges scratchpad filter (BEC-157)", () => {
 
     // No real files to commit → returns false (just like an empty status)
     expect(result).toBe(false);
+  });
+
+  // BEC-157 safety net (Sonnet review Important #1): if a scratchpad file is
+  // ALREADY tracked in HEAD (operator committed it pre-filter), unstaging via
+  // `git rm --cached` would record a permanent deletion. Skip the unstage for
+  // tracked entries — preserve the file as a normal commit.
+  it("preserves tracked scratchpad files instead of silently deleting them", async () => {
+    // Operator previously (pre-filter) committed .claude/settings.json
+    mkdirSync(join(repo, ".claude"), { recursive: true });
+    writeFileSync(join(repo, ".claude", "settings.json"), "old\n");
+    git(["add", "."], repo);
+    git(["commit", "-m", "operator committed scratchpad pre-filter"], repo);
+
+    // Now agent modifies it AND adds a real file
+    writeFileSync(join(repo, ".claude", "settings.json"), "new\n");
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "real.ts"), "real\n");
+
+    const result = await autoCommitChanges(repo, "BEC-999");
+
+    expect(result).toBe(true);
+    const files = listFilesInLastCommit(repo);
+    expect(files).toContain("src/real.ts");
+    // The tracked .claude/settings.json should still appear as committed
+    // (with new content) — NOT deleted from the repo.
+    expect(files).toContain(".claude/settings.json");
+    // Verify the file is not staged for deletion in HEAD~1..HEAD
+    const headContent = git(["show", "HEAD:.claude/settings.json"], repo);
+    expect(headContent).toBe("new\n");
+  });
+});
+
+describe("isScratchpadPath unit tests (BEC-157)", () => {
+  // Direct unit tests for the predicate, decoupled from git plumbing.
+  // Covers boundary cases that the integration tests don't reach.
+
+  it("matches .claude/ directory and contents", () => {
+    expect(isScratchpadPath(".claude")).toBe(true);
+    expect(isScratchpadPath(".claude/")).toBe(true);
+    expect(isScratchpadPath(".claude/settings.json")).toBe(true);
+    expect(isScratchpadPath(".claude/nested/deep.json")).toBe(true);
+  });
+
+  it("does NOT match .claude when nested under a directory", () => {
+    // Root-anchored: a subproject's .claude dir isn't pipeline scratchpad
+    expect(isScratchpadPath("frontend/.claude/x")).toBe(false);
+    expect(isScratchpadPath("packages/core/.claude/y")).toBe(false);
+  });
+
+  it("matches root-level BEC-NNN-*.md scratchpad", () => {
+    expect(isScratchpadPath("BEC-149-INDEX.md")).toBe(true);
+    expect(isScratchpadPath("BEC-1-x.md")).toBe(true);
+    expect(isScratchpadPath("BEC-9999-foo.md")).toBe(true);
+  });
+
+  it("does NOT match BEC-*.md without numeric ID or non-root path", () => {
+    expect(isScratchpadPath("BEC-foo.md")).toBe(false); // no numeric prefix
+    expect(isScratchpadPath("docs/BEC-149-INDEX.md")).toBe(false); // not at root
+    expect(isScratchpadPath("CHANGELOG.md")).toBe(false);
+  });
+
+  it("matches root-level verify-*.{mjs,ts,js,cjs} but not without extension", () => {
+    expect(isScratchpadPath("verify-fix.mjs")).toBe(true);
+    expect(isScratchpadPath("verify-x.ts")).toBe(true);
+    expect(isScratchpadPath("verify-y.js")).toBe(true);
+    expect(isScratchpadPath("verify-z.cjs")).toBe(true);
+    expect(isScratchpadPath("verify.mjs")).toBe(false); // no dash
+    expect(isScratchpadPath("verifyutils.mjs")).toBe(false); // no dash
+    expect(isScratchpadPath("src/utils/verify-input.ts")).toBe(false); // not at root
+  });
+
+  it("matches root-level BEC-NNN-*-VERIFICATION.md but NOT generic *-VERIFICATION.md", () => {
+    expect(isScratchpadPath("BEC-149-MIGRATION-VERIFICATION.md")).toBe(true);
+    expect(isScratchpadPath("BEC-200-VERIFICATION.md")).toBe(true);
+    // Pattern tightened (was overbroad in initial PR; would have filtered these):
+    expect(isScratchpadPath("SECURITY-VERIFICATION.md")).toBe(false);
+    expect(isScratchpadPath("API-VERIFICATION.md")).toBe(false);
+  });
+
+  it("does NOT match legitimate root-level files", () => {
+    expect(isScratchpadPath("CHANGELOG.md")).toBe(false);
+    expect(isScratchpadPath("CONTRIBUTING.md")).toBe(false);
+    expect(isScratchpadPath("README.md")).toBe(false);
+    expect(isScratchpadPath("LICENSE")).toBe(false);
+    expect(isScratchpadPath("package.json")).toBe(false);
+    expect(isScratchpadPath("turbo.json")).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/auto-commit-scratchpad.test.ts
+++ b/packages/core/src/__tests__/auto-commit-scratchpad.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { autoCommitChanges } from "../repo/git.js";
+
+/**
+ * BEC-157: pipeline auto-commit must filter agent scratchpad files (e.g.,
+ * `.claude/`, root-level `BEC-*-*.md`, `verify-*.{mjs,ts}`) so they don't get
+ * pushed to the target repo. The agent has no idea these are local scratchpad;
+ * the auto-commit step is the safety gate.
+ */
+
+const GIT_AUTHOR = {
+  GIT_AUTHOR_NAME: "Test Bot",
+  GIT_AUTHOR_EMAIL: "test-bot@example.com",
+  GIT_COMMITTER_NAME: "Test Bot",
+  GIT_COMMITTER_EMAIL: "test-bot@example.com",
+};
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, env: { ...process.env, ...GIT_AUTHOR }, encoding: "utf-8" });
+}
+
+function listFilesInLastCommit(repo: string): string[] {
+  return git(["show", "--name-only", "--pretty=format:", "HEAD"], repo)
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+}
+
+describe("autoCommitChanges scratchpad filter (BEC-157)", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "urateam-bec157-"));
+    git(["init", "--initial-branch=main"], repo);
+    git(["config", "user.email", "test-bot@example.com"], repo);
+    git(["config", "user.name", "Test Bot"], repo);
+    // Create a base commit so HEAD has a parent (autoCommitChanges expects a
+    // valid HEAD it can branch-check against; even without that, commits
+    // produce nicer diffs against a parent).
+    writeFileSync(join(repo, "README.md"), "# initial\n");
+    git(["add", "README.md"], repo);
+    git(["commit", "-m", "initial"], repo);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("commits real source files but excludes .claude/* scratchpad", async () => {
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "foo.ts"), "export const foo = 1;\n");
+    mkdirSync(join(repo, ".claude"), { recursive: true });
+    writeFileSync(join(repo, ".claude", "settings.json"), '{"hook":"x"}\n');
+
+    const result = await autoCommitChanges(repo, "BEC-999");
+
+    expect(result).toBe(true);
+    const files = listFilesInLastCommit(repo);
+    expect(files).toContain("src/foo.ts");
+    expect(files).not.toContain(".claude/settings.json");
+    // Scratchpad file still exists on disk — just not committed
+    expect(existsSync(join(repo, ".claude", "settings.json"))).toBe(true);
+  });
+
+  it("excludes root-level BEC-NNN-*.md scratchpad", async () => {
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "real.ts"), "export const real = 1;\n");
+    writeFileSync(join(repo, "BEC-149-INDEX.md"), "# scratchpad\n");
+    writeFileSync(join(repo, "BEC-149-PR-CHECKLIST.md"), "# checklist\n");
+
+    await autoCommitChanges(repo, "BEC-999");
+
+    const files = listFilesInLastCommit(repo);
+    expect(files).toContain("src/real.ts");
+    expect(files).not.toContain("BEC-149-INDEX.md");
+    expect(files).not.toContain("BEC-149-PR-CHECKLIST.md");
+  });
+
+  it("excludes root-level verify-*.{mjs,ts,js} scratchpad scripts", async () => {
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "real.ts"), "real\n");
+    writeFileSync(join(repo, "verify-fix.mjs"), "// scratchpad\n");
+    writeFileSync(join(repo, "verify-thing.ts"), "// scratchpad\n");
+
+    await autoCommitChanges(repo, "BEC-999");
+
+    const files = listFilesInLastCommit(repo);
+    expect(files).toContain("src/real.ts");
+    expect(files).not.toContain("verify-fix.mjs");
+    expect(files).not.toContain("verify-thing.ts");
+  });
+
+  it("does NOT exclude legitimate root-level files (CHANGELOG.md, CONTRIBUTING.md, README.md)", async () => {
+    writeFileSync(join(repo, "CHANGELOG.md"), "# changelog\n");
+    writeFileSync(join(repo, "CONTRIBUTING.md"), "# contrib\n");
+
+    await autoCommitChanges(repo, "BEC-999");
+
+    const files = listFilesInLastCommit(repo);
+    expect(files).toContain("CHANGELOG.md");
+    expect(files).toContain("CONTRIBUTING.md");
+  });
+
+  it("does NOT exclude verify-*.ts inside src/ (only root-level matches)", async () => {
+    // Real-world: a developer may legitimately have a `verify-*.ts` in
+    // src/utils/ as part of an actual feature. Only root-level scratchpad
+    // patterns get filtered.
+    mkdirSync(join(repo, "src", "utils"), { recursive: true });
+    writeFileSync(join(repo, "src", "utils", "verify-input.ts"), "export {};\n");
+
+    await autoCommitChanges(repo, "BEC-999");
+
+    const files = listFilesInLastCommit(repo);
+    expect(files).toContain("src/utils/verify-input.ts");
+  });
+
+  it("returns false when ALL changes are scratchpad (nothing real to commit)", async () => {
+    mkdirSync(join(repo, ".claude"), { recursive: true });
+    writeFileSync(join(repo, ".claude", "settings.json"), '{}\n');
+    writeFileSync(join(repo, "BEC-200-OUTPUT.md"), "# x\n");
+
+    const result = await autoCommitChanges(repo, "BEC-999");
+
+    // No real files to commit → returns false (just like an empty status)
+    expect(result).toBe(false);
+  });
+});

--- a/packages/core/src/repo/git.ts
+++ b/packages/core/src/repo/git.ts
@@ -471,18 +471,6 @@ export function choosePushStrategy(
 }
 
 /**
- * Check for uncommitted changes and auto-commit them if found.
- * Returns true if a commit was made, false if the worktree was clean.
- *
- * This is a safety net for when the agent doesn't commit its work
- * (hits maxTurns, maxTokens, or a permission error). Without this,
- * the push queue's rebase fails and the work is lost.
- *
- * @param expectedBranch - When provided, the function verifies that the
- *   worktree HEAD is on this branch before committing.  A mismatch throws
- *   immediately to prevent cross-branch contamination (BEC-99).
- */
-/**
  * BEC-157: paths that auto-commit must NEVER include in the agent's commit.
  * These are agent scratchpad / runner-state artifacts that the agent's
  * pipeline produces locally but should not ship to the target repo.
@@ -490,21 +478,52 @@ export function choosePushStrategy(
  * Each entry is a predicate against a worktree-relative path. Anchor patterns
  * to root (no leading `/`) so a legitimate `src/utils/verify-input.ts` is not
  * filtered.
+ *
+ * Trade-off: a legitimate root-level `verify-prod-config.mjs` style script
+ * would be silently filtered. Operators with such files must rename them
+ * (e.g., `check-prod-config.mjs`) or place them under a subdirectory.
  */
 const SCRATCHPAD_PATTERNS: ReadonlyArray<(path: string) => boolean> = [
   // Claude Code session state (runner-specific paths leak in here)
   (p) => p === ".claude" || p.startsWith(".claude/"),
   // Root-level BEC-NNN-*.md docs (agent self-documentation; not repo content)
   (p) => /^BEC-\d+-.*\.md$/.test(p),
-  // Root-level verify-*.{mjs,ts,js} scripts (agent self-validation; redundant
-  // with vitest)
+  // Root-level verify-*.{mjs,ts,js,cjs} scripts (agent self-validation;
+  // redundant with vitest). See trade-off note in docblock above.
   (p) => /^verify-.*\.(mjs|ts|js|cjs)$/.test(p),
-  // Root-level *-VERIFICATION.md
-  (p) => /^[A-Z][A-Z0-9_-]*-VERIFICATION\.md$/.test(p),
+  // Root-level BEC-NNN-*-VERIFICATION.md (parallel with BEC-NNN-*.md above —
+  // tightened from `[A-Z][A-Z0-9_-]*-VERIFICATION.md` so legitimate operator
+  // docs like `SECURITY-VERIFICATION.md` aren't filtered)
+  (p) => /^BEC-\d+-.*-VERIFICATION\.md$/.test(p),
 ];
 
 export function isScratchpadPath(path: string): boolean {
   return SCRATCHPAD_PATTERNS.some((p) => p(path));
+}
+
+/**
+ * BEC-157: identify scratchpad paths that are ALREADY tracked in HEAD.
+ * Returns the subset of `paths` that `git ls-files` reports as tracked.
+ *
+ * Why: the auto-commit filter unstages scratchpad paths via `git rm --cached`.
+ * For a NEWLY-created scratchpad file, this is a clean unstage — no record in
+ * HEAD, no harm done. But for a TRACKED file that the agent modified (e.g.,
+ * the operator previously committed `.claude/settings.json` before the filter
+ * existed), `git rm --cached` records a permanent deletion in the new commit
+ * and the file is removed from the repo. That's silent data loss at rollout
+ * time on any repo that committed scratchpad pre-filter.
+ *
+ * This function lets the caller detect the dangerous case and warn / abort.
+ */
+async function findTrackedPaths(
+  worktreePath: string,
+  paths: string[],
+): Promise<string[]> {
+  if (paths.length === 0) return [];
+  // `git ls-files -- <paths>` lists only those of the given paths that are
+  // tracked. Untracked paths produce no output (they're not errors).
+  const out = await gitExecSafe(["ls-files", "--", ...paths], worktreePath);
+  return out.split("\n").map((s) => s.trim()).filter(Boolean);
 }
 
 /**
@@ -529,6 +548,18 @@ function parseStatusPaths(status: string): string[] {
   return paths;
 }
 
+/**
+ * Check for uncommitted changes and auto-commit them if found.
+ * Returns true if a commit was made, false if the worktree was clean.
+ *
+ * This is a safety net for when the agent doesn't commit its work
+ * (hits maxTurns, maxTokens, or a permission error). Without this,
+ * the push queue's rebase fails and the work is lost.
+ *
+ * @param expectedBranch - When provided, the function verifies that the
+ *   worktree HEAD is on this branch before committing. A mismatch throws
+ *   immediately to prevent cross-branch contamination (BEC-99).
+ */
 export async function autoCommitChanges(
   worktreePath: string,
   issueId: string,
@@ -551,14 +582,30 @@ export async function autoCommitChanges(
   const realPaths = allPaths.filter((p) => !isScratchpadPath(p));
   const filteredPaths = allPaths.filter((p) => isScratchpadPath(p));
 
+  // BEC-157 safety net: if any filtered path is ALREADY TRACKED in HEAD
+  // (operator committed it pre-filter, e.g., before this PR shipped),
+  // unstaging via `git rm --cached` would record a permanent deletion in the
+  // new commit and remove the file from the repo. Detect and skip the unstage
+  // for those entries — leaving them staged as legit modifications/additions.
+  // Worst case: a tracked scratchpad file gets a normal modify-commit. Better
+  // than silent data loss.
+  const trackedScratchpad = await findTrackedPaths(worktreePath, filteredPaths);
+  const safeToUnstage = filteredPaths.filter((p) => !trackedScratchpad.includes(p));
+
   if (filteredPaths.length > 0) {
     getLog().info(
-      { issueId, filtered: filteredPaths },
+      { issueId, filtered: filteredPaths, trackedScratchpad },
       "auto-commit filtered scratchpad paths (BEC-157)",
     );
   }
+  if (trackedScratchpad.length > 0) {
+    getLog().warn(
+      { issueId, trackedScratchpad },
+      "auto-commit: scratchpad paths are tracked in HEAD; preserving as committed changes (operator should remove these from the repo manually if unwanted)",
+    );
+  }
 
-  if (realPaths.length === 0) {
+  if (realPaths.length === 0 && trackedScratchpad.length === 0) {
     getLog().warn(
       { issueId, worktreePath, allFiltered: allPaths },
       "auto-commit: no real changes after scratchpad filter (skipping commit)",
@@ -569,27 +616,24 @@ export async function autoCommitChanges(
   getLog().warn({ issueId, worktreePath }, "auto-committing uncommitted changes (agent did not commit)");
   // BEC-157 staging strategy: `git add -A` to correctly handle all status
   // types (modifications, additions, deletions of tracked files, renames),
-  // then `git rm --cached` any scratchpad paths that just got staged. Using
-  // `git add -- <paths>` with an explicit path list looks cleaner but doesn't
-  // stage deletions of tracked files (regression caught by the existing
-  // "handles deleted files" integration test).
+  // then `git rm --cached` any scratchpad paths that just got staged AND
+  // weren't already tracked in HEAD. Using `git add -- <paths>` with an
+  // explicit path list looks cleaner but doesn't stage deletions of tracked
+  // files (regression caught by the existing "handles deleted files"
+  // integration test).
   await gitExecSafe(["add", "-A"], worktreePath);
-  if (filteredPaths.length > 0) {
+  if (safeToUnstage.length > 0) {
     // Unstage scratchpad files. `git rm --cached -- <paths>` removes index
     // entries while leaving the worktree files alone. `--ignore-unmatch`
     // tolerates files that weren't tracked yet (untracked scratchpad new
     // files: they were `git add -A`-staged as new index entries, and
-    // `git rm --cached` removes them; for tracked scratchpad files that
-    // somehow exist, this removes them from the index but the next commit
-    // would recreate them as deletions — handled by the loop being
-    // tolerant). For our use-case (agent's freshly-created scratchpad),
-    // every filtered path is a new file added by the agent; rm --cached
-    // simply unstages.
+    // `git rm --cached` removes them).
+    //
     // `-r` is required when filteredPaths includes a directory entry (e.g.,
     // `.claude/` from `git status --porcelain` for a new untracked dir).
     // `--ignore-unmatch` tolerates entries that aren't in the index.
     await gitExecSafe(
-      ["rm", "-r", "--cached", "--ignore-unmatch", "--", ...filteredPaths],
+      ["rm", "-r", "--cached", "--ignore-unmatch", "--", ...safeToUnstage],
       worktreePath,
     );
   }

--- a/packages/core/src/repo/git.ts
+++ b/packages/core/src/repo/git.ts
@@ -567,8 +567,32 @@ export async function autoCommitChanges(
   }
 
   getLog().warn({ issueId, worktreePath }, "auto-committing uncommitted changes (agent did not commit)");
-  // `git add --` with explicit paths to avoid staging the scratchpad files.
-  await gitExecSafe(["add", "--", ...realPaths], worktreePath);
+  // BEC-157 staging strategy: `git add -A` to correctly handle all status
+  // types (modifications, additions, deletions of tracked files, renames),
+  // then `git rm --cached` any scratchpad paths that just got staged. Using
+  // `git add -- <paths>` with an explicit path list looks cleaner but doesn't
+  // stage deletions of tracked files (regression caught by the existing
+  // "handles deleted files" integration test).
+  await gitExecSafe(["add", "-A"], worktreePath);
+  if (filteredPaths.length > 0) {
+    // Unstage scratchpad files. `git rm --cached -- <paths>` removes index
+    // entries while leaving the worktree files alone. `--ignore-unmatch`
+    // tolerates files that weren't tracked yet (untracked scratchpad new
+    // files: they were `git add -A`-staged as new index entries, and
+    // `git rm --cached` removes them; for tracked scratchpad files that
+    // somehow exist, this removes them from the index but the next commit
+    // would recreate them as deletions — handled by the loop being
+    // tolerant). For our use-case (agent's freshly-created scratchpad),
+    // every filtered path is a new file added by the agent; rm --cached
+    // simply unstages.
+    // `-r` is required when filteredPaths includes a directory entry (e.g.,
+    // `.claude/` from `git status --porcelain` for a new untracked dir).
+    // `--ignore-unmatch` tolerates entries that aren't in the index.
+    await gitExecSafe(
+      ["rm", "-r", "--cached", "--ignore-unmatch", "--", ...filteredPaths],
+      worktreePath,
+    );
+  }
   try {
     await gitExec(
       ["commit", "-m", `feat(${issueId}): agent implementation (auto-committed)`],

--- a/packages/core/src/repo/git.ts
+++ b/packages/core/src/repo/git.ts
@@ -482,6 +482,53 @@ export function choosePushStrategy(
  *   worktree HEAD is on this branch before committing.  A mismatch throws
  *   immediately to prevent cross-branch contamination (BEC-99).
  */
+/**
+ * BEC-157: paths that auto-commit must NEVER include in the agent's commit.
+ * These are agent scratchpad / runner-state artifacts that the agent's
+ * pipeline produces locally but should not ship to the target repo.
+ *
+ * Each entry is a predicate against a worktree-relative path. Anchor patterns
+ * to root (no leading `/`) so a legitimate `src/utils/verify-input.ts` is not
+ * filtered.
+ */
+const SCRATCHPAD_PATTERNS: ReadonlyArray<(path: string) => boolean> = [
+  // Claude Code session state (runner-specific paths leak in here)
+  (p) => p === ".claude" || p.startsWith(".claude/"),
+  // Root-level BEC-NNN-*.md docs (agent self-documentation; not repo content)
+  (p) => /^BEC-\d+-.*\.md$/.test(p),
+  // Root-level verify-*.{mjs,ts,js} scripts (agent self-validation; redundant
+  // with vitest)
+  (p) => /^verify-.*\.(mjs|ts|js|cjs)$/.test(p),
+  // Root-level *-VERIFICATION.md
+  (p) => /^[A-Z][A-Z0-9_-]*-VERIFICATION\.md$/.test(p),
+];
+
+export function isScratchpadPath(path: string): boolean {
+  return SCRATCHPAD_PATTERNS.some((p) => p(path));
+}
+
+/**
+ * Parse `git status --porcelain` output into worktree-relative paths.
+ * Handles renames (`R old -> new`), additions, modifications, deletions,
+ * and untracked files.
+ */
+function parseStatusPaths(status: string): string[] {
+  const paths: string[] = [];
+  for (const line of status.split("\n")) {
+    if (!line.trim()) continue;
+    // Porcelain format: XY <space> <path> [-> <newpath>]
+    // Examples: " M src/foo.ts", "?? .claude/settings.json", "R  old -> new"
+    const rest = line.slice(3);
+    if (rest.includes(" -> ")) {
+      // Rename: take the new path
+      paths.push(rest.split(" -> ")[1]!.trim());
+    } else {
+      paths.push(rest.trim());
+    }
+  }
+  return paths;
+}
+
 export async function autoCommitChanges(
   worktreePath: string,
   issueId: string,
@@ -495,8 +542,33 @@ export async function autoCommitChanges(
   const status = await gitExecSafe(["status", "--porcelain"], worktreePath);
   if (!status.trim()) return false;
 
+  // BEC-157: filter out agent scratchpad paths before staging. The pipeline
+  // sees them as new files in the worktree (.claude/settings.json with
+  // runner paths, BEC-NNN-*.md doc proliferation, verify-*.mjs scripts that
+  // duplicate vitest coverage) but they must not be committed to the target
+  // repo. Legitimate code under src/ is unaffected.
+  const allPaths = parseStatusPaths(status);
+  const realPaths = allPaths.filter((p) => !isScratchpadPath(p));
+  const filteredPaths = allPaths.filter((p) => isScratchpadPath(p));
+
+  if (filteredPaths.length > 0) {
+    getLog().info(
+      { issueId, filtered: filteredPaths },
+      "auto-commit filtered scratchpad paths (BEC-157)",
+    );
+  }
+
+  if (realPaths.length === 0) {
+    getLog().warn(
+      { issueId, worktreePath, allFiltered: allPaths },
+      "auto-commit: no real changes after scratchpad filter (skipping commit)",
+    );
+    return false;
+  }
+
   getLog().warn({ issueId, worktreePath }, "auto-committing uncommitted changes (agent did not commit)");
-  await gitExecSafe(["add", "-A"], worktreePath);
+  // `git add --` with explicit paths to avoid staging the scratchpad files.
+  await gitExecSafe(["add", "--", ...realPaths], worktreePath);
   try {
     await gitExec(
       ["commit", "-m", `feat(${issueId}): agent implementation (auto-committed)`],


### PR DESCRIPTION
## Summary
The pipeline's auto-commit step (`autoCommitChanges` in `packages/core/src/repo/git.ts`) used `git add -A` followed by `git commit`, capturing every file the agent created in the worktree — including agent scratchpad files that shouldn't ship to the target repo.

Closes BEC-157. Surfaced from BEC-138 dogfood after PR #157 (BEC-149) was bloated with 3,392 lines of scratchpad noise.

## What's filtered

Three pattern classes, all anchored to repo root:

1. **`.claude/`** anywhere — Claude Code session state (runner-specific paths leak in here; PR #157 had `/home/ura/data/runs/-6RNw_K-PBYxoBKOsFT9O/worktree` baked in).
2. **Root-level `BEC-NNN-*.md`** — agent's own progress-tracking docs that duplicate the Linear ticket. PR #157 had 7 of these adding ~3000 lines.
3. **Root-level `verify-*.{mjs,ts,js,cjs}`** and **root-level `*-VERIFICATION.md`** — fragile regex-parse-the-source scripts the agent writes to "verify" its own work. Duplicate vitest.

Patterns are deliberately anchored to root so `src/utils/verify-input.ts` (legitimate code) and `docs/something-VERIFICATION.md` (legitimate doc) are unaffected.

## Implementation

- New `isScratchpadPath(path)` predicate exported from `git.ts` (also useful for downstream tests / debugging).
- New `parseStatusPaths(status)` helper handles `git status --porcelain` parsing including renames (`R old -> new`).
- `autoCommitChanges`:
  - Parses status into all paths
  - Splits into real vs. scratchpad
  - Logs filtered paths via structured `auto-commit filtered scratchpad paths (BEC-157)` info line for forensic visibility
  - When ALL paths are scratchpad → returns false (skips empty commit, with a structured warn line)
  - Otherwise: `git add -- <real-paths>` then commit (no `git add -A`)

## Test plan
- [x] 6 new TDD tests in `__tests__/auto-commit-scratchpad.test.ts` (RED → GREEN cycle):
  - excludes `.claude/*` but commits real source files
  - excludes root-level `BEC-NNN-*.md`
  - excludes root-level `verify-*.{mjs,ts,js}`
  - does NOT exclude legit root files (`CHANGELOG.md`, `CONTRIBUTING.md`)
  - does NOT exclude `verify-*.ts` inside `src/` (root-only matching)
  - returns false when ALL changes are scratchpad
- [x] Full core suite: 1404/1404 pass (was 1398; +6 new BEC-157 tests). 1 pre-existing unrelated test file failure (CLI tarball execFileSync) carried over from main; **not** introduced by this PR.
- [x] Typecheck clean
- [ ] CI run on this PR passes
- [ ] (Post-merge): redeploy BEC-138 dogfood with the new core version. Next bot PR should NOT contain `.claude/` or root-level scratchpad files.

## Decisions

**Why hardcoded patterns rather than a `.urateam-agent-ignore` config file?** YAGNI for v1. Three patterns cover the observed bloat from the BEC-149 run; if more patterns surface in subsequent dogfood runs, a configurable file can layer on. The `isScratchpadPath` export means tests/debugging can use the same source of truth.

**Why filter at auto-commit rather than at agent prompt?** Auto-commit is the safety gate that runs regardless of agent prompt quality. Agents from different Claude Code versions / different prompts may produce these files; centralizing the filter at git.ts makes it pipeline-version-independent.

**Audit trail**: a structured info-level log line `auto-commit filtered scratchpad paths (BEC-157)` with a `filtered` array of paths is emitted whenever filtering happens. Doesn't go to AUDIT KV (this is operational, not customer-facing) but is grep-able from container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)