### PR TITLE
feat(executor): BEC-162 bump implement maxTurns 50→100, test 25→50

### DIFF
--- a/packages/core/src/__tests__/agent-profiles.test.ts
+++ b/packages/core/src/__tests__/agent-profiles.test.ts
@@ -23,15 +23,21 @@ describe("getAgentProfiles defaults", () => {
     expect(getAgentProfiles()).toEqual(DEFAULT_AGENT_PROFILES);
   });
 
-  it("ships the documented test stage budget (urateam#38 baseline)", () => {
-    // The whole point of urateam#38 is that this baseline is too tight
-    // for bootstrapping. The override path is the fix; defaults are
-    // unchanged. Asserting the known shape so a silent default bump
+  it("ships the documented test + implement stage budgets", () => {
+    // BEC-162 (2026-05-06 BEC-138 dogfood): bumped from implement=50/test=25
+    // to implement=100/test=50 after non-trivial sev-2 tickets repeatedly
+    // hit the old caps. urateam#38 (bootstrapping) and the override path
+    // are unchanged; this is just a more realistic baseline for
+    // mature-repo work. Asserting exact shape so any future silent bump
     // shows up in review.
     expect(DEFAULT_AGENT_PROFILES.test).toMatchObject({
-      maxTurns: 25,
+      maxTurns: 50,
       maxInputTokens: 30_000,
       model: "claude-haiku-4-5",
+    });
+    expect(DEFAULT_AGENT_PROFILES.implement).toMatchObject({
+      maxTurns: 100,
+      maxInputTokens: 100_000,
     });
   });
 });
@@ -88,7 +94,7 @@ describe("getAgentProfiles env override", () => {
       test: { maxTurns: 0, maxInputTokens: -1 },
     });
     const p = getAgentProfiles();
-    expect(p.test.maxTurns).toBe(25); // default kept
+    expect(p.test.maxTurns).toBe(50); // BEC-162 default kept
     expect(p.test.maxInputTokens).toBe(30_000); // default kept
   });
 

--- a/packages/core/src/__tests__/agent-profiles.test.ts
+++ b/packages/core/src/__tests__/agent-profiles.test.ts
@@ -44,11 +44,14 @@ describe("getAgentProfiles defaults", () => {
 
 describe("getAgentProfiles env override", () => {
   it("merges a partial override on top of defaults", () => {
+    // BEC-162 review: pick a maxTurns value that does NOT match the default
+    // (50 post-bump). Otherwise a regression that drops the merge logic and
+    // falls back to the default would silently pass this assertion.
     process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
-      test: { maxTurns: 50, maxInputTokens: 80_000 },
+      test: { maxTurns: 75, maxInputTokens: 80_000 },
     });
     const p = getAgentProfiles();
-    expect(p.test.maxTurns).toBe(50);
+    expect(p.test.maxTurns).toBe(75);
     expect(p.test.maxInputTokens).toBe(80_000);
     // Untouched fields keep their default
     expect(p.test.model).toBe("claude-haiku-4-5");
@@ -76,15 +79,16 @@ describe("getAgentProfiles env override", () => {
   });
 
   it("ignores malformed individual fields without dropping the rest of the stage", () => {
+    // BEC-162 review: 75, not 50 — see "merges a partial override" above.
     process.env.URATEAM_AGENT_PROFILES = JSON.stringify({
       test: {
-        maxTurns: 50,            // valid → applied
+        maxTurns: 75,            // valid → applied
         maxInputTokens: "lots",  // invalid → ignored
         model: "",               // invalid (empty) → ignored
       },
     });
     const p = getAgentProfiles();
-    expect(p.test.maxTurns).toBe(50);
+    expect(p.test.maxTurns).toBe(75);
     expect(p.test.maxInputTokens).toBe(30_000); // default kept
     expect(p.test.model).toBe("claude-haiku-4-5"); // default kept
   });

--- a/packages/core/src/executor/profiles.ts
+++ b/packages/core/src/executor/profiles.ts
@@ -51,13 +51,18 @@ export const DEFAULT_AGENT_PROFILES: Record<string, AgentProfile> = deepFreeze({
   implement: {
     tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
     maxInputTokens: 100_000,
-    maxTurns: 50,
+    // BEC-162: bumped 50→100. Non-trivial sev-2 fixes (5-10 file reads +
+    // 5-10 writes + iterative bash) repeatedly hit the old cap on BEC-138
+    // dogfood. Daily budget + BEC-161 circuit breaker still bound total
+    // spend; per-stage cap just prevents single-run runaway.
+    maxTurns: 100,
     model: DEFAULT_MODEL,
   },
   test: {
     tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
     maxInputTokens: 30_000,
-    maxTurns: 25,
+    // BEC-162: bumped 25→50 for the same reason as implement above.
+    maxTurns: 50,
     model: HAIKU_MODEL,
   },
   review: {


### PR DESCRIPTION
Closes BEC-162.

## Summary

- `DEFAULT_AGENT_PROFILES.implement.maxTurns`: 50 → 100
- `DEFAULT_AGENT_PROFILES.test.maxTurns`: 25 → 50
- All other stage defaults unchanged.

## Why

Non-trivial sev-2 fixes on the 2026-05-06 BEC-138 dogfood repeatedly hit the old caps:

```
"Reached maximum number of turns (50)"  ← implement
"Reached maximum number of turns (25)"  ← test (twice)
```

5-10 file reads + 5-10 writes + iterative bash verification easily exceeds 50 turns for implement, and the old 25-turn test cap left no headroom for tickets whose acceptance criteria require running the suite + iterating on failures.

## Spend bounding

Total spend is still bounded by:
- `PM_AGENT_DAILY_TOKEN_BUDGET` (per-team / per-repo caps, unchanged)
- BEC-161 circuit breaker (stops after 3 consecutive failed runs, recently merged)

So bumping per-stage caps is no longer the primary line of defense against runaway spend.

## Distinct from BEC-159

BEC-159 covers the RALPH 6-turn evaluation cap, which is a separate stage with its own cap. This PR does not touch RALPH.

## Test plan

- [x] `agent-profiles.test.ts` "ships the documented test + implement stage budgets" updated to assert new values; comment notes the BEC-138 reason so any future silent bump shows up in review.
- [x] All 1413 core tests pass; `pnpm typecheck` clean.
- [ ] After merge: re-run a failed-against-old-caps ticket (e.g., a re-attempt at BEC-158) on the dogfood to confirm the new caps are sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)