### PR TITLE
feat(pipeline): BEC-163 add URATEAM_DEEP_REVIEW_PASSES env override

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -10,7 +10,7 @@ export const startCommand = new Command("start")
   .option("--dashboard-port <port>", "Dashboard port", "3001")
   .action(async (options) => {
     try {
-    const { createApp, defaultConfigs, cleanupWorktrees, addLogStream, initSlackAlertManager, createSlackAlertStream } = await import("@urateam/core");
+    const { createApp, defaultConfigs, applyDeepReviewPassesOverride, cleanupWorktrees, addLogStream, initSlackAlertManager, createSlackAlertStream } = await import("@urateam/core");
 
     // --- Slack error alerts (opt-in) ---
     if (
@@ -243,10 +243,19 @@ export const startCommand = new Command("start")
       }
     }
 
+    // BEC-163: enable BEC-134 OpenRouter fanout via env. Unset = defaults
+    // unchanged (every pipeline keeps deepReviewPasses=0). Set to a
+    // non-negative integer to override on every pipeline that has a
+    // `review` stage (auto-implement, bug, needs-design — not quick-fix).
+    const pipelineConfigs = applyDeepReviewPassesOverride(
+      defaultConfigs,
+      process.env.URATEAM_DEEP_REVIEW_PASSES,
+    );
+
     const config = {
       webhookSecret: process.env.LINEAR_WEBHOOK_SECRET,
       linearApiKey: process.env.LINEAR_API_KEY ?? "",
-      pipelineConfigs: defaultConfigs,
+      pipelineConfigs,
       repoConfigs,
       databaseUrl: process.env.DATABASE_URL,
       slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,

--- a/packages/core/src/__tests__/deep-review-passes-override.test.ts
+++ b/packages/core/src/__tests__/deep-review-passes-override.test.ts
@@ -1,0 +1,69 @@
+/**
+ * BEC-163 — env-var override for `deepReviewPasses` so operators can enable
+ * BEC-134 OpenRouter fanout without forking the built-in pipeline configs.
+ *
+ * Default behavior (env unset) is unchanged: every pipeline keeps its
+ * compiled-in `deepReviewPasses` value (0 for the built-ins).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  defaultConfigs,
+  applyDeepReviewPassesOverride,
+} from "../pipeline/config.js";
+
+describe("applyDeepReviewPassesOverride (BEC-163)", () => {
+  it("returns configs unchanged when env value is undefined", () => {
+    const out = applyDeepReviewPassesOverride(defaultConfigs, undefined);
+    expect(out).toEqual(defaultConfigs);
+    // Same reference for unchanged map is a nice-to-have but not required.
+    for (const [k, cfg] of Object.entries(out)) {
+      expect(cfg.deepReviewPasses).toBe(defaultConfigs[k].deepReviewPasses);
+    }
+  });
+
+  it("sets deepReviewPasses on every pipeline that has a review stage", () => {
+    const out = applyDeepReviewPassesOverride(defaultConfigs, "1");
+    expect(out["auto-implement"].deepReviewPasses).toBe(1);
+    expect(out["bug"].deepReviewPasses).toBe(1);
+    expect(out["needs-design"].deepReviewPasses).toBe(1);
+  });
+
+  it("does NOT touch pipelines without a review stage (e.g. quick-fix)", () => {
+    const out = applyDeepReviewPassesOverride(defaultConfigs, "1");
+    // quick-fix has stages: ["implement", "test"] — no review. Fanout would
+    // require a review stage to attach to, so the override is meaningless.
+    // Leave the default 0 so cost doesn't bump for trivial pipelines.
+    expect(out["quick-fix"].deepReviewPasses).toBe(0);
+    expect(out["quick-fix"].stages).not.toContain("review");
+  });
+
+  it("accepts integer values higher than 1", () => {
+    const out = applyDeepReviewPassesOverride(defaultConfigs, "3");
+    expect(out["auto-implement"].deepReviewPasses).toBe(3);
+  });
+
+  it("accepts 0 to explicitly disable on review-having pipelines", () => {
+    // Caller wants to assert: env=0 keeps the default-disabled state but
+    // proves the override path executed.
+    const out = applyDeepReviewPassesOverride(defaultConfigs, "0");
+    expect(out["auto-implement"].deepReviewPasses).toBe(0);
+  });
+
+  it("ignores invalid values (non-integer / negative) and returns the input unchanged", () => {
+    expect(
+      applyDeepReviewPassesOverride(defaultConfigs, "lots")["auto-implement"].deepReviewPasses,
+    ).toBe(0);
+    expect(
+      applyDeepReviewPassesOverride(defaultConfigs, "-1")["auto-implement"].deepReviewPasses,
+    ).toBe(0);
+    expect(
+      applyDeepReviewPassesOverride(defaultConfigs, "")["auto-implement"].deepReviewPasses,
+    ).toBe(0);
+  });
+
+  it("does not mutate the input map", () => {
+    const before = JSON.parse(JSON.stringify(defaultConfigs));
+    applyDeepReviewPassesOverride(defaultConfigs, "2");
+    expect(defaultConfigs).toEqual(before);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db } from ".
 export { pipelineRuns, stageRuns, agentLogs, activeWork, pmApprovals } from "./db/index.js";
 export { createApp, type ServerConfig } from "./server.js";
 export { PipelineRunner, type PipelineRunnerConfig, type LinearIssue } from "./pipeline/index.js";
-export { defaultConfigs, validatePipelineConfigs, validateRepoConfigs, resolvePipeline } from "./pipeline/index.js";
+export { defaultConfigs, validatePipelineConfigs, validateRepoConfigs, applyDeepReviewPassesOverride, resolvePipeline } from "./pipeline/index.js";
 export { createWebhookHandler } from "./webhook/index.js";
 export {
   CompositeNotifier,

--- a/packages/core/src/pipeline/config.ts
+++ b/packages/core/src/pipeline/config.ts
@@ -1,5 +1,8 @@
 import { PipelineConfigSchema, RepoConfigSchema } from "../types.js";
 import type { PipelineConfig, RepoConfig } from "../types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "pipeline.config" });
 
 // Shared reduced-cost loop defaults applied to every built-in pipeline.
 // These can be overridden per-pipeline in your own config by setting explicit values.
@@ -61,6 +64,42 @@ export function validatePipelineConfigs(
     validated[key] = result.data;
   }
   return validated;
+}
+
+/**
+ * BEC-163: env-var override for `deepReviewPasses` so operators can enable
+ * BEC-134 OpenRouter fanout without forking the built-in pipeline configs.
+ *
+ * Returns a new map where every pipeline whose `stages` array includes
+ * `"review"` has its `deepReviewPasses` set to the parsed env value.
+ * Pipelines without a `review` stage are passed through untouched (the
+ * fanout has nothing to attach to and the cost would be wasted).
+ *
+ * `envValue === undefined` → returns the input unchanged.
+ * Invalid input (non-integer, negative) → logs warn, returns input unchanged.
+ */
+export function applyDeepReviewPassesOverride(
+  configs: Record<string, PipelineConfig>,
+  envValue: string | undefined,
+): Record<string, PipelineConfig> {
+  if (envValue === undefined) return configs;
+  const n = parseInt(envValue, 10);
+  if (Number.isNaN(n) || n < 0 || envValue.trim() === "") {
+    log.warn(
+      { envValue, var: "URATEAM_DEEP_REVIEW_PASSES" },
+      "URATEAM_DEEP_REVIEW_PASSES must be a non-negative integer — ignoring",
+    );
+    return configs;
+  }
+  const result: Record<string, PipelineConfig> = {};
+  for (const [key, cfg] of Object.entries(configs)) {
+    if ((cfg.stages ?? []).includes("review")) {
+      result[key] = { ...cfg, deepReviewPasses: n };
+    } else {
+      result[key] = cfg;
+    }
+  }
+  return result;
 }
 
 export function validateRepoConfigs(

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -1,4 +1,9 @@
-export { defaultConfigs, validatePipelineConfigs, validateRepoConfigs } from "./config.js";
+export {
+  defaultConfigs,
+  validatePipelineConfigs,
+  validateRepoConfigs,
+  applyDeepReviewPassesOverride,
+} from "./config.js";
 export { resolvePipeline } from "./router.js";
 export { createQueue, type WorkQueue } from "./queue.js";
 export { PipelineRunner, type PipelineRunnerConfig, type LinearIssue } from "./runner.js";


### PR DESCRIPTION
Closes BEC-163.

## Summary

- New env var `URATEAM_DEEP_REVIEW_PASSES`. Unset = today's behavior (every pipeline keeps `deepReviewPasses=0` → fanout never fires). Non-negative integer = override on every pipeline that has a `review` stage.
- New `applyDeepReviewPassesOverride(configs, envValue)` helper in `packages/core/src/pipeline/config.ts`, exported from `@urateam/core`.
- CLI `start` calls it after loading `defaultConfigs`.

## Why

BEC-134 OpenRouter multi-model fanout is shipped to code but **never actually fires** for any operator using the built-in pipelines. `LOOP_DEFAULTS.deepReviewPasses = 0` and no built-in overrides it. Caught 2026-05-07 reviewing the autonomous PRs from BEC-138 dogfood: `REVIEW_MODELS` + `OPENROUTER_API_KEY` were configured, but zero `openrouter`/`fanout`/`deep-review` log lines and zero `review.fanout_*` audit events across 12+ hours.

## Why not bake it into LOOP_DEFAULTS

Tempting (one-line change), but it would silently bump $ cost on first deploy for every operator using auto-implement / bug. Env-knob keeps default unchanged; opt-in for those who want fanout.

## Why exclude quick-fix

`quick-fix.stages = ["implement", "test"]` — no `review` stage. Fanout has nothing to attach to and would just waste API calls.

## Test plan

- [x] 7 RED→GREEN tests in `deep-review-passes-override.test.ts`: unset, =1, higher values, =0 explicit, invalid (non-int / negative / empty), no-mutation guarantee, quick-fix exclusion.
- [x] All 1413 core tests pass; `pnpm typecheck` clean across core + cli + dashboard; `pnpm -r build` clean.
- [ ] After merge: add `URATEAM_DEEP_REVIEW_PASSES=1` to `.env.dogfood`, restart container, exercise an auto-implement pipeline run, confirm `openrouter`/`fanout` log lines appear and `review.fanout_*` audit events are emitted.

## Followup

Once this validates on the dogfood, the `gh release` notes for the next bump should call out the new knob so other operators know it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)