### PR TITLE
fix(BEC-163): reject non-integer URATEAM_DEEP_REVIEW_PASSES values

### DIFF
--- a/packages/core/src/__tests__/deep-review-passes-override.test.ts
+++ b/packages/core/src/__tests__/deep-review-passes-override.test.ts
@@ -59,6 +59,15 @@ describe("applyDeepReviewPassesOverride (BEC-163)", () => {
     expect(
       applyDeepReviewPassesOverride(defaultConfigs, "")["auto-implement"].deepReviewPasses,
     ).toBe(0);
+    // BEC-163 review feedback: parseInt silently truncates "1.5" → 1. Reject
+    // floats explicitly so an operator who fat-fingers a decimal sees the
+    // ignored-warning instead of a silent partial-match.
+    expect(
+      applyDeepReviewPassesOverride(defaultConfigs, "1.5")["auto-implement"].deepReviewPasses,
+    ).toBe(0);
+    expect(
+      applyDeepReviewPassesOverride(defaultConfigs, "1e2")["auto-implement"].deepReviewPasses,
+    ).toBe(0);
   });
 
   it("does not mutate the input map", () => {

--- a/packages/core/src/pipeline/config.ts
+++ b/packages/core/src/pipeline/config.ts
@@ -83,14 +83,19 @@ export function applyDeepReviewPassesOverride(
   envValue: string | undefined,
 ): Record<string, PipelineConfig> {
   if (envValue === undefined) return configs;
-  const n = parseInt(envValue, 10);
-  if (Number.isNaN(n) || n < 0 || envValue.trim() === "") {
+  // Reject anything that isn't a literal non-negative-integer string. parseInt
+  // would silently truncate "1.5" → 1, "1e2" → 1, etc., which is worse than
+  // returning the default — operators expect a fat-finger to be flagged, not
+  // applied as the prefix-parsable integer.
+  const trimmed = envValue.trim();
+  if (!/^\d+$/.test(trimmed)) {
     log.warn(
       { envValue, var: "URATEAM_DEEP_REVIEW_PASSES" },
       "URATEAM_DEEP_REVIEW_PASSES must be a non-negative integer — ignoring",
     );
     return configs;
   }
+  const n = parseInt(trimmed, 10);
   const result: Record<string, PipelineConfig> = {};
   for (const [key, cfg] of Object.entries(configs)) {
     if ((cfg.stages ?? []).includes("review")) {


### PR DESCRIPTION
Quick follow-up to PR #169 from the same Sonnet review pass.

## What

`parseInt("1.5", 10)` returns 1, so a typo like `URATEAM_DEEP_REVIEW_PASSES=1.5` (or `1e2` → 1, `1abc` → 1) silently downcasts to whatever-prefix-parses instead of being flagged as invalid. Tightens to require a literal non-negative-integer string via `/^\d+$/` before parseInt. Two new test cases lock the contract.

## Test plan

- [x] 7 deep-review-passes-override tests pass; new "1.5" and "1e2" cases verified to fall through the warn-and-skip path.
- [x] Existing valid-input cases (0, 1, 3) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)