### PR TITLE
fix-up(BEC-164): warn when REVIEW_MODELS_MAX_OUTPUT_TOKENS is below sane floor

### DIFF
--- a/packages/core/src/__tests__/review-provider-registry.test.ts
+++ b/packages/core/src/__tests__/review-provider-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   getEnabledProviders,
   type ReviewProvider,
@@ -109,6 +109,64 @@ describe("review-provider registry — fanout selection", () => {
       expect(
         fanoutCfg({ REVIEW_MODELS: "m1", OPENROUTER_API_KEY: "sk", REVIEW_MODELS_MAX_OUTPUT_TOKENS: "lots" }).maxOutputTokens,
       ).toBeUndefined();
+    });
+
+    describe("floor warn (BEC-164 follow-up — surface misconfigurations loudly)", () => {
+      // Captures pino stdout writes so we can assert a warn fires when the
+      // configured cap is suspiciously small. The original BEC-164 fix made
+      // `=1` parse correctly, but a typo would silently produce truncated
+      // garbage on every model — the same zero-findings symptom BEC-164 was
+      // meant to fix, just from a different cause. Sonnet review on PR #174.
+      function captureFanoutCfgWithStdout(env: NodeJS.ProcessEnv): { cfg: { maxOutputTokens?: number }; logs: string[] } {
+        const writes: string[] = [];
+        const orig = process.stdout.write.bind(process.stdout);
+        const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: any) => {
+          writes.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+          return true;
+        });
+        try {
+          const ps = getEnabledProviders(env);
+          const fanout = ps.find((p) => p.id === "openrouter");
+          const cfg = (fanout as unknown as { cfg: { maxOutputTokens?: number } }).cfg;
+          return { cfg, logs: writes };
+        } finally {
+          spy.mockRestore();
+          writes.forEach((w) => orig(w));
+        }
+      }
+
+      it("emits a warn when value is set but below the sane floor (256)", () => {
+        const { cfg, logs } = captureFanoutCfgWithStdout({
+          REVIEW_MODELS: "m1",
+          OPENROUTER_API_KEY: "sk",
+          REVIEW_MODELS_MAX_OUTPUT_TOKENS: "10",
+        });
+        // Behavior preserved — operator's intent is honored, cap is set to 10.
+        expect(cfg.maxOutputTokens).toBe(10);
+        // Visibility: a warn line surfaces the misconfiguration.
+        const warnLine = logs.find((l) =>
+          /maxOutputTokens|REVIEW_MODELS_MAX_OUTPUT_TOKENS/.test(l) && /floor|too.small|below/i.test(l),
+        );
+        expect(warnLine, `expected a floor-warn line; got ${JSON.stringify(logs)}`).toBeDefined();
+      });
+
+      it("does NOT warn when value is at or above the floor", () => {
+        const { cfg, logs } = captureFanoutCfgWithStdout({
+          REVIEW_MODELS: "m1",
+          OPENROUTER_API_KEY: "sk",
+          REVIEW_MODELS_MAX_OUTPUT_TOKENS: "256",
+        });
+        expect(cfg.maxOutputTokens).toBe(256);
+        expect(logs.find((l) => /maxOutputTokens.*floor|too.small/i.test(l))).toBeUndefined();
+      });
+
+      it("does NOT warn when value is unset", () => {
+        const { logs } = captureFanoutCfgWithStdout({
+          REVIEW_MODELS: "m1",
+          OPENROUTER_API_KEY: "sk",
+        });
+        expect(logs.find((l) => /maxOutputTokens.*floor|too.small/i.test(l))).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/core/src/executor/review/review-provider.ts
+++ b/packages/core/src/executor/review/review-provider.ts
@@ -1,6 +1,9 @@
 import type { HandoffArtifact, ReviewFinding } from "../../types.js";
 import { AgenticDeepReviewProvider } from "./agentic-deep-review.js";
 import { OpenRouterFanoutProvider } from "./openrouter-fanout.js";
+import { createLogger } from "../../logger.js";
+
+const log = createLogger({ component: "review.provider" });
 
 export type ReviewProviderId = "agentic" | "openrouter";
 
@@ -35,6 +38,14 @@ export interface ReviewProvider {
 const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
 const DEFAULT_TIMEOUT_MS = 300_000;
 const DEFAULT_MAX_INPUT_TOKENS = 150_000;
+/**
+ * Below this, a structured-finding response can't even fit a small JSON
+ * envelope — the fanout would silently produce truncated garbage on every
+ * model, the same zero-findings symptom BEC-164 was meant to fix, just from
+ * a different cause. Operators get a warn but the value is still applied
+ * (no auto-correction — preserves operator intent for unusual setups).
+ */
+const SANE_OUTPUT_TOKENS_FLOOR = 256;
 
 export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[] {
   const providers: ReviewProvider[] = [new AgenticDeepReviewProvider()];
@@ -57,6 +68,21 @@ export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[] {
   }
   if (!fanoutDesired) return providers;
 
+  // BEC-164: optional output-token cap. Unset = the model's provider default
+  // applies (can be huge → 402s on limited-budget accounts). Invalid input
+  // falls through to undefined so the cap stays unset.
+  const maxOutputTokens = parsePositiveIntOrUndefined(env.REVIEW_MODELS_MAX_OUTPUT_TOKENS);
+  if (maxOutputTokens !== undefined && maxOutputTokens < SANE_OUTPUT_TOKENS_FLOOR) {
+    log.warn(
+      {
+        var: "REVIEW_MODELS_MAX_OUTPUT_TOKENS",
+        value: maxOutputTokens,
+        floor: SANE_OUTPUT_TOKENS_FLOOR,
+      },
+      "REVIEW_MODELS_MAX_OUTPUT_TOKENS is below the sane floor — model responses will likely be truncated mid-finding and produce zero parseable output. Consider setting it to at least 1024.",
+    );
+  }
+
   providers.push(
     new OpenRouterFanoutProvider({
       apiKey,
@@ -64,10 +90,7 @@ export function getEnabledProviders(env: NodeJS.ProcessEnv): ReviewProvider[] {
       models,
       timeoutMs: parseIntOr(env.REVIEW_MODELS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
       maxInputTokens: parseIntOr(env.REVIEW_MODELS_MAX_INPUT_TOKENS, DEFAULT_MAX_INPUT_TOKENS),
-      // BEC-164: optional output-token cap. Unset = the model's provider
-      // default applies (can be huge → 402s on limited-budget accounts).
-      // Invalid input falls through to undefined so the cap stays unset.
-      maxOutputTokens: parsePositiveIntOrUndefined(env.REVIEW_MODELS_MAX_OUTPUT_TOKENS),
+      maxOutputTokens,
     }),
   );
   return providers;


### PR DESCRIPTION
Sonnet review follow-up on PR #174.

## Summary

Adds a `log.warn` when `REVIEW_MODELS_MAX_OUTPUT_TOKENS` is set but `< 256`. Operator intent is preserved (the value is still applied) — this is a visibility fix only, modeled on BEC-160's "make silent misconfigurations loud" lesson.

## Why

Reviewer on #174 flagged the closing edge: a typo like `=10` parses cleanly under the existing `>0` guard, gets forwarded to OpenRouter, and every model response is truncated mid-JSON. The structured-finding parse fails, the `rawOutput` fallback fires, and operators see zero findings — exactly the silent-zero-comments symptom BEC-164 was written to fix, just from a different cause.

A floor warn won't auto-correct (that would surprise operators with unusual setups), but it surfaces the misconfiguration loudly so it's caught in boot logs instead of after the fact via missing PR comments.

## Test plan

- [x] 3 vitest cases capture pino stdout: value below floor → warn line surfaces; value at/above floor → no warn; unset → no warn.
- [x] All 15 review-provider-registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)