### PR TITLE
chore(dogfood): sync docker-compose.dogfood.yml args to v0.1.35

### DIFF
--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.18
-        URATEAM_CLI_VERSION: 0.1.20
-        URATEAM_DASHBOARD_VERSION: 0.1.18
+        URATEAM_CORE_VERSION: 0.1.21
+        URATEAM_CLI_VERSION: 0.1.23
+        URATEAM_DASHBOARD_VERSION: 0.1.21
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped


### PR DESCRIPTION
Tiny follow-up to v0.1.35.

The compose file's `args:` block was stale (0.1.18 / 0.1.20 / 0.1.18 since BEC-138 bootstrap). The v0.1.35 release commit bumped the Dockerfile ARG defaults but missed the compose-file overrides, so `docker compose build` silently installed the OLD package versions. Caught during the v0.1.35 dogfood rebuild — fresh image needed `--no-cache` AND a host-local args edit before npm picked up the new versions.

Sync brings them to match the v0.1.35 Dockerfile (0.1.21 / 0.1.23 / 0.1.21).

## Test plan
- [x] Operator on the dogfood host had to apply this same edit to make `docker compose build` install v0.1.35 packages.
- [ ] Future release (v0.1.36+) should bump both Dockerfile and this file together. Consider dropping the redundant `args:` override in a follow-up so we have a single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)