### PR TITLE
fix(notifier,pm): BEC-165 ensure Linear → In Review on every PR-creating run

### DIFF
--- a/packages/core/src/__tests__/notifier.test.ts
+++ b/packages/core/src/__tests__/notifier.test.ts
@@ -184,7 +184,7 @@ describe("LinearNotifier", () => {
     expect(body).toContain("500 output");
   });
 
-  it("formats pipeline complete comment correctly (no auto-merge)", async () => {
+  it("formats pipeline complete comment correctly (no auto-merge) and transitions to In Review", async () => {
     const notifier = new TestableLinearNotifier();
     const run = makeRun();
     const result = makePipelineResult();
@@ -196,7 +196,27 @@ describe("LinearNotifier", () => {
     expect(body).toContain("Pipeline Complete");
     expect(body).toContain("https://github.com/org/repo/pull/42");
     expect(body).toContain("3");
-    // "In Review" is now set by onHumanReviewNeeded, not onPipelineComplete
+    // BEC-165: any pipeline that ends with a PR but isn't auto-merged must
+    // transition to "In Review". Previously this responsibility was delegated
+    // to onHumanReviewNeeded — but not every PR-creating runner path calls it
+    // (auto-implement with autoMerge:false skips both onHumanReviewNeeded and
+    // any state-transition path), leaving Linear stuck on "In Progress" → the
+    // recover-stuck → re-run loop documented in BEC-165.
+    expect(notifier.transitions).toEqual([{ issueId: "TEAM-123", stateName: "In Review" }]);
+  });
+
+  it("BEC-165: pipeline complete without PR (rare) does not transition state", async () => {
+    const notifier = new TestableLinearNotifier();
+    const run = makeRun();
+    // The PipelineResult type declares prUrl as required string; runner.ts
+    // passes "" or a real URL. Empty string is the "no PR opened" signal that
+    // the production callsite uses (`if (result.prUrl)` falsy check).
+    const result = { ...makePipelineResult(), prUrl: "" };
+
+    await notifier.onPipelineComplete(run, result);
+
+    // No PR opened (e.g. no-op run, hard failure earlier) — leave state alone
+    // so a separate failure-handler path can decide.
     expect(notifier.transitions).toEqual([]);
   });
 

--- a/packages/core/src/__tests__/recover-stuck.test.ts
+++ b/packages/core/src/__tests__/recover-stuck.test.ts
@@ -191,6 +191,127 @@ describe("recoverStuckInProgressIssues", () => {
     });
   });
 
+  it("BEC-165: stuck-In-Progress with completed last run + pr_url moves to In Review (not Backlog)", async () => {
+    // Defense-in-depth: even when the runner forgot to move Linear → In Review
+    // after PR creation (the original BEC-165 bug at the source), recover-stuck
+    // should NOT move the issue back to Backlog and re-trigger the doom loop.
+    // It should detect the open PR and move to In Review instead.
+    const issue = {
+      id: "issue-uuid-completed-with-pr",
+      identifier: "BEC-153",
+      title: "Stuck issue with completed PR",
+      team: Promise.resolve({ id: "team-1" }),
+      state: Promise.resolve({ name: "In Progress" }),
+    };
+    const linearClient = makeLinearClient([issue]);
+    const db = makeDb([], [
+      {
+        issueId: "BEC-153",
+        status: "completed",
+        startedAt: new Date("2026-05-07T15:13:00Z"),
+        prUrl: "https://github.com/JonB32/urateam/pull/172",
+      },
+    ]);
+    const stateMap = new Map([
+      ["team-1:Backlog", "state-backlog-1"],
+      ["team-1:In Review", "state-in-review-1"],
+    ]);
+
+    const result = await recoverStuckInProgressIssues({
+      linearClient,
+      db: db as any,
+      teamIds: ["team-1"],
+      targetState: "Backlog",  // caller wanted Backlog…
+      maxPerTick: 5,
+      stateMap,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].lastRunStatus).toBe("completed");
+    // …but the open-PR override redirected to In Review.
+    expect(result[0].targetState).toBe("In Review");
+    expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-uuid-completed-with-pr", {
+      stateId: "state-in-review-1",
+    });
+  });
+
+  it("BEC-165: completed last run WITHOUT pr_url falls through to caller's targetState (genuine no-progress recovery)", async () => {
+    // Distinguish from the override path — a completed run with no PR is a
+    // legitimate "no work shipped" recovery; should still go to Backlog.
+    const issue = {
+      id: "issue-uuid-completed-no-pr",
+      identifier: "BEC-99",
+      title: "Stuck no-op completed run",
+      team: Promise.resolve({ id: "team-1" }),
+      state: Promise.resolve({ name: "In Progress" }),
+    };
+    const linearClient = makeLinearClient([issue]);
+    const db = makeDb([], [
+      {
+        issueId: "BEC-99",
+        status: "completed",
+        startedAt: new Date("2026-04-02"),
+        prUrl: null,
+      },
+    ]);
+    const stateMap = new Map([
+      ["team-1:Backlog", "state-backlog-1"],
+      ["team-1:In Review", "state-in-review-1"],
+    ]);
+
+    const result = await recoverStuckInProgressIssues({
+      linearClient,
+      db: db as any,
+      teamIds: ["team-1"],
+      targetState: "Backlog",
+      maxPerTick: 5,
+      stateMap,
+    });
+
+    expect(result[0].targetState).toBe("Backlog");
+    expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-uuid-completed-no-pr", {
+      stateId: "state-backlog-1",
+    });
+  });
+
+  it("BEC-165: open-PR override falls back to caller's targetState when In Review state-id is missing", async () => {
+    // Defense in depth shouldn't crash if the workspace has no In Review state
+    // (some Linear setups customize the column names). Fall back to original
+    // behavior so the issue still moves out of stuck In Progress.
+    const issue = {
+      id: "issue-uuid-no-in-review",
+      identifier: "BEC-100",
+      title: "Workspace lacks In Review",
+      team: Promise.resolve({ id: "team-1" }),
+      state: Promise.resolve({ name: "In Progress" }),
+    };
+    const linearClient = makeLinearClient([issue]);
+    const db = makeDb([], [
+      {
+        issueId: "BEC-100",
+        status: "completed",
+        startedAt: new Date("2026-04-02"),
+        prUrl: "https://github.com/x/y/pull/1",
+      },
+    ]);
+    // Note: stateMap intentionally omits "In Review"
+    const stateMap = new Map([["team-1:Backlog", "state-backlog-1"]]);
+
+    const result = await recoverStuckInProgressIssues({
+      linearClient,
+      db: db as any,
+      teamIds: ["team-1"],
+      targetState: "Backlog",
+      maxPerTick: 5,
+      stateMap,
+    });
+
+    expect(result[0].targetState).toBe("Backlog");
+    expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-uuid-no-in-review", {
+      stateId: "state-backlog-1",
+    });
+  });
+
   it("recovers orphaned issue with no DB record", async () => {
     const issue = {
       id: "issue-orphan",

--- a/packages/core/src/notifier/linear.ts
+++ b/packages/core/src/notifier/linear.ts
@@ -76,6 +76,17 @@ export class LinearNotifier implements Notifier {
     const tasks: Promise<void>[] = [this.postComment(run.issueId, comment)];
     if (result.autoMerged) {
       tasks.push(this.transitionState(run.issueId, LINEAR_STATES.DONE));
+    } else if (result.prUrl) {
+      // BEC-165: ensure every pipeline that opens a PR moves Linear off
+      // "In Progress". Previously this was delegated to onHumanReviewNeeded,
+      // but the runner doesn't call that on every PR-creating path (e.g.
+      // auto-implement with autoMerge:false, no draft-flagging, no rebase
+      // conflict). Without this catch-all, the issue stayed on "In Progress"
+      // and recover-stuck moved it back to Backlog 30 min later → re-run
+      // loop on completed work, burning agent + OpenRouter tokens.
+      // Idempotent w/ onHumanReviewNeeded's transition (paths that call both
+      // see one extra Linear API call, no behavior change).
+      tasks.push(this.transitionState(run.issueId, LINEAR_STATES.IN_REVIEW));
     }
     await Promise.all(tasks);
   }

--- a/packages/core/src/pm/actions/recover-stuck.ts
+++ b/packages/core/src/pm/actions/recover-stuck.ts
@@ -29,7 +29,12 @@ export interface StuckIssueResult {
   title: string;
   previousState: string;
   lastRunStatus: string | null;
-  targetState: "Backlog" | "Todo";
+  /**
+   * BEC-165: includes "In Review" when the open-PR override redirects
+   * (last run completed AND has a pr_url AND a workspace In Review state
+   * exists). Otherwise the caller's input targetState ("Backlog" | "Todo").
+   */
+  targetState: "Backlog" | "Todo" | "In Review";
 }
 
 /**
@@ -105,14 +110,17 @@ export async function recoverStuckInProgressIssues(
   const toProcess = stuckIssues.slice(0, maxPerTick);
   const stuckIdentifiers = toProcess.map((i: any) => i.identifier);
 
-  // 5. Batch-fetch most recent pipeline run status for each stuck issue
+  // 5. Batch-fetch most recent pipeline run status + prUrl for each stuck issue.
+  //    BEC-165: prUrl is needed for the open-PR override below.
   const lastRunStatusMap = new Map<string, string>();
+  const lastRunPrUrlMap = new Map<string, string | null>();
   if (stuckIdentifiers.length > 0) {
     const runs = await db
       .select({
         issueId: pipelineRuns.issueId,
         status: pipelineRuns.status,
         startedAt: pipelineRuns.startedAt,
+        prUrl: pipelineRuns.prUrl,
       })
       .from(pipelineRuns)
       .where(inArray(pipelineRuns.issueId, stuckIdentifiers));
@@ -126,6 +134,7 @@ export async function recoverStuckInProgressIssues(
     for (const run of sorted) {
       if (!lastRunStatusMap.has(run.issueId)) {
         lastRunStatusMap.set(run.issueId, run.status);
+        lastRunPrUrlMap.set(run.issueId, run.prUrl ?? null);
       }
     }
   }
@@ -140,11 +149,28 @@ export async function recoverStuckInProgressIssues(
     // Linear SDK lazy relations — must await team and state
     const team = await issue.team;
     const teamId = team?.id;
-    const targetStateId = teamId ? stateMap.get(`${teamId}:${targetState}`) : undefined;
+    const lastRunStatus = lastRunStatusMap.get(issue.identifier) ?? null;
+    const lastRunPrUrl = lastRunPrUrlMap.get(issue.identifier) ?? null;
 
-    if (!targetStateId) {
+    // BEC-165: open-PR override — if the most recent run completed AND
+    // produced a PR, the runner forgot to move Linear → "In Review" (the
+    // bug fixed in linear.ts onPipelineComplete). Recovering to "Backlog"
+    // here would re-promote the issue and burn another full pipeline cycle
+    // on already-merged-or-pending work. Redirect to "In Review" instead.
+    // Falls back to caller's targetState if the workspace lacks an "In
+    // Review" state (custom Linear column setups).
+    const inReviewOverride =
+      lastRunStatus === "completed" && lastRunPrUrl !== null && teamId
+        ? stateMap.get(`${teamId}:In Review`)
+        : undefined;
+    const effectiveTargetState: "Backlog" | "Todo" | "In Review" =
+      inReviewOverride !== undefined ? "In Review" : targetState;
+    const effectiveTargetStateId = inReviewOverride
+      ?? (teamId ? stateMap.get(`${teamId}:${targetState}`) : undefined);
+
+    if (!effectiveTargetStateId) {
       log.warn(
-        { identifier: issue.identifier, teamId, targetState },
+        { identifier: issue.identifier, teamId, targetState: effectiveTargetState },
         "no target state ID found for team — skipping stuck issue",
       );
       continue;
@@ -152,22 +178,22 @@ export async function recoverStuckInProgressIssues(
 
     const state = await issue.state;
     const previousStateName: string = state?.name ?? "In Progress";
-    const lastRunStatus = lastRunStatusMap.get(issue.identifier) ?? null;
 
     try {
-      // Move the issue to the configured target state
-      await linearClient.updateIssue(issue.id, { stateId: targetStateId });
+      await linearClient.updateIssue(issue.id, { stateId: effectiveTargetStateId });
 
-      // Post a comment on the Linear issue explaining the auto-recovery
       const runNote = lastRunStatus
-        ? `Most recent pipeline run status: \`${lastRunStatus}\`.`
+        ? `Most recent pipeline run status: \`${lastRunStatus}\`${lastRunPrUrl ? ` (PR: ${lastRunPrUrl})` : ""}.`
         : "No pipeline run record found in the database.";
+      const overrideNote = inReviewOverride
+        ? "\n\n*BEC-165 override: completed run produced a PR — moving to In Review instead of re-promoting.*"
+        : "";
       await linearClient.createComment({
         issueId: issue.id,
         body:
           `🤖 **PM Agent — Auto-recovered stuck issue**\n\n` +
           `This issue was detected in **In Progress** state with no active pipeline run. ` +
-          `It has been automatically moved to **${targetState}** for re-evaluation.\n\n${runNote}`,
+          `It has been automatically moved to **${effectiveTargetState}** for re-evaluation.\n\n${runNote}${overrideNote}`,
       });
 
       results.push({
@@ -176,7 +202,7 @@ export async function recoverStuckInProgressIssues(
         title: issue.title,
         previousState: previousStateName,
         lastRunStatus,
-        targetState,
+        targetState: effectiveTargetState,
       });
 
       log.info(
@@ -184,7 +210,8 @@ export async function recoverStuckInProgressIssues(
           identifier: issue.identifier,
           previousState: previousStateName,
           lastRunStatus,
-          targetState,
+          targetState: effectiveTargetState,
+          inReviewOverride: inReviewOverride !== undefined,
         },
         "auto-recovered stuck In Progress issue",
       );


### PR DESCRIPTION
Closes BEC-165.

## Summary

Two-layer fix for the doom loop where successfully-completed pipelines that opened a PR would leave Linear stuck on "In Progress" → recover-stuck moved it back to Backlog → re-promote → re-run on shipped work. Active bleed surfaced today on BEC-153 (PR #172 already opened, ~7 attempted re-runs over 5 hours).

## Layer 1 — source fix (`notifier/linear.ts`)

`onPipelineComplete` previously only set `DONE` on auto-merge. When a PR was opened but not auto-merged (e.g. `auto-implement` pipeline with `autoMerge: false`, no draft-flagging, no rebase conflict), **no state transition fired at all**. The "In Review" responsibility was delegated to `onHumanReviewNeeded`, but the runner doesn't call that on every PR-creating path.

Now `onPipelineComplete` transitions to `IN_REVIEW` when `prUrl` is set and `autoMerged` is false. Idempotent with `onHumanReviewNeeded` for paths that call both.

## Layer 2 — defense in depth (`pm/actions/recover-stuck.ts`)

When recovering a stuck "In Progress" issue, fetch `pr_url` alongside `status`. If the most recent run **completed** AND has `pr_url` AND the workspace has an "In Review" state, redirect the recovery target to "In Review" instead of the caller's "Backlog". Catches the case where Layer 1's transition itself failed (Linear API error). Falls back to caller's `targetState` if the workspace lacks an "In Review" state (custom Linear column setups).

## Why both

Layer 1 fixes 100% of the bug at source. Layer 2 is insurance — if a Linear API call ever fails inside `onPipelineComplete`, recovery still routes correctly instead of starting the doom loop.

## Test plan

- [x] 5 RED→GREEN tests covering: notifier IN_REVIEW transition (the bug being fixed), no-PR fallthrough, recover-stuck override, recover-stuck no-PR fallthrough, recover-stuck no-In-Review-state fallback.
- [x] All 1450 core tests pass; typecheck clean.
- [ ] After merge + deploy: confirm BEC-153's old re-run pattern doesn't repeat on a fresh test ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)