### PR TITLE
chore(release): v0.1.37 — BEC-152 + BEC-153 + BEC-164 + BEC-165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
+## [0.1.37] — 2026-05-07
+
+Bumps:
+- `@urateam/core`: 0.1.22 → 0.1.23
+- `@urateam/cli`: 0.1.24 → 0.1.25
+- `@urateam/dashboard`: 0.1.22 → 0.1.23
+- `create-urateam`: 0.1.25 → 0.1.26
+
+### Fixed
+- **BEC-165** — Pipeline runs that successfully open a PR now move Linear to "In Review" 100% of the time. Previously the transition was conditionally delegated to `onHumanReviewNeeded`, which not every PR-creating runner path called (e.g. auto-implement with `autoMerge:false`, no draft-flagging, no rebase conflict). Issues stayed on "In Progress" → recover-stuck moved them back to Backlog 30 min later → re-promote → re-run loop on shipped work, burning agent + OpenRouter tokens. Two-layer fix: (1) `onPipelineComplete` is the catch-all source of truth — sets `IN_REVIEW` when `prUrl` is set and not auto-merged. (2) `recover-stuck` is defense-in-depth — when recovering a stuck issue, redirects to `In Review` if the most recent run completed with a `pr_url` (catches the case where layer 1's transition itself failed). (#176)
+- **BEC-152** — `REPO_CLONE_DIR` and `AGENT_RUN_DIR` defaults switched from `/var/agent-{repos,runs}` to `homedir()/{work/repos,data/runs}` so non-root containers (the dogfood `USER ura` setup) work without operator-side env overrides. Adds startup `preflightDirs` that `mkdir -p`s and write-tests both paths with an actionable error if either fails. Existing operators with explicit env-var overrides are unchanged. (#173)
+- **BEC-153** — Dogfood Dockerfile installs the `sqlite3` CLI alongside the better-sqlite3 binding so the runbook queries documented in `docs/superpowers/runbooks/2026-05-04-bec-138-dogfood-soak.md` work without the `apk add --user 0` host workaround. (#172)
+
+### Added
+- **BEC-164** — New `REVIEW_MODELS_MAX_OUTPUT_TOKENS` env var caps the `max_tokens` forwarded to OpenRouter on every fanout request. Unset = today's behavior (the model's provider default applies, which can be 65536 for gemini-2.5-pro / 16384 for gpt-4o → 402 errors on accounts with limited credit). Validation rejects floats / non-integer strings; values below 256 emit a warn at boot pointing at 1024 as a sane minimum. (#174, #175)
+
 ## [0.1.36] — 2026-05-07
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.22
-ARG URATEAM_CLI_VERSION=0.1.24
-ARG URATEAM_DASHBOARD_VERSION=0.1.22
+ARG URATEAM_CORE_VERSION=0.1.23
+ARG URATEAM_CLI_VERSION=0.1.25
+ARG URATEAM_DASHBOARD_VERSION=0.1.23
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.22
-        URATEAM_CLI_VERSION: 0.1.24
-        URATEAM_DASHBOARD_VERSION: 0.1.22
+        URATEAM_CORE_VERSION: 0.1.23
+        URATEAM_CLI_VERSION: 0.1.25
+        URATEAM_DASHBOARD_VERSION: 0.1.23
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
4 fixes shipped today, all from BEC-138 dogfood. 2 of 4 are fully-autonomous bot PRs (BEC-152, BEC-153) on top of v0.1.36's hardening.

## What's in v0.1.37

| Ticket | Sev | What it does | PR |
|--------|-----|--------------|----|
| **BEC-165** | sev-2 | Pipeline → Linear → In Review on every PR-creating run (closes recover-stuck doom loop on completed work) | #176 |
| **BEC-152** | sev-3 | REPO_CLONE_DIR/AGENT_RUN_DIR defaults work in non-root containers | #173 |
| **BEC-164** | sev-3 | REVIEW_MODELS_MAX_OUTPUT_TOKENS env knob caps fanout request size | #174, #175 |
| **BEC-153** | sev-3 | Dogfood Dockerfile installs sqlite3 CLI (no more host workaround) | #172 |

## Release pipeline

1. Merge this PR
2. Push `v0.1.37` tag → fires npm OIDC publish
3. `gh release create v0.1.37`
4. Rebuild dogfood image; verify BEC-153 (sqlite baked) + BEC-152 (default paths work) + BEC-165 (Linear state correct on next pipeline run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)