### PR TITLE
feat(review): BEC-164 add REVIEW_MODELS_MAX_OUTPUT_TOKENS env knob

### DIFF
--- a/packages/core/src/__tests__/openrouter-fanout.test.ts
+++ b/packages/core/src/__tests__/openrouter-fanout.test.ts
@@ -114,4 +114,37 @@ describe("OpenRouterFanoutProvider", () => {
     expect(runs).toHaveLength(2);
     expect(runs.every((r) => r.status === "failed")).toBe(true);
   });
+
+  describe("BEC-164 maxOutputTokens config", () => {
+    it("when unset, no max_tokens is forwarded to chatCompletion (preserves model default)", async () => {
+      chatCompletion.mockResolvedValue({ content: validJson, inputTokens: 1, outputTokens: 1 });
+      const { OpenRouterFanoutProvider } = await import(
+        "../executor/review/openrouter-fanout.js"
+      );
+      const p = new OpenRouterFanoutProvider({
+        apiKey: "k", baseUrl: "https://x/api/v1",
+        models: ["m1"], timeoutMs: 1000, maxInputTokens: 100_000,
+        // maxOutputTokens intentionally omitted
+      });
+      await p.runReview(ctx());
+      const opts = chatCompletion.mock.calls[0][2];
+      expect(opts.maxTokens).toBeUndefined();
+    });
+
+    it("when set, maxTokens is forwarded so OpenRouter sends max_tokens in the request body", async () => {
+      chatCompletion.mockResolvedValue({ content: validJson, inputTokens: 1, outputTokens: 1 });
+      const { OpenRouterFanoutProvider } = await import(
+        "../executor/review/openrouter-fanout.js"
+      );
+      const p = new OpenRouterFanoutProvider({
+        apiKey: "k", baseUrl: "https://x/api/v1",
+        models: ["m1", "m2"], timeoutMs: 1000, maxInputTokens: 100_000,
+        maxOutputTokens: 4000,
+      });
+      await p.runReview(ctx());
+      // Both parallel calls receive the cap.
+      expect(chatCompletion.mock.calls[0][2].maxTokens).toBe(4000);
+      expect(chatCompletion.mock.calls[1][2].maxTokens).toBe(4000);
+    });
+  });
 });

--- a/packages/core/src/__tests__/review-provider-registry.test.ts
+++ b/packages/core/src/__tests__/review-provider-registry.test.ts
@@ -77,4 +77,38 @@ describe("review-provider registry — fanout selection", () => {
     const models = (fanout as unknown as { cfg: { models: string[] } }).cfg.models;
     expect(models).toEqual(["m1", "m2"]);
   });
