### PR TITLE
chore(release): v0.1.38 — BEC-174 + BEC-175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
+## [0.1.38] — 2026-05-08
+
+Bumps:
+- `@urateam/core`: 0.1.23 → 0.1.24
+- `@urateam/cli`: 0.1.25 → 0.1.26
+- `@urateam/dashboard`: 0.1.23 → 0.1.24
+- `create-urateam`: 0.1.26 → 0.1.27
+
+### Added
+- **BEC-174** — Periodic sweep of stale `origin/agent/*` branches with no open PR. Runs on the same hourly cadence as the worktree-cleanup cron. New env `PM_AGENT_AGENT_BRANCH_TTL_DAYS` (default `7`) controls the staleness cutoff; branches with open PRs are always preserved. Failures from the open-PR check are treated as "has PR" — a transient GitHub outage can never wipe a branch we couldn't verify. Emits one `pm.agent_branch_swept` audit event per delete. Per-repo sweep dirs (keyed by `sha256(repoUrl).slice(0,8)`) prevent cross-repo collisions in multi-repo deployments. (#185)
+- **BEC-175** — Optional per-PR cost summary comment posted after `onPipelineComplete`, showing per-stage tokens (implement / test / review / fanout) and total dollar cost. Gated by `URATEAM_PR_COST_SUMMARY=true` (default off). Idempotent: a prior pipeline run on the same PR will not be duplicated — the new `prHasCommentStartingWith` helper checks for the `🤖 **Pipeline cost summary**` header before posting. Best-effort: failures never block pipeline completion. (#186)
+
 ## [0.1.37] — 2026-05-07
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.23
-ARG URATEAM_CLI_VERSION=0.1.25
-ARG URATEAM_DASHBOARD_VERSION=0.1.23
+ARG URATEAM_CORE_VERSION=0.1.24
+ARG URATEAM_CLI_VERSION=0.1.26
+ARG URATEAM_DASHBOARD_VERSION=0.1.24
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.23
-        URATEAM_CLI_VERSION: 0.1.25
-        URATEAM_DASHBOARD_VERSION: 0.1.23
+        URATEAM_CORE_VERSION: 0.1.24
+        URATEAM_CLI_VERSION: 0.1.26
+        URATEAM_DASHBOARD_VERSION: 0.1.24
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Cuts v0.1.38, shipping the two enhancements from this session:

- **BEC-174** (#185) — hourly sweep of stale `agent/*` branches with no open PR
- **BEC-175** (#186) — opt-in per-PR cost summary comment

## Bumps

| Package | From | To |
|---|---|---|
| `@urateam/core` | 0.1.23 | 0.1.24 |
| `@urateam/cli` | 0.1.25 | 0.1.26 |
| `@urateam/dashboard` | 0.1.23 | 0.1.24 |
| `create-urateam` | 0.1.26 | 0.1.27 |

Dockerfile ARGs and `docker-compose.dogfood.yml` `args:` block bumped together (post-v0.1.35 discipline — no manual host edit required).

## Test plan

- [x] All 4 `package.json` versions consistent with Dockerfile + compose
- [x] CHANGELOG entry added above [0.1.37] in keep-a-changelog format
- [x] BEC-174 + BEC-175 already merged to main with green CI

After merge: tag `v0.1.38` to fire the OIDC publish workflow, then `gh release create v0.1.38`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)