### PR TITLE
chore(release): v0.1.39 — BEC-178

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
+## [0.1.39] — 2026-05-08
+
+Bumps:
+- `@urateam/core`: 0.1.24 → 0.1.25
+- `@urateam/cli`: 0.1.26 → 0.1.27
+- `@urateam/dashboard`: 0.1.24 → 0.1.25
+- `create-urateam`: 0.1.27 → 0.1.28
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.38] — 2026-05-08
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ Bumps:
 - `@urateam/dashboard`: 0.1.24 → 0.1.25
 - `create-urateam`: 0.1.27 → 0.1.28
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Added
+- **BEC-178** — New `URATEAM_AUTO_MERGE=true|false` env override mirroring `URATEAM_DEEP_REVIEW_PASSES` (BEC-163). Operators can now opt every pipeline into auto-merge without forking the built-in pipeline configs. Case-insensitive; invalid values are ignored with a warn log. Auto-merge gates (diff size, blocking review findings, mandatory reviewers, exclude patterns, approving reviews) still apply when true. (#200)
+
 ## [0.1.38] — 2026-05-08
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.24
-ARG URATEAM_CLI_VERSION=0.1.26
-ARG URATEAM_DASHBOARD_VERSION=0.1.24
+ARG URATEAM_CORE_VERSION=0.1.25
+ARG URATEAM_CLI_VERSION=0.1.27
+ARG URATEAM_DASHBOARD_VERSION=0.1.25
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.24
-        URATEAM_CLI_VERSION: 0.1.26
-        URATEAM_DASHBOARD_VERSION: 0.1.24
+        URATEAM_CORE_VERSION: 0.1.25
+        URATEAM_CLI_VERSION: 0.1.27
+        URATEAM_DASHBOARD_VERSION: 0.1.25
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Cuts v0.1.39, shipping BEC-178 (`URATEAM_AUTO_MERGE` env override).

## Bumps

| Package | From | To |
|---|---|---|
| `@urateam/core` | 0.1.24 | 0.1.25 |
| `@urateam/cli` | 0.1.26 | 0.1.27 |
| `@urateam/dashboard` | 0.1.24 | 0.1.25 |
| `create-urateam` | 0.1.27 | 0.1.28 |

## First production use of BEC-176

This release was cut via `pnpm cut-release patch --push` — the helper that landed in v0.1.38 (#189). Bumped 7 files atomically, opened the PR. CHANGELOG TODO replaced with a real Added section in a follow-up commit.

## Test plan

- [x] All 4 `package.json` versions consistent with Dockerfile + compose
- [x] CHANGELOG entry above [0.1.38] in keep-a-changelog format
- [x] BEC-178 already merged to main with green CI

After merge: tag `v0.1.39` → OIDC publish workflow fires → `gh release create v0.1.39`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)