### PR TITLE
fix(runner): BEC-180 skip non-git dirs in worktree-prune sweep

### DIFF
--- a/packages/core/src/__tests__/prune-worktrees-in-repo-dirs.test.ts
+++ b/packages/core/src/__tests__/prune-worktrees-in-repo-dirs.test.ts
@@ -1,0 +1,76 @@
+/**
+ * BEC-180: skip non-git dirs in the worktree-prune sweep.
+ *
+ * Pre-fix, the runner ran `git worktree prune` on every entry under
+ * `repoCloneDir`. Since BEC-174 landed, that includes `.agent-sweep/`,
+ * which has no top-level `.git` — every tick logged a `level:50` ERROR.
+ *
+ * The new helper whitelists by `.git/` presence before pruning.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { pruneWorktreesInRepoDirs } from "../repo/git.js";
+
+describe("pruneWorktreesInRepoDirs (BEC-180)", () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), "prune-base-"));
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("returns empty result when baseDir does not exist", async () => {
+    const result = await pruneWorktreesInRepoDirs(join(baseDir, "does-not-exist"));
+    expect(result).toEqual({ pruned: [], skipped: [] });
+  });
+
+  it("skips a sibling dir that has no .git/ entry", async () => {
+    // The BEC-174 sweep dir holds per-repo subdirs but no top-level .git.
+    await mkdir(join(baseDir, ".agent-sweep"), { recursive: true });
+    await mkdir(join(baseDir, ".agent-sweep", "abc12345"), { recursive: true });
+
+    const result = await pruneWorktreesInRepoDirs(baseDir);
+    expect(result.pruned).toEqual([]);
+    expect(result.skipped).toContain(".agent-sweep");
+  });
+
+  it("prunes only entries that have a top-level .git/ directory", async () => {
+    // Real git repo
+    const gitDir = join(baseDir, "real-clone");
+    await mkdir(gitDir, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: gitDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: gitDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: gitDir, stdio: "pipe" });
+    await writeFile(join(gitDir, "README"), "x\n");
+    execFileSync("git", ["add", "."], { cwd: gitDir, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: gitDir, stdio: "pipe" });
+
+    // Non-git sibling (the BEC-174 case)
+    await mkdir(join(baseDir, "sweep-cache"), { recursive: true });
+
+    // Plain file at base — not a directory, must be skipped silently
+    await writeFile(join(baseDir, "stray.txt"), "");
+
+    const result = await pruneWorktreesInRepoDirs(baseDir);
+    expect(result.pruned).toEqual(["real-clone"]);
+    expect(result.skipped.sort()).toEqual(["stray.txt", "sweep-cache"].sort());
+  });
+
+  it("treats .git as a file (submodule / worktree) the same as a directory", async () => {
+    // Some git setups (worktrees, submodules) have .git as a regular file
+    // pointing at the actual gitdir. We just need it to exist.
+    const dir = join(baseDir, "worktree-style");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, ".git"), "gitdir: /tmp/some-real-gitdir\n");
+
+    const result = await pruneWorktreesInRepoDirs(baseDir);
+    expect(result.pruned).toContain("worktree-style");
+  });
+});

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -29,7 +29,7 @@ import type { ReviewModelRun } from "../executor/review/review-provider.js";
 import { extractHandoff } from "../executor/extract-handoff.js";
 import { DEFAULT_AGENT_CLAUDE_MD } from "../executor/agent-config.js";
 import { generatePRDescription } from "./pr-description.js";
-import { access, readdir, writeFile, appendFile } from "node:fs/promises";
+import { access, writeFile, appendFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { execFile as execFileCb } from "node:child_process";
@@ -53,8 +53,8 @@ import {
   getChangedFiles,
   checkDuplicateBranch,
   branchName,
-  gitExecSafe,
   createWorktreeFromRemote,
+  pruneWorktreesInRepoDirs,
 } from "../repo/git.js";
 import {
   addPRComment,
@@ -2580,24 +2580,11 @@ export class PipelineRunner {
 
   /**
    * Run `git worktree prune` on every repository directory found under
-   * repoCloneDir. Uses gitExecSafe so failures (e.g. non-git directories)
-   * are silently ignored.
+   * repoCloneDir. BEC-180: skips entries with no `.git/` (e.g. the BEC-174
+   * `.agent-sweep/` parent dir) so they don't produce noisy ERROR logs.
    */
   private async pruneAllWorktreeRefs(): Promise<void> {
-    let entries: string[];
-    try {
-      entries = await readdir(this.repoCloneDir);
-    } catch {
-      // repoCloneDir does not exist yet — nothing to prune.
-      return;
-    }
-
-    await Promise.all(
-      entries.map((entry) =>
-        // gitExecSafe returns "" on error, so non-git directories are harmless.
-        gitExecSafe(["worktree", "prune"], join(this.repoCloneDir, entry)),
-      ),
-    );
+    await pruneWorktreesInRepoDirs(this.repoCloneDir);
   }
 
   /**

--- a/packages/core/src/repo/git.ts
+++ b/packages/core/src/repo/git.ts
@@ -851,6 +851,43 @@ export function branchName(issueId: string, slug: string): string {
 }
 
 /**
+ * BEC-180: run `git worktree prune` only on entries under `baseDir` that have
+ * a `.git` entry (file or directory). Sibling dirs that aren't git repos —
+ * notably the BEC-174 `.agent-sweep/` parent — are silently skipped instead of
+ * producing noisy `level: 50` ERROR logs from `git worktree`'s "not a git
+ * repository" complaint.
+ *
+ * Returns the names that were pruned vs skipped (both relative to baseDir),
+ * which makes the function trivially testable.
+ */
+export async function pruneWorktreesInRepoDirs(
+  baseDir: string,
+): Promise<{ pruned: string[]; skipped: string[] }> {
+  let entries: string[];
+  try {
+    entries = await readdir(baseDir);
+  } catch {
+    return { pruned: [], skipped: [] };
+  }
+
+  const pruned: string[] = [];
+  const skipped: string[] = [];
+  for (const entry of entries) {
+    const dir = join(baseDir, entry);
+    try {
+      // .git can be a directory (regular clone) OR a file (worktree /
+      // submodule pointer). `access` succeeds for either.
+      await access(join(dir, ".git"));
+      await gitExecSafe(["worktree", "prune"], dir);
+      pruned.push(entry);
+    } catch {
+      skipped.push(entry);
+    }
+  }
+  return { pruned, skipped };
+}
+
+/**
  * Scan baseDir for run directories (each containing a "worktree" sub-dir) that
  * are older than ttlHours and remove them.  Returns the list of paths removed.
  *


### PR DESCRIPTION
## Summary

Filed BEC-180. Stops the noisy `level: 50` `git worktree failed` errors that fire every tick because the runner's pre-tick prune iterates `.agent-sweep/` (BEC-174's per-repo sweep parent) which has no top-level \`.git\`.

## Approach

Whitelist by \`.git\` presence (file or directory — supports both clones and worktree-pointer files). Extracted to a pure helper \`pruneWorktreesInRepoDirs\` for testability.

## Test plan

- [x] 4 unit tests (prune-worktrees-in-repo-dirs.test.ts):
  - returns empty when baseDir doesn't exist
  - skips a sibling dir with no \`.git/\` (the BEC-174 case)
  - prunes only entries that have \`.git\`
  - treats \`.git\` as a file (worktree/submodule pointer) the same as a directory
- [x] Full \`pnpm --filter @urateam/core test\` — 1470 pass, 0 failures
- [x] Build clean

Closes BEC-180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)