### PR TITLE
feat(pm): BEC-174 sweep stale agent/* branches with no open PR

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -423,6 +423,7 @@ export const startCommand = new Command("start")
     function shutdown() {
       console.log("Shutting down...");
       clearInterval(cleanupInterval);
+      clearInterval(branchSweepInterval);
       if (pmInterval) clearInterval(pmInterval);
       rmScheduler?.stop();
       let closed = 0;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -12,7 +12,7 @@ export const startCommand = new Command("start")
   .option("--dashboard-port <port>", "Dashboard port", "3001")
   .action(async (options) => {
     try {
-    const { createApp, defaultConfigs, applyDeepReviewPassesOverride, cleanupWorktrees, addLogStream, initSlackAlertManager, createSlackAlertStream } = await import("@urateam/core");
+    const { createApp, defaultConfigs, applyDeepReviewPassesOverride, cleanupWorktrees, runAgentBranchSweep, addLogStream, initSlackAlertManager, createSlackAlertStream } = await import("@urateam/core");
 
     // --- Slack error alerts (opt-in) ---
     if (
@@ -293,6 +293,42 @@ export const startCommand = new Command("start")
     await runCleanup();
     const cleanupInterval = setInterval(runCleanup, 60 * 60 * 1000);
     cleanupInterval.unref();
+
+    // --- Stale agent-branch sweep cron (BEC-174) ---
+    // Sweeps `agent/*` branches on origin whose tip commit is older than
+    // PM_AGENT_AGENT_BRANCH_TTL_DAYS (default 7) AND that have no open PR.
+    // Skips branches with open PRs to preserve active human review.
+    const _parsedAgentBranchTtl = parseInt(
+      process.env.PM_AGENT_AGENT_BRANCH_TTL_DAYS ?? "7",
+      10,
+    );
+    const agentBranchTtlDays =
+      Number.isFinite(_parsedAgentBranchTtl) && _parsedAgentBranchTtl > 0
+        ? _parsedAgentBranchTtl
+        : 7;
+
+    const repoUrls = Object.values(config.repoConfigs).map(
+      (r) => (r as { url: string }).url,
+    );
+
+    async function runBranchSweepTick() {
+      try {
+        await runAgentBranchSweep({
+          db,
+          repoUrls,
+          repoCloneDir: config.repoCloneDir,
+          ttlDays: agentBranchTtlDays,
+        });
+      } catch (err) {
+        console.error("Branch sweep tick failed:", (err as Error).message);
+      }
+    }
+    void runBranchSweepTick();
+    const branchSweepInterval = setInterval(
+      () => void runBranchSweepTick(),
+      60 * 60 * 1000,
+    );
+    branchSweepInterval.unref();
 
     // --- PM Agent (opt-in) ---
     let pmInterval: ReturnType<typeof setInterval> | undefined;

--- a/packages/core/src/__tests__/agent-branch-sweep.test.ts
+++ b/packages/core/src/__tests__/agent-branch-sweep.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { sweepStaleAgentBranches } from "../repo/agent-branch-sweep.js";
+import { pmAgentBranchSweptEvent } from "../audit/events.js";
+
+function git(
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: "pipe",
+    env: { ...process.env, ...env },
+  })
+    .toString()
+    .trim();
+}
+
+async function makeBareRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "agent-sweep-bare-"));
+  git(["init", "-b", "main", "--bare"], dir);
+  return dir;
+}
+
+async function cloneInto(bareUrl: string): Promise<string> {
+  const parent = await mkdtemp(join(tmpdir(), "agent-sweep-parent-"));
+  const cloneDir = join(parent, "clone");
+  execFileSync("git", ["clone", bareUrl, cloneDir], { stdio: "pipe" });
+  git(["config", "user.email", "test@test.com"], cloneDir);
+  git(["config", "user.name", "Test"], cloneDir);
+  return cloneDir;
+}
+
+async function commitAndPush(
+  cloneDir: string,
+  branch: string,
+  fileName: string,
+  dateIso?: string,
+): Promise<void> {
+  git(["checkout", "main"], cloneDir);
+  git(["checkout", "-b", branch], cloneDir);
+  await writeFile(join(cloneDir, fileName), "x\n");
+  git(["add", "."], cloneDir);
+  const env: Record<string, string> = {};
+  if (dateIso) {
+    env.GIT_AUTHOR_DATE = dateIso;
+    env.GIT_COMMITTER_DATE = dateIso;
+  }
+  git(["commit", "-m", `seed ${branch}`], cloneDir, env);
+  git(["push", "origin", branch], cloneDir);
+}
+
+describe("sweepStaleAgentBranches", () => {
+  let bareRepo: string;
+  let cloneDir: string;
+
+  beforeEach(async () => {
+    bareRepo = await makeBareRepo();
+    cloneDir = await cloneInto(bareRepo);
+
+    // Initial commit on main so we can branch off it
+    await writeFile(join(cloneDir, "README.md"), "init\n");
+    git(["add", "."], cloneDir);
+    git(["commit", "-m", "init"], cloneDir);
+    git(["push", "origin", "main"], cloneDir);
+
+    // Seed: 1 fresh, 1 stale-no-PR, 1 stale-with-PR
+    const longAgo = "2024-01-01T00:00:00Z";
+    await commitAndPush(cloneDir, "agent/BEC-100-stale-no-pr", "a.txt", longAgo);
+    await commitAndPush(cloneDir, "agent/BEC-101-stale-with-pr", "b.txt", longAgo);
+    await commitAndPush(cloneDir, "agent/BEC-102-fresh", "c.txt"); // current date
+
+    git(["checkout", "main"], cloneDir);
+  });
+
+  afterEach(async () => {
+    await rm(bareRepo, { recursive: true, force: true });
+    // cloneDir lives under a parent tempdir; remove its parent
+    await rm(join(cloneDir, ".."), { recursive: true, force: true });
+  });
+
+  it("deletes only stale branches with no open PR", async () => {
+    const result = await sweepStaleAgentBranches({
+      workCwd: cloneDir,
+      ttlDays: 7,
+      hasOpenPR: async (branch) => branch === "agent/BEC-101-stale-with-pr",
+    });
+
+    expect(result.deleted.map((d) => d.name)).toEqual([
+      "agent/BEC-100-stale-no-pr",
+    ]);
+    expect(result.deleted[0].ageDays).toBeGreaterThan(7);
+    expect(result.skippedHasPR).toEqual(["agent/BEC-101-stale-with-pr"]);
+    expect(result.skippedFresh).toEqual(["agent/BEC-102-fresh"]);
+
+    // Verify against the bare remote
+    const remoteRefs = git(["ls-remote", "--heads", bareRepo], cloneDir);
+    expect(remoteRefs).not.toContain("agent/BEC-100-stale-no-pr");
+    expect(remoteRefs).toContain("agent/BEC-101-stale-with-pr");
+    expect(remoteRefs).toContain("agent/BEC-102-fresh");
+  });
+
+  it("returns empty result when no agent/* branches exist", async () => {
+    // Wipe all agent branches first
+    for (const b of [
+      "agent/BEC-100-stale-no-pr",
+      "agent/BEC-101-stale-with-pr",
+      "agent/BEC-102-fresh",
+    ]) {
+      git(["push", "origin", "--delete", b], cloneDir);
+    }
+    const result = await sweepStaleAgentBranches({
+      workCwd: cloneDir,
+      ttlDays: 7,
+      hasOpenPR: async () => false,
+    });
+    expect(result).toEqual({ deleted: [], skippedHasPR: [], skippedFresh: [] });
+  });
+
+  it("treats hasOpenPR errors as 'has PR' (fail-safe — never deletes a branch we can't verify)", async () => {
+    const result = await sweepStaleAgentBranches({
+      workCwd: cloneDir,
+      ttlDays: 7,
+      hasOpenPR: async () => {
+        throw new Error("gh API down");
+      },
+    });
+    // All stale branches should be skipped, none deleted
+    expect(result.deleted).toEqual([]);
+    expect(result.skippedHasPR).toContain("agent/BEC-100-stale-no-pr");
+    expect(result.skippedHasPR).toContain("agent/BEC-101-stale-with-pr");
+    expect(result.skippedFresh).toEqual(["agent/BEC-102-fresh"]);
+  });
+});
+
+describe("pmAgentBranchSweptEvent", () => {
+  it("returns an audit event with the documented shape", () => {
+    const event = pmAgentBranchSweptEvent({
+      branch: "agent/BEC-100-foo",
+      ageDays: 12,
+      reason: "stale (no open PR for 7 days)",
+    });
+    expect(event.eventType).toBe("pm.agent_branch_swept");
+    expect(event.actor).toBe("pm-agent");
+    expect(event.actorType).toBe("pm-agent");
+    expect(event.payload).toEqual({
+      branch: "agent/BEC-100-foo",
+      ageDays: 12,
+      reason: "stale (no open PR for 7 days)",
+    });
+    expect(event.id).toMatch(/^evt_/);
+  });
+});

--- a/packages/core/src/__tests__/agent-branch-sweep.test.ts
+++ b/packages/core/src/__tests__/agent-branch-sweep.test.ts
@@ -135,6 +135,14 @@ describe("sweepStaleAgentBranches", () => {
     expect(result.skippedHasPR).toContain("agent/BEC-100-stale-no-pr");
     expect(result.skippedHasPR).toContain("agent/BEC-101-stale-with-pr");
     expect(result.skippedFresh).toEqual(["agent/BEC-102-fresh"]);
+
+    // Defence-in-depth: assert the bare remote was untouched. A future
+    // regression that ran the delete BEFORE hasOpenPR would still pass an
+    // in-memory assertion alone — verifying remote refs guards that.
+    const remoteRefs = git(["ls-remote", "--heads", bareRepo], cloneDir);
+    expect(remoteRefs).toContain("agent/BEC-100-stale-no-pr");
+    expect(remoteRefs).toContain("agent/BEC-101-stale-with-pr");
+    expect(remoteRefs).toContain("agent/BEC-102-fresh");
   });
 });
 

--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -67,6 +67,7 @@ describe("audit_events immutability", () => {
       "packages/core/src/pm/actions/resolve-approvals.ts",
       "packages/core/src/release-manager/scheduler.ts",
       "packages/core/src/release-manager/slack-handler.ts",
+      "packages/core/src/repo/agent-branch-sweep-runner.ts",
       "packages/core/src/qa/github.ts",
       "packages/core/src/qa/gap.ts",
       "packages/core/src/__tests__/audit-immutability.test.ts",

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -71,6 +71,23 @@ export function pmCancelledEvent(args: {
   });
 }
 
+export function pmAgentBranchSweptEvent(args: {
+  branch: string;
+  ageDays: number;
+  reason: string;
+}): AuditEvent {
+  return base({
+    eventType: "pm.agent_branch_swept",
+    actor: "pm-agent",
+    actorType: "pm-agent",
+    payload: {
+      branch: args.branch,
+      ageDays: args.ageDays,
+      reason: args.reason,
+    },
+  });
+}
+
 export function pmTriageClassifiedEvent(args: {
   issueId: string;
   label: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,16 @@ export {
 } from "./repo/devcontainer.js";
 export { checkRequirements, buildRalphContext, type RalphCheckResult } from "./executor/ralph.js";
 export { cleanupWorktrees } from "./repo/git.js";
+export {
+  sweepStaleAgentBranches,
+  type SweepInput,
+  type SweepResult,
+  type SweptBranch,
+} from "./repo/agent-branch-sweep.js";
+export {
+  runAgentBranchSweep,
+  type RunAgentBranchSweepDeps,
+} from "./repo/agent-branch-sweep-runner.js";
 export { isClaudeAuthValid, resetAuthCheckCache } from "./executor/auth-check.js";
 export type { GitHubConfig } from "./repo/github.js";
 export { createGitHubClient } from "./repo/github.js";

--- a/packages/core/src/repo/agent-branch-sweep-runner.ts
+++ b/packages/core/src/repo/agent-branch-sweep-runner.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import type { AnyDb } from "../db/client.js";
 import { logAuditEventUnchecked } from "../audit/writer.js";
@@ -65,11 +66,15 @@ export async function runAgentBranchSweep(
   deps: RunAgentBranchSweepDeps,
 ): Promise<void> {
   const seen = new Set<string>();
-  const sweepDir = join(deps.repoCloneDir, ".agent-sweep");
   for (const repoUrl of deps.repoUrls) {
     if (seen.has(repoUrl)) continue;
     seen.add(repoUrl);
     try {
+      // Per-repo sweep dir: prevents cross-repo collisions when multiple
+      // repoUrls are configured (cloneRepo's "wrong remote" path errors out
+      // on a populated dir) and serialises overlapping ticks for the same repo.
+      const repoSlug = createHash("sha256").update(repoUrl).digest("hex").slice(0, 8);
+      const sweepDir = join(deps.repoCloneDir, ".agent-sweep", repoSlug);
       await cloneRepo(repoUrl, sweepDir);
       const result = await sweepStaleAgentBranches({
         workCwd: sweepDir,

--- a/packages/core/src/repo/agent-branch-sweep-runner.ts
+++ b/packages/core/src/repo/agent-branch-sweep-runner.ts
@@ -1,0 +1,104 @@
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import type { AnyDb } from "../db/client.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
+import { pmAgentBranchSweptEvent } from "../audit/events.js";
+import { createLogger } from "../logger.js";
+import { cloneRepo } from "./git.js";
+import { sweepStaleAgentBranches } from "./agent-branch-sweep.js";
+
+const log = createLogger({ component: "agent-branch-sweep-runner" });
+
+/**
+ * Default open-PR check via `gh pr list`. Errors propagate to the caller, which
+ * treats them as "has PR" (fail-safe — never delete a branch we couldn't verify).
+ */
+async function defaultHasOpenPR(repoUrl: string, branch: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "gh",
+      [
+        "pr", "list",
+        "--repo", repoUrl,
+        "--head", branch,
+        "--state", "open",
+        "--json", "number",
+        "--limit", "1",
+      ],
+      { timeout: 15_000 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        try {
+          const arr = JSON.parse(stdout || "[]");
+          resolve(Array.isArray(arr) && arr.length > 0);
+        } catch (e) {
+          reject(e);
+        }
+      },
+    );
+  });
+}
+
+export interface RunAgentBranchSweepDeps {
+  db: AnyDb;
+  /** Distinct repo URLs to sweep. Duplicates are silently skipped. */
+  repoUrls: string[];
+  /** Used as the parent directory for the transient sweep clone. */
+  repoCloneDir: string;
+  /** Branches older than this with no open PR are deleted. */
+  ttlDays: number;
+  /** Test seam — defaults to a `gh pr list` shell-out. */
+  hasOpenPR?: (repoUrl: string, branch: string) => Promise<boolean>;
+}
+
+/**
+ * BEC-174: sweep stale `agent/*` branches across every configured repo.
+ * Emits one `pm.agent_branch_swept` audit event per deleted branch.
+ *
+ * Tolerates per-repo failures: a clone error or sweep error in one repo
+ * does not stop processing of subsequent repos.
+ */
+export async function runAgentBranchSweep(
+  deps: RunAgentBranchSweepDeps,
+): Promise<void> {
+  const seen = new Set<string>();
+  const sweepDir = join(deps.repoCloneDir, ".agent-sweep");
+  for (const repoUrl of deps.repoUrls) {
+    if (seen.has(repoUrl)) continue;
+    seen.add(repoUrl);
+    try {
+      await cloneRepo(repoUrl, sweepDir);
+      const result = await sweepStaleAgentBranches({
+        workCwd: sweepDir,
+        ttlDays: deps.ttlDays,
+        hasOpenPR: (branch) =>
+          (deps.hasOpenPR ?? defaultHasOpenPR)(repoUrl, branch),
+      });
+
+      for (const swept of result.deleted) {
+        void logAuditEventUnchecked(
+          deps.db,
+          pmAgentBranchSweptEvent({
+            branch: swept.name,
+            ageDays: swept.ageDays,
+            reason: `stale (no open PR for ${deps.ttlDays}+ days)`,
+          }),
+        );
+      }
+      if (result.deleted.length > 0) {
+        log.info(
+          { repoUrl, count: result.deleted.length },
+          `branch sweep removed ${result.deleted.length} stale agent branch(es)`,
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { repoUrl, err: (err as Error).message },
+        "branch sweep failed for repo",
+      );
+    }
+  }
+}

--- a/packages/core/src/repo/agent-branch-sweep.ts
+++ b/packages/core/src/repo/agent-branch-sweep.ts
@@ -1,0 +1,147 @@
+import { gitExec, gitExecSafe } from "./git.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "agent-branch-sweep" });
+
+export interface AgentBranchInfo {
+  /** Branch name without the "origin/" remote prefix, e.g. "agent/BEC-100-foo". */
+  name: string;
+  /** Tip-commit committer date. */
+  committedAt: Date;
+}
+
+/**
+ * Fetch then list every `agent/*` ref on origin, returning the tip commit date
+ * for age comparisons. Uses an existing local clone (workCwd) so we can run
+ * `git for-each-ref` against the fetched refs.
+ */
+export async function listRemoteAgentBranches(
+  workCwd: string,
+): Promise<AgentBranchInfo[]> {
+  await gitExec(
+    [
+      "fetch",
+      "--prune",
+      "origin",
+      "+refs/heads/agent/*:refs/remotes/origin/agent/*",
+    ],
+    workCwd,
+  );
+  const out = await gitExecSafe(
+    [
+      "for-each-ref",
+      "--format=%(refname:short) %(committerdate:unix)",
+      "refs/remotes/origin/agent/",
+    ],
+    workCwd,
+  );
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const idx = line.lastIndexOf(" ");
+      const refname = line.slice(0, idx);
+      const ts = parseInt(line.slice(idx + 1), 10);
+      return {
+        name: refname.replace(/^origin\//, ""),
+        committedAt: new Date(ts * 1000),
+      };
+    });
+}
+
+/** Delete a remote branch via `git push origin --delete`. */
+export async function deleteRemoteBranch(
+  workCwd: string,
+  branch: string,
+): Promise<void> {
+  await gitExec(["push", "origin", "--delete", branch], workCwd);
+}
+
+export interface SweepInput {
+  /** A local clone with `origin` set to the repo we're sweeping. */
+  workCwd: string;
+  /** Branch is "stale" if its tip commit is older than this. */
+  ttlDays: number;
+  /**
+   * Predicate that returns true if a branch has an open PR. Throws are treated
+   * as "has PR" (fail-safe — we never delete a branch we couldn't verify).
+   */
+  hasOpenPR: (branch: string) => Promise<boolean>;
+  /** Defaults to `new Date()`. Overridable for tests. */
+  now?: Date;
+  /** Test seam — defaults to {@link listRemoteAgentBranches}. */
+  listBranches?: () => Promise<AgentBranchInfo[]>;
+  /** Test seam — defaults to {@link deleteRemoteBranch}. */
+  deleteBranch?: (branch: string) => Promise<void>;
+}
+
+export interface SweptBranch {
+  name: string;
+  /** Floor of (now - tipCommitDate) in days. Used for audit reasoning. */
+  ageDays: number;
+}
+
+export interface SweepResult {
+  /** Branches successfully deleted on origin, with their tip-commit age at delete time. */
+  deleted: SweptBranch[];
+  /** Stale branches that still have an open PR (or whose PR-state lookup failed). */
+  skippedHasPR: string[];
+  /** Branches younger than the TTL (always preserved). */
+  skippedFresh: string[];
+}
+
+/**
+ * Sweep stale `agent/*` branches on origin. A branch is deleted iff:
+ *   1. its tip commit is older than `ttlDays`, AND
+ *   2. it has no open PR.
+ *
+ * Failures from the PR-lookup predicate are treated as "has PR" so a transient
+ * GitHub outage can never wipe out an active branch.
+ */
+export async function sweepStaleAgentBranches(
+  input: SweepInput,
+): Promise<SweepResult> {
+  const list = input.listBranches ?? (() => listRemoteAgentBranches(input.workCwd));
+  const del =
+    input.deleteBranch ?? ((branch: string) => deleteRemoteBranch(input.workCwd, branch));
+  const now = input.now ?? new Date();
+  const cutoffMs = now.getTime() - input.ttlDays * 24 * 60 * 60 * 1000;
+
+  const branches = await list();
+  const result: SweepResult = { deleted: [], skippedHasPR: [], skippedFresh: [] };
+
+  for (const branch of branches) {
+    if (branch.committedAt.getTime() >= cutoffMs) {
+      result.skippedFresh.push(branch.name);
+      continue;
+    }
+    let openPr: boolean;
+    try {
+      openPr = await input.hasOpenPR(branch.name);
+    } catch (err) {
+      log.warn(
+        { branch: branch.name, err: (err as Error).message },
+        "hasOpenPR check failed — preserving branch",
+      );
+      result.skippedHasPR.push(branch.name);
+      continue;
+    }
+    if (openPr) {
+      result.skippedHasPR.push(branch.name);
+      continue;
+    }
+    try {
+      await del(branch.name);
+      const ageDays = Math.floor(
+        (now.getTime() - branch.committedAt.getTime()) / (24 * 60 * 60 * 1000),
+      );
+      result.deleted.push({ name: branch.name, ageDays });
+    } catch (err) {
+      log.warn(
+        { branch: branch.name, err: (err as Error).message },
+        "branch delete failed — will retry next sweep",
+      );
+    }
+  }
+  return result;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -421,6 +421,7 @@ export const AuditEventTypeSchema = z.enum([
   "pm.approval_requested", "pm.approval_resolved",
   "pm.issue_promoted", "pm.issue_deprioritized", "pm.issue_cancelled",
   "pm.triage_classified",
+  "pm.agent_branch_swept",
   "budget.alert_fired", "budget.run_refused",
   "license.validation_failed", "config.loaded",
   "dashboard.manual_action",


### PR DESCRIPTION
## Summary

Filed BEC-174. Periodic sweep (1h cron, alongside the worktree-cleanup cron) of stale `origin/agent/*` branches that have no open PR — preventing accumulation of dead agent-run refs on the remote.

- New env var `PM_AGENT_AGENT_BRANCH_TTL_DAYS` (default `7`) controls staleness cutoff
- Branches with open PRs are always preserved (active human review)
- `hasOpenPR` errors are treated as "has PR" — transient GitHub outages never wipe a branch we couldn't verify
- Emits one `pm.agent_branch_swept` audit event per delete
- New module `packages/core/src/repo/agent-branch-sweep.ts` (pure logic) + `agent-branch-sweep-runner.ts` (orchestration with audit emission, gated to the immutability allow-list)

Closes BEC-174.

## Test plan

- [x] Integration test (`agent-branch-sweep.test.ts`) seeds 3 branches against a real bare repo: 1 fresh, 1 stale-no-PR, 1 stale-with-PR → only the middle is deleted
- [x] Empty-state test: no agent branches → returns empty result
- [x] Fail-safe test: throwing `hasOpenPR` → no branches deleted (skippedHasPR)
- [x] Audit event factory unit test verifies shape (eventType, actor, payload)
- [x] Full `@urateam/core` suite: 1455 passed, 11 skipped, 0 failures
- [x] `pnpm --filter @urateam/{core,cli,dashboard} build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)