### PR TITLE
chore(release): v0.1.36 — BEC-158 + BEC-159 + BEC-163 + compose-args sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
-## [Unreleased]
+## [0.1.36] — 2026-05-07
+
+Bumps:
+- `@urateam/core`: 0.1.21 → 0.1.22
+- `@urateam/cli`: 0.1.23 → 0.1.24
+- `@urateam/dashboard`: 0.1.21 → 0.1.22
+- `create-urateam`: 0.1.24 → 0.1.25
+
+### Added
+- **BEC-163** — `URATEAM_DEEP_REVIEW_PASSES` env knob to opt into BEC-134's OpenRouter multi-model fanout without forking the built-in pipeline configs. When set to a non-negative integer, applies to every pipeline that has a `review` stage in its `stages` array (so `auto-implement`, `bug`, `needs-design` — `quick-fix` is correctly excluded since it has no review stage). Default unset preserves today's behavior (every pipeline keeps `deepReviewPasses=0`). Validation rejects floats / non-integer strings. (#169, #170)
+- **BEC-158** — Multi-model review fanout now posts a fallback advisory comment with the raw model output when the structured-finding parse fails. Previously, OpenRouter calls were made (cost incurred) but the prose output was discarded if it didn't conform to the expected JSON schema. Operators now see *something* per model even when the model emits prose. Audit event `review.fanout_fallback_used` fires so deployments hitting this path are detectable. (#166)
 
 ### Fixed (OSS+)
-- **BEC-159** — RALPH evaluation agent turn cap raised from 6 to 15. The previous 6-turn cap was insufficient for acceptance criteria requiring shell-execution verification (e.g. "pnpm -r test must pass"), which requires ≥ 6 turns just to read the ticket, inspect the diff, run the command, and produce a verdict. RALPH would exhaust the cap before returning a verdict, causing correctly-implemented PRs to be incorrectly drafted for human review. Operators can override via the `RALPH_MAX_TURNS` environment variable for tickets whose acceptance criteria require more extensive shell verification.
+- **BEC-159** — RALPH evaluation agent turn cap raised from 6 to 15. The previous 6-turn cap was insufficient for acceptance criteria requiring shell-execution verification (e.g. "pnpm -r test must pass"), which requires ≥ 6 turns just to read the ticket, inspect the diff, run the command, and produce a verdict. RALPH would exhaust the cap before returning a verdict, causing correctly-implemented PRs to be incorrectly drafted for human review. Operators can override via the `RALPH_MAX_TURNS` environment variable for tickets whose acceptance criteria require more extensive shell verification. (#167)
+
+### Chore
+- `docker-compose.dogfood.yml` `args:` block sync'd to v0.1.35 versions (this got stale during BEC-138 bootstrap and silently pinned `npm install -g` to old packages until the v0.1.35 dogfood rebuild surfaced it). Future releases bump both Dockerfile ARG defaults and compose `args:` together. (#168)
 
 ## [0.1.35] — 2026-05-06
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.21
-ARG URATEAM_CLI_VERSION=0.1.23
-ARG URATEAM_DASHBOARD_VERSION=0.1.21
+ARG URATEAM_CORE_VERSION=0.1.22
+ARG URATEAM_CLI_VERSION=0.1.24
+ARG URATEAM_DASHBOARD_VERSION=0.1.22
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.21
-        URATEAM_CLI_VERSION: 0.1.23
-        URATEAM_DASHBOARD_VERSION: 0.1.21
+        URATEAM_CORE_VERSION: 0.1.22
+        URATEAM_CLI_VERSION: 0.1.24
+        URATEAM_DASHBOARD_VERSION: 0.1.22
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- 3 features (BEC-158 review fanout fallback, BEC-159 RALPH 6-turn → 15, BEC-163 deepReviewPasses env knob) + 1 chore (compose-args sync).
- Bumps all 4 npm packages + Dockerfile ARG defaults + compose `args:` block (kept in sync to avoid the v0.1.35 surprise).

## What's in v0.1.36

| Ticket | Severity | What it does | PR |
|--------|----------|--------------|----|
| **BEC-163** | sev-2 | `URATEAM_DEEP_REVIEW_PASSES` env knob unlocks BEC-134 OpenRouter fanout per pipeline | [#169](https://github.com/JonB32/urateam/pull/169), [#170](https://github.com/JonB32/urateam/pull/170) |
| **BEC-158** | sev-2 | Multi-model review posts raw-output fallback when structured parse fails | [#166](https://github.com/JonB32/urateam/pull/166) |
| **BEC-159** | sev-3 | RALPH cap 6→15 — drafted-PR-on-correct-work fix for shell-verifiable acceptance criteria | [#167](https://github.com/JonB32/urateam/pull/167) |
| chore | — | docker-compose.dogfood.yml args sync | [#168](https://github.com/JonB32/urateam/pull/168) |

## Why now (vs. waiting for autonomous bot-cut)

RM was holding off on auto-firing v0.1.36 because of a `timeSinceLastHours = 72h` pacing gate (only 12.4h since v0.1.35). Cutting manually so we can validate BEC-134 fanout end-to-end + unblock BEC-159's RALPH fix in the dogfood today rather than 60h from now.

Note: 3 of the 4 feature PRs are fully-autonomous bot PRs through the BEC-138 dogfood — validates the BEC-161 circuit breaker + BEC-162 maxTurns bump from v0.1.35 working in production.

## Release pipeline

1. Merge this PR
2. Push `v0.1.36` tag → fires npm OIDC publish
3. `gh release create v0.1.36`
4. Rebuild + redeploy dogfood image; observe BEC-134 fanout fires on next pipeline run + bot PRs no longer get RALPH-drafted

🤖 Generated with [Claude Code](https://claude.com/claude-code)