### PR TITLE
chore(release): v0.1.35 — BEC-154 + BEC-155 + BEC-160 + BEC-161 + BEC-162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
+## [0.1.35] — 2026-05-06
+
+Bumps:
+- `@urateam/core`: 0.1.20 → 0.1.21
+- `@urateam/cli`: 0.1.22 → 0.1.23
+- `@urateam/dashboard`: 0.1.20 → 0.1.21
+- `create-urateam`: 0.1.23 → 0.1.24
+
+### Added
+- **BEC-161** — PM circuit breaker. After **3 consecutive failed pipeline runs** for the same Linear issue (with no successful run between), the `promote` and `start-todo` actions skip the issue with reason `circuit-breaker: N consecutive failed runs (threshold 3)` instead of re-promoting. Closes the recover-stuck → promote → start-todo → fail doom loop that burned agent + OpenRouter tokens on BEC-138 dogfood with zero PRs produced. New env knob `PM_AGENT_MAX_CONSECUTIVE_FAILURES` (default 3, set 0 to disable). (#161)
+- **BEC-160** — Release Manager scheduler now emits a `log.info({ reason, ... }, "tick skip")` line on every skip-emit branch (`mergedPRsSince`/`qa_*`, `awaiting-approval`, `tag_exists`) AND a `log.info(..., "tick fire")` on the successful-fire branch. Prior behavior wrote audit-table rows but no stdout, so operators tailing `docker logs` couldn't tell whether RM was alive — `~3.8 hrs` of misdiagnosis on the 2026-05-06 dogfood before the audit table was queried directly. (#164)
+
+### Changed
+- **BEC-162** — Default `maxTurns` for the implement stage bumped 50 → 100, and for the test stage 25 → 50. Non-trivial sev-2 fixes on BEC-138 dogfood repeatedly hit the old caps. Other stages unchanged. Operators can still override per-stage via the existing `URATEAM_AGENT_PROFILES` env knob. Total spend remains bounded by `PM_AGENT_DAILY_TOKEN_BUDGET` and the BEC-161 circuit breaker. (#163)
+
+### Fixed
+- **BEC-154 / BEC-155** — Dockerfile now bakes a default `git config user.name`/`user.email` and the gh-cli credential helper that `gh auth setup-git` would otherwise have to write at runtime. Without these, every container rebuild silently broke autonomous git operations until an operator manually re-applied them. Operators retain full override via `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` env vars (those win over `git config`). (#162)
+
 ## [0.1.34] — 2026-05-06
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.18
-ARG URATEAM_CLI_VERSION=0.1.20
-ARG URATEAM_DASHBOARD_VERSION=0.1.18
+ARG URATEAM_CORE_VERSION=0.1.21
+ARG URATEAM_CLI_VERSION=0.1.23
+ARG URATEAM_DASHBOARD_VERSION=0.1.21
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

- Bumps `@urateam/core`, `@urateam/cli`, `@urateam/dashboard`, `create-urateam`.
- Bumps Dockerfile ARG versions to match (so the dogfood image rebuild picks up the new packages once npm OIDC publish completes).
- CHANGELOG entry summarizing the five Linear tickets closing in this release.

## What's in v0.1.35

| Ticket | Severity | What it does |
|--------|----------|--------------|
| **BEC-161** | sev-2 | PM circuit breaker after 3 consecutive failed runs (#161) |
| **BEC-160** | sev-3 | RM scheduler emits stdout log on every tick path (#164) |
| **BEC-162** | sev-2 | implement maxTurns 50→100, test 25→50 (#163) |
| **BEC-154+155** | sev-2 | Dockerfile bakes git identity + gh credential helper (#162) |

All five Linear tickets surfaced from the 2026-05-06 BEC-138 self-dogfood — the doom-loop investigation that validated BEC-138 as a feedback channel for v1.0 hardening.

## Release pipeline

1. ✅ This PR (you merging is the gate)
2. Push `v0.1.35` tag → fires npm OIDC publish workflow
3. `gh release create v0.1.35` for the GitHub release page
4. Rebuild + redeploy dogfood image; re-add `auto-implement` / `quick-fix` labels to BEC-158 + BEC-159 to validate the full stack on real tickets

## Test plan

- [x] All 1414 core tests pass.
- [x] Each individual feature PR (#161-#164) is CI-green and reviewed.
- [ ] After npm publish: rebuild dogfood, observe that container does NOT need post-rebuild manual `gh auth setup-git` (BEC-155 validation).
- [ ] After dogfood rebuild: re-label BEC-158 + BEC-159, observe pipelines either succeed OR cleanly hit the new circuit breaker after 3 attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)