+
+  describe("BEC-164 REVIEW_MODELS_MAX_OUTPUT_TOKENS env parsing", () => {
+    function fanoutCfg(env: NodeJS.ProcessEnv) {
+      const ps = getEnabledProviders(env);
+      const fanout = ps.find((p) => p.id === "openrouter");
+      return (fanout as unknown as { cfg: { maxOutputTokens?: number } }).cfg;
+    }
+
+    it("when env unset, maxOutputTokens is undefined (preserves model default)", () => {
+      const cfg = fanoutCfg({ REVIEW_MODELS: "m1", OPENROUTER_API_KEY: "sk" });
+      expect(cfg.maxOutputTokens).toBeUndefined();
+    });
+
+    it("when set to a positive integer, parses as number", () => {
+      const cfg = fanoutCfg({
+        REVIEW_MODELS: "m1",
+        OPENROUTER_API_KEY: "sk",
+        REVIEW_MODELS_MAX_OUTPUT_TOKENS: "4000",
+      });
+      expect(cfg.maxOutputTokens).toBe(4000);
+    });
+
+    it("invalid input (zero / negative / non-numeric) → undefined (caller's chatCompletion gets no maxTokens)", () => {
+      expect(
+        fanoutCfg({ REVIEW_MODELS: "m1", OPENROUTER_API_KEY: "sk", REVIEW_MODELS_MAX_OUTPUT_TOKENS: "0" }).maxOutputTokens,
+      ).toBeUndefined();
+      expect(
+        fanoutCfg({ REVIEW_MODELS: "m1", OPENROUTER_API_KEY: "sk", REVIEW_MODELS_MAX_OUTPUT_TOKENS: "-1" }).maxOutputTokens,
+      ).toBeUndefined();
+      expect(
+        fanoutCfg({ REVIEW_MODELS: "m1", OPENROUTER_API_KEY: "sk", REVIEW_MODELS_MAX_OUTPUT_TOKENS: "lots" }).maxOutputTokens,
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/executor/review/openrouter-fanout.ts
+++ b/packages/core/src/executor/review/openrouter-fanout.ts
@@ -12,6 +12,13 @@ export interface OpenRouterFanoutConfig {
   models: string[];
   timeoutMs: number;
   maxInputTokens: number;
+  /**
+   * BEC-164: optional cap on `max_tokens` forwarded to OpenRouter. Unset
+   * means the provider's default applies (which can be very high — e.g.
+   * gemini-2.5-pro defaults to 65536 — and burn credits on accounts with
+   * limited budget). Set to a positive integer (e.g. 4000) to bound cost.
+   */
+  maxOutputTokens?: number;
 }
 
 export class OpenRouterFanoutProvider implements ReviewProvider {
@@ -66,6 +73,7 @@ export class OpenRouterFanoutProvider implements ReviewProvider {
     try {
       const result = await this.client.chatCompletion(modelId, prompt.messages, {
         signal: ac.signal,
+        ...(this.cfg.maxOutputTokens !== undefined && { maxTokens: this.cfg.maxOutputTokens }),
       });
       // Try structured parse; fall back to raw output on parse failure.
       let findings: ReviewModelRun["findings"] = [];

--- a/packages/core/src/executor/review/review-provider.ts
+++ b/packages/core/src/executor/review/review-provider.ts
@@ -64,6 +64,10 @@ export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[] {
       models,
       timeoutMs: parseIntOr(env.REVIEW_MODELS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
       maxInputTokens: parseIntOr(env.REVIEW_MODELS_MAX_INPUT_TOKENS, DEFAULT_MAX_INPUT_TOKENS),
+      // BEC-164: optional output-token cap. Unset = the model's provider
+      // default applies (can be huge → 402s on limited-budget accounts).
+      // Invalid input falls through to undefined so the cap stays unset.
+      maxOutputTokens: parsePositiveIntOrUndefined(env.REVIEW_MODELS_MAX_OUTPUT_TOKENS),
     }),
   );
   return providers;
@@ -73,4 +77,10 @@ function parseIntOr(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function parsePositiveIntOrUndefined(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
 }


### PR DESCRIPTION
Closes BEC-164.

## Summary
- New env var `REVIEW_MODELS_MAX_OUTPUT_TOKENS`. Unset = identical to today (no `max_tokens` sent → model's default applies). Set to a positive integer to bound cost.
- Plumbs through `OpenRouterFanoutConfig.maxOutputTokens` → `chatCompletion(..., { maxTokens })` → request body `max_tokens`.

## Why

OpenRouter fanout currently sends no `max_tokens` cap. The provider then applies the model's default — gemini-2.5-pro defaults to **65536**, gpt-4o to **16384** — and accounts on limited credit get 402 errors before any model can respond. **PR #172 (BEC-153 dogfood run) shipped with zero advisory comments for exactly this reason.**

Operators on free / limited tiers can now set e.g. `REVIEW_MODELS_MAX_OUTPUT_TOKENS=4000` and use cheap or free models successfully.

## Test plan

- [x] 2 fanout-level tests: when config omits `maxOutputTokens`, `chatCompletion` gets no `maxTokens`; when set, all parallel calls receive the cap.
- [x] 3 env-parsing tests: unset → undefined; positive int → number; invalid (`0` / `-1` / `"lots"`) → undefined.
- [x] All 1429 core tests pass; typecheck + build clean across packages.
- [ ] After merge: set `REVIEW_MODELS_MAX_OUTPUT_TOKENS=4000` on dogfood, run a pipeline, confirm fanout posts comments instead of hitting 402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)