### PR TITLE
fix(dockerfile): BEC-154 + BEC-155 bake git identity + gh credential helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,22 @@ RUN addgroup -S ura && adduser -S -G ura ura
 USER ura
 WORKDIR /home/ura
 
+# BEC-154: bake a default git identity so the executor's `git commit` doesn't
+# silently fail with "Please tell me who you are" inside non-root containers
+# that don't have a real user. Operators can override via GIT_AUTHOR_NAME /
+# GIT_AUTHOR_EMAIL env vars in their .env file (those win over `git config`).
+#
+# BEC-155: bake the gh-cli credential helper config that `gh auth setup-git`
+# would otherwise write at runtime — without this, `git push` fails with
+# "could not read Username for 'https://github.com'" until an operator runs
+# `docker exec ... gh auth setup-git` after every container restart.
+RUN git config --global user.name  "Urateam Agent" \
+ && git config --global user.email "agent@urateam.local" \
+ && git config --global --replace-all "credential.https://github.com.helper"      "" \
+ && git config --global --add         "credential.https://github.com.helper"      '!/usr/bin/gh auth git-credential' \
+ && git config --global --replace-all "credential.https://gist.github.com.helper" "" \
+ && git config --global --add         "credential.https://gist.github.com.helper" '!/usr/bin/gh auth git-credential'
+
 # Persistent volumes:
 # - /home/ura/data: SQLite database
 # - /home/ura/work: cloned repos + worktrees (PM agent clones REPO_URL here)


### PR DESCRIPTION
Closes BEC-154, BEC-155.

## Summary

- Bakes a default `git config user.name` / `user.email` into the image so non-root containers don't silently fail `git commit` (BEC-154).
- Bakes the gh-cli credential helper config that `gh auth setup-git` would otherwise have to write at runtime (BEC-155).
- Both stay overrideable: operators set `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` in `.env` to use a real identity (env wins over `git config`).

## Why

On 2026-05-06 the BEC-138 dogfood lost both pieces of state after a rebuild. Every autonomous PR attempt failed at push time with `git push failed: could not read Username for 'https://github.com'` until I manually re-ran `docker exec urateam-dogfood gh auth setup-git`. This shouldn't be a manual step — bake it into the image so rebuilds are idempotent.

## Test plan

- [x] Replicated the RUN sequence in a fresh `node:22-alpine` container (alpine + git + github-cli, non-root `ura` user) and confirmed the resulting `/home/ura/.gitconfig` matches exactly what `gh auth setup-git` produces at runtime in the live dogfood.
- [ ] After merge: rebuild dogfood image without manually running `gh auth setup-git`, confirm autonomous PRs push successfully on first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)