### PR TITLE
feat(scripts): BEC-176 pnpm cut-release helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "typecheck": "turbo typecheck",
     "test": "turbo test",
     "test:integration": "pnpm --filter @urateam/core test:integration && pnpm --filter create-urateam build && pnpm --filter create-urateam test:integration",
+    "test:scripts": "tsx --test scripts/*.test.ts",
     "lint": "turbo lint",
-    "dev": "turbo dev"
+    "dev": "turbo dev",
+    "cut-release": "tsx scripts/cut-release.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0",

--- a/scripts/cut-release-lib.ts
+++ b/scripts/cut-release-lib.ts
@@ -1,0 +1,107 @@
+/**
+ * BEC-176: pure functions for the `pnpm cut-release` helper.
+ *
+ * Only string manipulation here — no fs, no git, no exec. The orchestration
+ * script (cut-release.ts) is the only place those happen, which keeps this
+ * module trivially testable.
+ */
+
+export type BumpKind = "patch" | "minor" | "major";
+
+export interface PackageVersions {
+  core: string;
+  cli: string;
+  dashboard: string;
+  createUrateam: string;
+}
+
+export function bumpVersion(v: string, kind: BumpKind): string {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
+  if (!m) throw new Error(`bumpVersion: invalid semver "${v}"`);
+  const maj = parseInt(m[1]!, 10);
+  const min = parseInt(m[2]!, 10);
+  const pat = parseInt(m[3]!, 10);
+  if (kind === "major") return `${maj + 1}.0.0`;
+  if (kind === "minor") return `${maj}.${min + 1}.0`;
+  return `${maj}.${min}.${pat + 1}`;
+}
+
+export function bumpAll(prev: PackageVersions, kind: BumpKind): PackageVersions {
+  return {
+    core: bumpVersion(prev.core, kind),
+    cli: bumpVersion(prev.cli, kind),
+    dashboard: bumpVersion(prev.dashboard, kind),
+    createUrateam: bumpVersion(prev.createUrateam, kind),
+  };
+}
+
+/** Replace the top-level `"version": "..."` field. Preserves all other formatting. */
+export function bumpPackageJson(content: string, newVersion: string): string {
+  return content.replace(/("version":\s*)"[^"]+"/, `$1"${newVersion}"`);
+}
+
+export function bumpDockerfile(
+  content: string,
+  v: { core: string; cli: string; dashboard: string },
+): string {
+  return content
+    .replace(/^(ARG URATEAM_CORE_VERSION=)[\d.]+/m, `$1${v.core}`)
+    .replace(/^(ARG URATEAM_CLI_VERSION=)[\d.]+/m, `$1${v.cli}`)
+    .replace(/^(ARG URATEAM_DASHBOARD_VERSION=)[\d.]+/m, `$1${v.dashboard}`);
+}
+
+export function bumpComposeFile(
+  content: string,
+  v: { core: string; cli: string; dashboard: string },
+): string {
+  return content
+    .replace(/(URATEAM_CORE_VERSION:\s*)[\d.]+/, `$1${v.core}`)
+    .replace(/(URATEAM_CLI_VERSION:\s*)[\d.]+/, `$1${v.cli}`)
+    .replace(/(URATEAM_DASHBOARD_VERSION:\s*)[\d.]+/, `$1${v.dashboard}`);
+}
+
+export function buildChangelogEntry(args: {
+  releaseTag: string;
+  date: string;
+  prev: PackageVersions;
+  next: PackageVersions;
+}): string {
+  const ver = args.releaseTag.replace(/^v/, "");
+  return [
+    `## [${ver}] — ${args.date}`,
+    "",
+    "Bumps:",
+    `- \`@urateam/core\`: ${args.prev.core} → ${args.next.core}`,
+    `- \`@urateam/cli\`: ${args.prev.cli} → ${args.next.cli}`,
+    `- \`@urateam/dashboard\`: ${args.prev.dashboard} → ${args.next.dashboard}`,
+    `- \`create-urateam\`: ${args.prev.createUrateam} → ${args.next.createUrateam}`,
+    "",
+    "<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Insert a new changelog entry above the latest existing version section.
+ * Idempotent: if a section for the same version already exists, returns the
+ * input unchanged so half-cut runs can be re-attempted safely.
+ */
+export function insertChangelogEntry(content: string, entry: string): string {
+  const verMatch = /## \[(\d+\.\d+\.\d+)\] —/.exec(entry);
+  if (verMatch && content.includes(`## [${verMatch[1]}] —`)) {
+    return content;
+  }
+  const idx = content.search(/^## \[\d+\.\d+\.\d+\] —/m);
+  if (idx === -1) return content.trimEnd() + "\n\n" + entry;
+  return content.slice(0, idx) + entry + content.slice(idx);
+}
+
+/**
+ * Compute next release tag from the latest existing tag (e.g. "v0.1.38" → "v0.1.39").
+ * Caller passes tags sorted newest-first.
+ */
+export function nextReleaseTag(latestTags: string[], kind: BumpKind): string {
+  const latest = latestTags.find((t) => /^v\d+\.\d+\.\d+$/.test(t));
+  const cur = latest ? latest.replace(/^v/, "") : "0.0.0";
+  return `v${bumpVersion(cur, kind)}`;
+}

--- a/scripts/cut-release.test.ts
+++ b/scripts/cut-release.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import {
+  bumpVersion,
+  bumpAll,
+  bumpPackageJson,
+  bumpDockerfile,
+  bumpComposeFile,
+  buildChangelogEntry,
+  insertChangelogEntry,
+  nextReleaseTag,
+} from "./cut-release-lib.ts";
+
+test("bumpVersion: patch / minor / major", () => {
+  assert.equal(bumpVersion("0.1.23", "patch"), "0.1.24");
+  assert.equal(bumpVersion("0.1.23", "minor"), "0.2.0");
+  assert.equal(bumpVersion("0.1.23", "major"), "1.0.0");
+  assert.equal(bumpVersion("9.99.99", "patch"), "9.99.100");
+});
+
+test("bumpVersion: rejects non-semver input", () => {
+  assert.throws(() => bumpVersion("not-a-version", "patch"));
+  assert.throws(() => bumpVersion("1.2", "patch"));
+  assert.throws(() => bumpVersion("v1.2.3", "patch"));
+});
+
+test("bumpAll bumps every package by the same kind", () => {
+  const out = bumpAll(
+    { core: "0.1.23", cli: "0.1.25", dashboard: "0.1.23", createUrateam: "0.1.26" },
+    "patch",
+  );
+  assert.deepEqual(out, {
+    core: "0.1.24",
+    cli: "0.1.26",
+    dashboard: "0.1.24",
+    createUrateam: "0.1.27",
+  });
+});
+
+test("bumpPackageJson replaces only the top-level version field", () => {
+  const input = `{
+  "name": "foo",
+  "version": "0.1.23",
+  "private": true,
+  "dependencies": {
+    "bar": "version 0.1.23"
+  }
+}
+`;
+  const out = bumpPackageJson(input, "0.1.24");
+  assert.equal(
+    out,
+    `{
+  "name": "foo",
+  "version": "0.1.24",
+  "private": true,
+  "dependencies": {
+    "bar": "version 0.1.23"
+  }
+}
+`,
+  );
+});
+
+test("bumpDockerfile updates only the URATEAM_*_VERSION ARGs", () => {
+  const input =
+    "ARG URATEAM_CORE_VERSION=0.1.23\n" +
+    "ARG URATEAM_CLI_VERSION=0.1.25\n" +
+    "ARG URATEAM_DASHBOARD_VERSION=0.1.23\n" +
+    "ARG CLAUDE_CODE_VERSION=2.1.128\n";
+  const out = bumpDockerfile(input, {
+    core: "0.1.24",
+    cli: "0.1.26",
+    dashboard: "0.1.24",
+  });
+  assert.equal(
+    out,
+    "ARG URATEAM_CORE_VERSION=0.1.24\n" +
+      "ARG URATEAM_CLI_VERSION=0.1.26\n" +
+      "ARG URATEAM_DASHBOARD_VERSION=0.1.24\n" +
+      "ARG CLAUDE_CODE_VERSION=2.1.128\n",
+  );
+});
+
+test("bumpComposeFile updates only the URATEAM_*_VERSION args", () => {
+  const input =
+    "        URATEAM_CORE_VERSION: 0.1.23\n" +
+    "        URATEAM_CLI_VERSION: 0.1.25\n" +
+    "        URATEAM_DASHBOARD_VERSION: 0.1.23\n" +
+    "        CLAUDE_CODE_VERSION: 2.1.128\n";
+  const out = bumpComposeFile(input, {
+    core: "0.1.24",
+    cli: "0.1.26",
+    dashboard: "0.1.24",
+  });
+  assert.match(out, /URATEAM_CORE_VERSION: 0\.1\.24/);
+  assert.match(out, /URATEAM_CLI_VERSION: 0\.1\.26/);
+  assert.match(out, /URATEAM_DASHBOARD_VERSION: 0\.1\.24/);
+  assert.match(out, /CLAUDE_CODE_VERSION: 2\.1\.128/);
+});
+
+test("buildChangelogEntry produces keep-a-changelog format", () => {
+  const entry = buildChangelogEntry({
+    releaseTag: "v0.1.38",
+    date: "2026-05-08",
+    prev: { core: "0.1.23", cli: "0.1.25", dashboard: "0.1.23", createUrateam: "0.1.26" },
+    next: { core: "0.1.24", cli: "0.1.26", dashboard: "0.1.24", createUrateam: "0.1.27" },
+  });
+  assert.match(entry, /^## \[0\.1\.38\] — 2026-05-08$/m);
+  assert.match(entry, /Bumps:/);
+  assert.match(entry, /`@urateam\/core`: 0\.1\.23 → 0\.1\.24/);
+  assert.match(entry, /`create-urateam`: 0\.1\.26 → 0\.1\.27/);
+  assert.match(entry, /TODO: replace/);
+});
+
+test("insertChangelogEntry: prepends above the latest version section", () => {
+  const existing =
+    "# Changelog\n\nintro line\n\n## [0.1.37] — 2026-05-07\n\nv0.1.37 body\n";
+  const entry = "## [0.1.38] — 2026-05-08\n\nv0.1.38 body\n\n";
+  const out = insertChangelogEntry(existing, entry);
+  // New entry must appear before the old one
+  const newIdx = out.indexOf("## [0.1.38]");
+  const oldIdx = out.indexOf("## [0.1.37]");
+  assert.ok(newIdx > -1 && oldIdx > -1 && newIdx < oldIdx);
+});
+
+test("insertChangelogEntry: idempotent — same version already present is a no-op", () => {
+  const existing =
+    "# Changelog\n\n## [0.1.38] — 2026-05-08\n\nbody\n\n## [0.1.37] — 2026-05-07\n\n";
+  const entry = "## [0.1.38] — 2026-05-08\n\nfresh body\n\n";
+  assert.equal(insertChangelogEntry(existing, entry), existing);
+});
+
+test("insertChangelogEntry: file with no existing version sections appends to the end", () => {
+  const existing = "# Changelog\n\nintro only\n";
+  const entry = "## [0.1.0] — 2024-01-01\n\nbody\n\n";
+  const out = insertChangelogEntry(existing, entry);
+  assert.match(out, /intro only[\s\S]*## \[0\.1\.0\]/);
+});
+
+test("nextReleaseTag: takes latest from sorted list, ignores non-semver tags", () => {
+  assert.equal(
+    nextReleaseTag(["v0.1.38", "v0.1.37", "some-other-tag"], "patch"),
+    "v0.1.39",
+  );
+  assert.equal(nextReleaseTag(["v0.1.38"], "minor"), "v0.2.0");
+  assert.equal(nextReleaseTag([], "patch"), "v0.0.1");
+});

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env tsx
+/**
+ * BEC-176: `pnpm cut-release patch|minor|major [--dry-run] [--push]`
+ *
+ * Bumps every version-bearing file atomically and stages a release commit:
+ *   1. packages/{core,cli,dashboard,create-urateam}/package.json
+ *   2. Dockerfile ARGs (URATEAM_CORE_VERSION / CLI / DASHBOARD)
+ *   3. docker-compose.dogfood.yml `args:` block
+ *   4. CHANGELOG.md (new section above the latest existing one)
+ *
+ * Idempotent: re-running when a section for the same release tag already
+ * exists is a no-op for the changelog (the package.json bumps will run
+ * again — re-running cleanly is the operator's responsibility).
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  bumpAll,
+  bumpComposeFile,
+  bumpDockerfile,
+  bumpPackageJson,
+  buildChangelogEntry,
+  insertChangelogEntry,
+  nextReleaseTag,
+  type BumpKind,
+  type PackageVersions,
+} from "./cut-release-lib.ts";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+
+interface FilePatch {
+  path: string;
+  before: string;
+  after: string;
+}
+
+function readPkg(rel: string): { content: string; version: string } {
+  const content = readFileSync(resolve(REPO_ROOT, rel), "utf8");
+  const m = /"version":\s*"([^"]+)"/.exec(content);
+  if (!m) throw new Error(`no version field in ${rel}`);
+  return { content, version: m[1]! };
+}
+
+function getCurrentVersions(): PackageVersions {
+  return {
+    core: readPkg("packages/core/package.json").version,
+    cli: readPkg("packages/cli/package.json").version,
+    dashboard: readPkg("packages/dashboard/package.json").version,
+    createUrateam: readPkg("packages/create-urateam/package.json").version,
+  };
+}
+
+function getReleaseTags(): string[] {
+  try {
+    return execSync("git tag -l 'v*' --sort=-v:refname", {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    })
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function buildPatches(
+  prev: PackageVersions,
+  next: PackageVersions,
+  releaseTag: string,
+  date: string,
+): FilePatch[] {
+  const patches: FilePatch[] = [];
+
+  for (const [rel, ver] of [
+    ["packages/core/package.json", next.core],
+    ["packages/cli/package.json", next.cli],
+    ["packages/dashboard/package.json", next.dashboard],
+    ["packages/create-urateam/package.json", next.createUrateam],
+  ] as const) {
+    const before = readFileSync(resolve(REPO_ROOT, rel), "utf8");
+    const after = bumpPackageJson(before, ver);
+    if (before !== after) patches.push({ path: rel, before, after });
+  }
+
+  const dockerfileBefore = readFileSync(resolve(REPO_ROOT, "Dockerfile"), "utf8");
+  const dockerfileAfter = bumpDockerfile(dockerfileBefore, next);
+  if (dockerfileBefore !== dockerfileAfter) {
+    patches.push({ path: "Dockerfile", before: dockerfileBefore, after: dockerfileAfter });
+  }
+
+  const composeBefore = readFileSync(
+    resolve(REPO_ROOT, "docker-compose.dogfood.yml"),
+    "utf8",
+  );
+  const composeAfter = bumpComposeFile(composeBefore, next);
+  if (composeBefore !== composeAfter) {
+    patches.push({
+      path: "docker-compose.dogfood.yml",
+      before: composeBefore,
+      after: composeAfter,
+    });
+  }
+
+  const changelogBefore = readFileSync(resolve(REPO_ROOT, "CHANGELOG.md"), "utf8");
+  const entry = buildChangelogEntry({ releaseTag, date, prev, next });
+  const changelogAfter = insertChangelogEntry(changelogBefore, entry);
+  if (changelogBefore !== changelogAfter) {
+    patches.push({
+      path: "CHANGELOG.md",
+      before: changelogBefore,
+      after: changelogAfter,
+    });
+  }
+
+  return patches;
+}
+
+function applyPatches(patches: FilePatch[]): void {
+  for (const p of patches) {
+    writeFileSync(resolve(REPO_ROOT, p.path), p.after);
+  }
+}
+
+interface CliArgs {
+  bump: BumpKind;
+  dryRun: boolean;
+  push: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const flags = new Set(argv.filter((a) => a.startsWith("--")));
+  const bump = positional[0];
+  if (bump !== "patch" && bump !== "minor" && bump !== "major") {
+    throw new Error(
+      `usage: pnpm cut-release patch|minor|major [--dry-run] [--push]\n  got: ${argv.join(" ")}`,
+    );
+  }
+  return {
+    bump,
+    dryRun: flags.has("--dry-run"),
+    push: flags.has("--push"),
+  };
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const prev = getCurrentVersions();
+  const next = bumpAll(prev, args.bump);
+  const releaseTag = nextReleaseTag(getReleaseTags(), args.bump);
+  const date = today();
+
+  const patches = buildPatches(prev, next, releaseTag, date);
+
+  console.log(`Cut release: ${releaseTag}  (date ${date})`);
+  console.log("Bumps:");
+  console.log(`  @urateam/core:        ${prev.core} → ${next.core}`);
+  console.log(`  @urateam/cli:         ${prev.cli} → ${next.cli}`);
+  console.log(`  @urateam/dashboard:   ${prev.dashboard} → ${next.dashboard}`);
+  console.log(`  create-urateam:       ${prev.createUrateam} → ${next.createUrateam}`);
+  console.log("");
+  console.log(`Files to update (${patches.length}):`);
+  for (const p of patches) console.log(`  ${p.path}`);
+
+  if (args.dryRun) {
+    console.log("\n--dry-run: nothing written.");
+    return;
+  }
+
+  if (patches.length === 0) {
+    console.log("\nNothing to do — already on target versions.");
+    return;
+  }
+
+  applyPatches(patches);
+
+  const branch = `chore/release-${releaseTag}`;
+  console.log(`\nCreating branch ${branch} and committing...`);
+  execSync(`git checkout -b ${branch}`, { cwd: REPO_ROOT, stdio: "inherit" });
+  execSync(`git add ${patches.map((p) => p.path).join(" ")}`, {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+  const message = `chore(release): ${releaseTag}\n\nBumps:\n` +
+    `- @urateam/core:        ${prev.core} → ${next.core}\n` +
+    `- @urateam/cli:         ${prev.cli} → ${next.cli}\n` +
+    `- @urateam/dashboard:   ${prev.dashboard} → ${next.dashboard}\n` +
+    `- create-urateam:       ${prev.createUrateam} → ${next.createUrateam}\n`;
+  execSync(`git commit -m ${JSON.stringify(message)}`, {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+
+  if (args.push) {
+    console.log(`\nPushing ${branch} and opening PR...`);
+    execSync(`git push -u origin ${branch}`, { cwd: REPO_ROOT, stdio: "inherit" });
+    execSync(
+      `gh pr create --title "chore(release): ${releaseTag}" --body "Automated bump via \`pnpm cut-release ${args.bump}\`. Edit the CHANGELOG TODO before merging."`,
+      { cwd: REPO_ROOT, stdio: "inherit" },
+    );
+  } else {
+    console.log("\nDone. Next steps:");
+    console.log(
+      `  1. Edit CHANGELOG.md to replace the TODO with ### Added / ### Fixed sections`,
+    );
+    console.log(`  2. git push -u origin ${branch}`);
+    console.log(`  3. gh pr create`);
+    console.log(
+      `  4. After merge: git tag ${releaseTag} <merge-sha> && git push origin ${releaseTag}`,
+    );
+    console.log(
+      `  5. gh release create ${releaseTag} --title "${releaseTag} — <feature>" --notes ...`,
+    );
+  }
+}
+
+main();

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -13,7 +13,7 @@
  * again — re-running cleanly is the operator's responsibility).
  */
 
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -125,6 +125,20 @@ function applyPatches(patches: FilePatch[]): void {
   }
 }
 
+/**
+ * Run a command via spawnSync (no shell — argv is passed directly so backticks
+ * and other shell metacharacters in arguments are never interpreted). Throws
+ * with the exit status on failure.
+ */
+function run(cmd: string, argv: string[]): void {
+  const r = spawnSync(cmd, argv, { cwd: REPO_ROOT, stdio: "inherit" });
+  if (r.status !== 0) {
+    throw new Error(
+      `${cmd} ${argv.join(" ")} failed (status ${r.status ?? "spawn error"})`,
+    );
+  }
+}
+
 interface CliArgs {
   bump: BumpKind;
   dryRun: boolean;
@@ -180,32 +194,41 @@ function main(): void {
     return;
   }
 
+  // Create the branch BEFORE writing files. If `git checkout -b` fails (e.g.
+  // the branch already exists from a prior half-cut run), the working tree
+  // stays clean — operator can delete the branch and retry without manual
+  // `git checkout -- .` cleanup.
+  const branch = `chore/release-${releaseTag}`;
+  console.log(`\nCreating branch ${branch}...`);
+  try {
+    run("git", ["checkout", "-b", branch]);
+  } catch (err) {
+    throw new Error(
+      `${(err as Error).message}\nIf the branch exists from a previous run: \`git branch -D ${branch}\` and retry.`,
+    );
+  }
+
   applyPatches(patches);
 
-  const branch = `chore/release-${releaseTag}`;
-  console.log(`\nCreating branch ${branch} and committing...`);
-  execSync(`git checkout -b ${branch}`, { cwd: REPO_ROOT, stdio: "inherit" });
-  execSync(`git add ${patches.map((p) => p.path).join(" ")}`, {
-    cwd: REPO_ROOT,
-    stdio: "inherit",
-  });
   const message = `chore(release): ${releaseTag}\n\nBumps:\n` +
     `- @urateam/core:        ${prev.core} → ${next.core}\n` +
     `- @urateam/cli:         ${prev.cli} → ${next.cli}\n` +
     `- @urateam/dashboard:   ${prev.dashboard} → ${next.dashboard}\n` +
     `- create-urateam:       ${prev.createUrateam} → ${next.createUrateam}\n`;
-  execSync(`git commit -m ${JSON.stringify(message)}`, {
-    cwd: REPO_ROOT,
-    stdio: "inherit",
-  });
+  run("git", ["add", ...patches.map((p) => p.path)]);
+  run("git", ["commit", "-m", message]);
 
   if (args.push) {
     console.log(`\nPushing ${branch} and opening PR...`);
-    execSync(`git push -u origin ${branch}`, { cwd: REPO_ROOT, stdio: "inherit" });
-    execSync(
-      `gh pr create --title "chore(release): ${releaseTag}" --body "Automated bump via \`pnpm cut-release ${args.bump}\`. Edit the CHANGELOG TODO before merging."`,
-      { cwd: REPO_ROOT, stdio: "inherit" },
-    );
+    run("git", ["push", "-u", "origin", branch]);
+    // Argv passed directly to spawnSync — backticks in --body are NOT
+    // interpreted as bash command substitution because no shell is involved.
+    run("gh", [
+      "pr", "create",
+      "--title", `chore(release): ${releaseTag}`,
+      "--body",
+      `Automated bump via \`pnpm cut-release ${args.bump}\`. Edit the CHANGELOG TODO before merging.`,
+    ]);
   } else {
     console.log("\nDone. Next steps:");
     console.log(


### PR DESCRIPTION
## Summary

Filed BEC-176. One-command release bump replacing the v5-min bump-and-paste flow.

```
pnpm cut-release patch [--dry-run] [--push]
```

Updates atomically:
- `packages/{core,cli,dashboard,create-urateam}/package.json`
- `Dockerfile` `ARG URATEAM_*_VERSION=...`
- `docker-compose.dogfood.yml` `args:` block
- `CHANGELOG.md` (new section inserted above the latest existing one with a `### TODO` placeholder for the operator to fill in)

Plus stages the bump commit on a fresh `chore/release-vX.Y.Z` branch. With `--push` it also pushes and opens the PR via `gh`.

## Why

The 2026-05-07 session shipped 3 manual cuts (v0.1.35, v0.1.36, v0.1.37). v0.1.35 missed the compose `args:` block — required a sync follow-up (#168). This helper makes that class of miss structurally impossible.

## Architecture

- `scripts/cut-release-lib.ts` — pure functions (no fs / no git / no exec). Trivially testable.
- `scripts/cut-release.ts` — orchestration. Reads package.json files, git tags, applies patches, commits, optionally pushes.
- `scripts/cut-release.test.ts` — 11 unit tests via `node:test` + tsx. Run with `pnpm test:scripts`.

## Test plan

- [x] `pnpm test:scripts` — 11 / 11 pass
- [x] `pnpm cut-release patch --dry-run` against live main (post v0.1.38) — correctly identifies 7 files to update, computes v0.1.39, writes nothing
- [x] All pure functions covered: `bumpVersion`, `bumpAll`, `bumpPackageJson`, `bumpDockerfile`, `bumpComposeFile`, `buildChangelogEntry`, `insertChangelogEntry`, `nextReleaseTag`
- [x] Idempotency tested: `insertChangelogEntry` is a no-op when a section for the same version already exists
- [x] Edge cases: invalid semver throws, no existing tags → starts at `v0.0.1`, file with no version sections → entry appended

## Closes

Closes BEC-176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)