### PR TITLE
fix(release-manager): BEC-160 emit stdout log on every tick skip path

### DIFF
--- a/packages/core/src/__tests__/release-manager-scheduler.test.ts
+++ b/packages/core/src/__tests__/release-manager-scheduler.test.ts
@@ -156,6 +156,37 @@ describe("createReleaseManagerScheduler — single tick", () => {
     expect(skipLine).toMatch(/mergedPRsSince not met/);
   });
 
+  it("BEC-160 review: fire path also emits a stdout log.info — a successful release must not be silent", async () => {
+    // Same captured-stdout pattern as the skip-path test above. Asserts the
+    // fire branch (the production-event branch) also surfaces in docker logs.
+    const writes: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: any) => {
+      writes.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+      return true;
+    });
+
+    try {
+      const cfg = ReleaseManagerConfigSchema.parse({
+        enabled: true,
+        triggers: { mergedPRsSince: 1 },
+      });
+      const octokit = makeMockOctokit();
+      const sched = createReleaseManagerScheduler({
+        config: cfg, db, octokit, repoUrl, isLicensed: () => true, slack: undefined,
+      });
+      await sched.tick();
+    } finally {
+      spy.mockRestore();
+      writes.forEach((w) => orig(w));
+    }
+
+    const logLines = writes.filter((w) => w.includes("ReleaseManager:scheduler"));
+    const fireLine = logLines.find((w) => w.includes("tick fire"));
+    expect(fireLine, `expected a tick-fire log line; got ${JSON.stringify(logLines)}`).toBeDefined();
+    expect(fireLine).toMatch(/v1\.0\.1/);
+  });
+
   it("awaiting-approval path: requireSlackApproval=true with no fresh approval → awaiting-approval row, Slack prompt, no tag", async () => {
     const cfg = ReleaseManagerConfigSchema.parse({
       enabled: true,

--- a/packages/core/src/__tests__/release-manager-scheduler.test.ts
+++ b/packages/core/src/__tests__/release-manager-scheduler.test.ts
@@ -122,6 +122,40 @@ describe("createReleaseManagerScheduler — single tick", () => {
     expect(octokit.git.createRef).not.toHaveBeenCalled();
   });
 
+  it("BEC-160: skip path emits a stdout log.info so operators see the tick (visibility gap fix)", async () => {
+    // Capture stdout chunks while the tick runs. Pino writes JSON-per-line to
+    // process.stdout; we assert one of those lines reflects the skip event.
+    const writes: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: any) => {
+      writes.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+      return true;
+    });
+
+    try {
+      const cfg = ReleaseManagerConfigSchema.parse({
+        enabled: true,
+        triggers: { mergedPRsSince: 100 },
+      });
+      const octokit = makeMockOctokit();
+      const sched = createReleaseManagerScheduler({
+        config: cfg, db, octokit, repoUrl, isLicensed: () => true, slack: undefined,
+      });
+      await sched.tick();
+    } finally {
+      spy.mockRestore();
+      // Flush any captured noise so test runner output is unaffected
+      writes.forEach((w) => orig(w));
+    }
+
+    const logLines = writes.filter((w) => w.includes("ReleaseManager:scheduler"));
+    const skipLine = logLines.find((w) =>
+      w.includes("tick skip") || w.includes("triggers not met"),
+    );
+    expect(skipLine, `expected a tick-skip log line; got ${JSON.stringify(logLines)}`).toBeDefined();
+    expect(skipLine).toMatch(/mergedPRsSince not met/);
+  });
+
   it("awaiting-approval path: requireSlackApproval=true with no fresh approval → awaiting-approval row, Slack prompt, no tag", async () => {
     const cfg = ReleaseManagerConfigSchema.parse({
       enabled: true,

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -530,6 +530,13 @@ export function createReleaseManagerScheduler(
         mergedPrCount: state.mergedCommitsSinceLastTag,
       }),
     );
+    // BEC-160: stdout visibility for the fire path. A successful release is a
+    // production event — operators must see it in `docker logs`, not just the
+    // audit table. Slack-suppressed deployments would otherwise be silent.
+    log.info(
+      { repoUrl, branch, tag: proposedVersion, sha: state.headSha, mergedPrCount: state.mergedCommitsSinceLastTag, releaseUrl: githubResult.releaseUrl },
+      "tick fire",
+    );
     await maybePostSlack(
       `:rocket: Released *${proposedVersion}* for ${repoUrl} (${branch}). ${githubResult.releaseUrl}`,
       null,

--- a/packages/core/src/release-manager/scheduler.ts
+++ b/packages/core/src/release-manager/scheduler.ts
@@ -401,6 +401,12 @@ export function createReleaseManagerScheduler(
         attemptCount,
       });
       void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: finalReason }));
+      // BEC-160: emit a stdout line for every skip so operators tailing
+      // docker logs can see the scheduler is alive and why it's skipping.
+      log.info(
+        { repoUrl, branch, reason: finalReason, mergedCommitsSinceLastTag: state.mergedCommitsSinceLastTag, lastTag: state.lastTag, proposedVersion },
+        "tick skip",
+      );
       // Slack notification with dedup
       await maybePostSlack(
         `:double_vertical_bar: Release skipped for *${repoUrl}* (${branch}): ${finalReason}`,
@@ -419,6 +425,11 @@ export function createReleaseManagerScheduler(
         proposedVersion,
       });
       void logAuditEventUnchecked(db, releaseSkippedEvent({ repoUrl, branch, reason: "awaiting-approval" }));
+      // BEC-160: stdout visibility for the awaiting-approval skip path.
+      log.info(
+        { repoUrl, branch, reason: "awaiting-approval", proposedVersion },
+        "tick skip",
+      );
       // Always post on first transition to awaiting-approval (bypass dedup).
       // Reset lastSlackSkipReason so a subsequent regular-skip will re-post.
       lastSlackSkipReason = null;
@@ -447,6 +458,11 @@ export function createReleaseManagerScheduler(
         proposedVersion,
       });
       void logAuditEventUnchecked(db, releaseTagConflictEvent({ repoUrl, branch, tag: proposedVersion }));
+      // BEC-160: stdout visibility for the tag-exists skip path.
+      log.info(
+        { repoUrl, branch, reason: "tag_exists", proposedVersion },
+        "tick skip",
+      );
       return;
     }
 


### PR DESCRIPTION
Closes BEC-160.

## Summary

Adds `log.info({ reason, ... }, "tick skip")` on the three skip-emit branches in `release-manager/scheduler.ts` `tick()`:

1. **mergedPRsSince / qa-not-met** (the most-frequent path)
2. **awaiting-approval**
3. **tag_exists**

Audit-event behavior is unchanged; this is purely a visibility / observability fix.

## Why

The original BEC-160 ticket framed the scheduler as "dead" (boot log only, no further output). Investigation 2026-05-06 22:47 UTC proved it was actually firing every 30 min — the audit DB had ticks every cycle with reason `mergedPRsSince not met (0/3)`. The skip path just didn't emit to stdout. Operators tailing `docker logs` reasonably concluded it was broken; ~3.8 hours of misdiagnosis were burned before the audit table was queried directly.

Fix: every audit-emitting skip branch now also emits a stdout line with the same reason + relevant trigger state (`mergedCommitsSinceLastTag`, `lastTag`, `proposedVersion`).

## Test plan

- [x] New test `release-manager-scheduler.test.ts` "BEC-160: skip path emits a stdout log.info" captures `process.stdout.write` during a stubbed tick and asserts the `tick skip` line is present with the expected reason. Verified RED → GREEN.
- [x] All 1414 core tests pass; existing scheduler tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)