### PR TITLE
feat(pipeline): BEC-178 URATEAM_AUTO_MERGE env override

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -12,7 +12,7 @@ export const startCommand = new Command("start")
   .option("--dashboard-port <port>", "Dashboard port", "3001")
   .action(async (options) => {
     try {
-    const { createApp, defaultConfigs, applyDeepReviewPassesOverride, cleanupWorktrees, runAgentBranchSweep, addLogStream, initSlackAlertManager, createSlackAlertStream } = await import("@urateam/core");
+    const { createApp, defaultConfigs, applyDeepReviewPassesOverride, applyAutoMergeOverride, cleanupWorktrees, runAgentBranchSweep, addLogStream, initSlackAlertManager, createSlackAlertStream } = await import("@urateam/core");
 
     // --- Slack error alerts (opt-in) ---
     if (
@@ -202,9 +202,17 @@ export const startCommand = new Command("start")
     // unchanged (every pipeline keeps deepReviewPasses=0). Set to a
     // non-negative integer to override on every pipeline that has a
     // `review` stage (auto-implement, bug, needs-design — not quick-fix).
-    const pipelineConfigs = applyDeepReviewPassesOverride(
-      defaultConfigs,
-      process.env.URATEAM_DEEP_REVIEW_PASSES,
+    //
+    // BEC-178: opt every pipeline into auto-merge via env. Unset = defaults
+    // unchanged (autoMerge undefined / off). Set to "true" or "false" to
+    // override every pipeline. Auto-merge gates (diff size, blocking review
+    // findings, mandatory reviewers, etc.) still apply when true.
+    const pipelineConfigs = applyAutoMergeOverride(
+      applyDeepReviewPassesOverride(
+        defaultConfigs,
+        process.env.URATEAM_DEEP_REVIEW_PASSES,
+      ),
+      process.env.URATEAM_AUTO_MERGE,
     );
 
     // --- Resolve and validate workspace directories ---

--- a/packages/core/src/__tests__/auto-merge-override.test.ts
+++ b/packages/core/src/__tests__/auto-merge-override.test.ts
@@ -1,0 +1,78 @@
+/**
+ * BEC-178 — env-var override for `autoMerge` so operators can opt every
+ * pipeline into auto-merge without forking the built-in pipeline configs.
+ *
+ * Mirrors the BEC-163 `applyDeepReviewPassesOverride` pattern.
+ *
+ * Default behavior (env unset) is unchanged: every pipeline keeps its
+ * compiled-in `autoMerge` value (undefined / off in the built-ins).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  defaultConfigs,
+  applyAutoMergeOverride,
+} from "../pipeline/config.js";
+
+describe("applyAutoMergeOverride (BEC-178)", () => {
+  it("returns configs unchanged when env value is undefined", () => {
+    const out = applyAutoMergeOverride(defaultConfigs, undefined);
+    expect(out).toEqual(defaultConfigs);
+  });
+
+  it("sets autoMerge: true on EVERY pipeline when env is 'true'", () => {
+    const out = applyAutoMergeOverride(defaultConfigs, "true");
+    expect(out["auto-implement"].autoMerge).toBe(true);
+    expect(out["bug"].autoMerge).toBe(true);
+    expect(out["needs-design"].autoMerge).toBe(true);
+    expect(out["quick-fix"].autoMerge).toBe(true);
+  });
+
+  it("sets autoMerge: false on EVERY pipeline when env is 'false' (explicit opt-out)", () => {
+    const out = applyAutoMergeOverride(defaultConfigs, "false");
+    for (const k of Object.keys(out)) {
+      expect(out[k].autoMerge).toBe(false);
+    }
+  });
+
+  it("is case-insensitive (TRUE / True / true all match)", () => {
+    expect(
+      applyAutoMergeOverride(defaultConfigs, "TRUE")["auto-implement"].autoMerge,
+    ).toBe(true);
+    expect(
+      applyAutoMergeOverride(defaultConfigs, "True")["auto-implement"].autoMerge,
+    ).toBe(true);
+    expect(
+      applyAutoMergeOverride(defaultConfigs, "FALSE")["auto-implement"].autoMerge,
+    ).toBe(false);
+  });
+
+  it("ignores invalid values and returns the input unchanged", () => {
+    // Non-boolean strings that operators might fat-finger: "yes", "1", "on", ""
+    for (const invalid of ["yes", "1", "on", "", "0", "no"]) {
+      const out = applyAutoMergeOverride(defaultConfigs, invalid);
+      expect(out["auto-implement"].autoMerge).toBe(
+        defaultConfigs["auto-implement"].autoMerge,
+      );
+    }
+  });
+
+  it("does not mutate the input map", () => {
+    const before = JSON.parse(JSON.stringify(defaultConfigs));
+    applyAutoMergeOverride(defaultConfigs, "true");
+    expect(defaultConfigs).toEqual(before);
+  });
+
+  it("preserves all other pipeline fields when applying the override", () => {
+    const out = applyAutoMergeOverride(defaultConfigs, "true");
+    // Spot-check that we didn't lose other config (stages, retry, etc.)
+    expect(out["auto-implement"].stages).toEqual(
+      defaultConfigs["auto-implement"].stages,
+    );
+    expect(out["auto-implement"].retry).toEqual(
+      defaultConfigs["auto-implement"].retry,
+    );
+    expect(out["auto-implement"].prStrategy).toBe(
+      defaultConfigs["auto-implement"].prStrategy,
+    );
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ export {
   type StageCostBreakdown,
   type CostSummaryConfig,
 } from "./pipeline/cost-summary.js";
-export { defaultConfigs, validatePipelineConfigs, validateRepoConfigs, applyDeepReviewPassesOverride, resolvePipeline } from "./pipeline/index.js";
+export { defaultConfigs, validatePipelineConfigs, validateRepoConfigs, applyDeepReviewPassesOverride, applyAutoMergeOverride, resolvePipeline } from "./pipeline/index.js";
 export { createWebhookHandler } from "./webhook/index.js";
 export {
   CompositeNotifier,

--- a/packages/core/src/pipeline/config.ts
+++ b/packages/core/src/pipeline/config.ts
@@ -107,6 +107,40 @@ export function applyDeepReviewPassesOverride(
   return result;
 }
 
+/**
+ * BEC-178: env-var override for `autoMerge` so operators can opt every
+ * pipeline into auto-merge without forking the built-in pipeline configs.
+ *
+ * `envValue === undefined` → returns the input unchanged.
+ * `envValue === "true"` (case-insensitive) → sets `autoMerge: true` on every pipeline.
+ * `envValue === "false"` (case-insensitive) → sets `autoMerge: false` on every pipeline.
+ * Any other value → logs warn, returns input unchanged.
+ *
+ * The runner still gates auto-merge on diff size, blocking review findings,
+ * exclude patterns, mandatory reviewers, and approving reviews — flipping
+ * `autoMerge: true` doesn't bypass those gates.
+ */
+export function applyAutoMergeOverride(
+  configs: Record<string, PipelineConfig>,
+  envValue: string | undefined,
+): Record<string, PipelineConfig> {
+  if (envValue === undefined) return configs;
+  const trimmed = envValue.trim().toLowerCase();
+  if (trimmed !== "true" && trimmed !== "false") {
+    log.warn(
+      { envValue, var: "URATEAM_AUTO_MERGE" },
+      "URATEAM_AUTO_MERGE must be 'true' or 'false' — ignoring",
+    );
+    return configs;
+  }
+  const autoMerge = trimmed === "true";
+  const result: Record<string, PipelineConfig> = {};
+  for (const [key, cfg] of Object.entries(configs)) {
+    result[key] = { ...cfg, autoMerge };
+  }
+  return result;
+}
+
 export function validateRepoConfigs(
   configs: Record<string, unknown>
 ): Record<string, RepoConfig> {

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -3,6 +3,7 @@ export {
   validatePipelineConfigs,
   validateRepoConfigs,
   applyDeepReviewPassesOverride,
+  applyAutoMergeOverride,
 } from "./config.js";
 export { resolvePipeline } from "./router.js";
 export { createQueue, type WorkQueue } from "./queue.js";


### PR DESCRIPTION
## Summary

Filed BEC-178. Env-var override for \`autoMerge\` mirroring the BEC-163 \`applyDeepReviewPassesOverride\` pattern.

\`\`\`
URATEAM_AUTO_MERGE=true|false   # case-insensitive
\`\`\`

- Unset → defaults unchanged (autoMerge undefined / off)
- "true" → every pipeline gets autoMerge: true (gates still apply)
- "false" → every pipeline gets autoMerge: false (explicit opt-out)
- Invalid → warn + unchanged

Wired into \`start.ts\` after the existing \`applyDeepReviewPassesOverride\` call so the two overrides compose cleanly.

## Why

User asked for autoMerge on the dogfood; this is the cleanest path — env override mirroring BEC-163, no source changes to default configs, full backward compat.

## Test plan

- [x] 7 unit tests (auto-merge-override.test.ts) covering all branches
- [x] Full \`pnpm --filter @urateam/core test\` — 1466 passed, 0 failures
- [x] \`pnpm --filter @urateam/{core,cli} build\` clean

Closes BEC-178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)