### PR TITLE
chore(release): v0.1.34 — BEC-148 + BEC-156 + BEC-157 + BEC-147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
+## [0.1.34] — 2026-05-06
+
+Bumps:
+- `@urateam/core`: 0.1.19 → 0.1.20
+- `@urateam/cli`: 0.1.21 → 0.1.22
+- `@urateam/dashboard`: 0.1.19 → 0.1.20
+- `create-urateam`: 0.1.22 → 0.1.23
+
+### Added
+- **BEC-156** — Dashboard's basic-auth path on Enterprise tier now synthesizes an admin user after credentials verify, so RBAC's `requirePermission` middleware passes without requiring SSO. Operators using basic auth get full dashboard access (they already proved knowledge of the shared password); SSO remains the path for differentiated multi-user permissions. Surfaced from BEC-138 dogfood; basic-auth users on Enterprise were silently 401'd on every dashboard route. (#158)
+- **BEC-157** — Pipeline auto-commit (`autoCommitChanges` in `packages/core/src/repo/git.ts`) now filters agent scratchpad files (`.claude/`, root-level `BEC-NNN-*.md`, root-level `verify-*.{mjs,ts,js,cjs}`, `BEC-NNN-*-VERIFICATION.md`) before committing. Bot-generated PRs no longer ship runner-specific paths or agent self-documentation. Includes a safety net: scratchpad paths already tracked in HEAD (operator committed pre-filter) are preserved as legit changes rather than silently deleted. New `isScratchpadPath` predicate exported for tests / debugging. (#159)
+- **BEC-148** — `turbo.json` `test` task gets `dependsOn: ["^build"]` so `pnpm -r test` from the repo root no longer fails on `@urateam/core` resolution. Parallel to PR #145's `typecheck` fix. First fully-autonomous bot PR through the dogfood loop on the `quick-fix` pipeline. (#156)
+- **BEC-147** — CHANGELOG conventions migrated to GitHub Releases as source of truth for v0.1.7+. CHANGELOG.md preserved for historical reference; new releases use auto-generated GH release notes going forward. (#155)
+
 ## [0.1.33] — 2026-05-05
 
 Bumps:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Cuts v0.1.34. Bumps:
- @urateam/core: 0.1.19 → 0.1.20
- @urateam/cli: 0.1.21 → 0.1.22
- @urateam/dashboard: 0.1.19 → 0.1.20
- create-urateam: 0.1.22 → 0.1.23

## Released features

- **BEC-156** (#158) — Dashboard basic-auth + RBAC synthesizes admin user. Fixes silent 401s for Enterprise basic-auth deployments without SSO.
- **BEC-157** (#159) — Pipeline auto-commit filters agent scratchpad files (.claude/, BEC-*.md, verify-*.{mjs,ts,js,cjs}, BEC-NNN-*-VERIFICATION.md). Includes safety net for tracked scratchpad files.
- **BEC-148** (#156) — turbo.json test task gets \`dependsOn: ["^build"]\`. **First fully-autonomous bot PR through the BEC-138 dogfood loop on the quick-fix pipeline.**
- **BEC-147** (#155) — CHANGELOG conventions migrated to GH Releases. **First fully-autonomous bot PR through the BEC-138 dogfood loop overall.**

## Dogfood validation milestone

This release is the first to ship code primarily authored by the BEC-138 dogfood agent (PRs #155 and #156 were both opened, reviewed, and committed by \`urateam-dogfood-bot\`). The autonomous loop is validated end-to-end:

\`\`\`
Linear ticket → PM agent (poll, label-match) → pipeline (clone, agent SDK, auto-commit) →
PR push (gh CLI auth) → human review → merge → release cut
\`\`\`

## Cut sequence (after merge)

1. \`git tag v0.1.34 <merge-sha> && git push origin v0.1.34\` — fires publish.yml
2. \`gh release create v0.1.34 --title "..." --notes "..."\`
3. Redeploy BEC-138 dogfood with bumped \`URATEAM_*_VERSION\` build args (0.1.20 / 0.1.22 / 0.1.20)

## Test plan
- [x] All 4 package.json versions bumped
- [x] CHANGELOG: new \`## [0.1.34]\` section above [0.1.33]
- [x] \`pnpm install\` clean
- [ ] CI run on this PR passes
- [ ] Post-merge: tag pushed, publish.yml runs green, all 4 packages on npm at expected versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)