### PR TITLE
feat(review): low-yield review-model health check + audit alert

### DIFF
--- a/packages/core/src/__tests__/audit-immutability.test.ts
+++ b/packages/core/src/__tests__/audit-immutability.test.ts
@@ -65,6 +65,7 @@ describe("audit_events immutability", () => {
       "packages/core/src/pm/actions/triage.ts",
       "packages/core/src/pm/actions/promote.ts",
       "packages/core/src/pm/actions/resolve-approvals.ts",
+      "packages/core/src/pipeline/review-providers-runner.ts",
       "packages/core/src/release-manager/scheduler.ts",
       "packages/core/src/release-manager/slack-handler.ts",
       "packages/core/src/repo/agent-branch-sweep-runner.ts",

--- a/packages/core/src/__tests__/audit/review-model-low-output-ratio-event.test.ts
+++ b/packages/core/src/__tests__/audit/review-model-low-output-ratio-event.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { reviewModelLowOutputRatioEvent } from "../../audit/events.js";
+
+describe("reviewModelLowOutputRatioEvent", () => {
+  it("returns an audit event with the documented shape", () => {
+    const event = reviewModelLowOutputRatioEvent({
+      modelId: "gpt-oss-120b:free",
+      outputRatio: 0.011,
+      runs: 10,
+      threshold: 0.05,
+    });
+    expect(event.eventType).toBe("review.model_low_output_ratio");
+    expect(event.actor).toBe("system");
+    expect(event.actorType).toBe("system");
+    expect(event.payload).toEqual({
+      modelId: "gpt-oss-120b:free",
+      outputRatio: 0.011,
+      runs: 10,
+      threshold: 0.05,
+    });
+    expect(event.id).toMatch(/^evt_/);
+  });
+});

--- a/packages/core/src/__tests__/review/model-health.test.ts
+++ b/packages/core/src/__tests__/review/model-health.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { reviewModelRuns } from "../../db/schema.js";
+import { nanoid } from "nanoid";
+import {
+  getModelHealthScores,
+  flagLowYieldModels,
+} from "../../executor/review/model-health.js";
+
+function setupDb() {
+  const sqlite = new Database(":memory:");
+  // Minimal table — only what the helper queries
+  sqlite.exec(`
+    CREATE TABLE review_model_runs (
+      id TEXT PRIMARY KEY,
+      stage_run_id TEXT NOT NULL,
+      provider_id TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      duration_ms INTEGER NOT NULL DEFAULT 0,
+      error_message TEXT,
+      truncated_files INTEGER NOT NULL DEFAULT 0,
+      started_at INTEGER,
+      completed_at INTEGER
+    );
+  `);
+  return drizzle(sqlite);
+}
+
+describe("getModelHealthScores", () => {
+  it("computes output ratio per model from review_model_runs in lookback window", async () => {
+    const db = setupDb();
+    const stageId = nanoid();
+    const now = new Date();
+    // Healthy model: 80% output ratio
+    for (let i = 0; i < 10; i++) {
+      await db.insert(reviewModelRuns).values({
+        id: nanoid(), stageRunId: stageId, providerId: "openrouter",
+        modelId: "claude-haiku-4-5", status: "completed",
+        inputTokens: 2000, outputTokens: 8000, startedAt: now,
+      });
+    }
+    // Bad model: ~1% output ratio
+    for (let i = 0; i < 10; i++) {
+      await db.insert(reviewModelRuns).values({
+        id: nanoid(), stageRunId: stageId, providerId: "openrouter",
+        modelId: "gpt-oss-120b:free", status: "completed",
+        inputTokens: 27000, outputTokens: 300, startedAt: now,
+      });
+    }
+    const scores = await getModelHealthScores(db as any, { lookbackHours: 168, minRuns: 5 });
+    expect(scores.get("claude-haiku-4-5")?.outputRatio).toBeCloseTo(0.8, 1);
+    expect(scores.get("gpt-oss-120b:free")?.outputRatio).toBeCloseTo(0.011, 2);
+    expect(scores.get("claude-haiku-4-5")?.runs).toBe(10);
+    expect(scores.get("gpt-oss-120b:free")?.runs).toBe(10);
+  });
+
+  it("excludes failed runs (status != 'completed') from the ratio", async () => {
+    const db = setupDb();
+    const stageId = nanoid();
+    const now = new Date();
+    for (let i = 0; i < 5; i++) {
+      await db.insert(reviewModelRuns).values({
+        id: nanoid(), stageRunId: stageId, providerId: "openrouter",
+        modelId: "model-a", status: "completed",
+        inputTokens: 1000, outputTokens: 800, startedAt: now,
+      });
+      await db.insert(reviewModelRuns).values({
+        id: nanoid(), stageRunId: stageId, providerId: "openrouter",
+        modelId: "model-a", status: "failed",
+        inputTokens: 0, outputTokens: 0, startedAt: now,
+      });
+    }
+    const scores = await getModelHealthScores(db as any, { lookbackHours: 168, minRuns: 5 });
+    expect(scores.get("model-a")?.runs).toBe(5);
+    expect(scores.get("model-a")?.outputRatio).toBeCloseTo(800 / 1800, 2);
+  });
+
+  it("excludes runs older than lookbackHours", async () => {
+    const db = setupDb();
+    const stageId = nanoid();
+    const ancient = new Date(Date.now() - 200 * 3600_000); // 200h ago > 168h lookback
+    const recent = new Date();
+    for (let i = 0; i < 5; i++) {
+      await db.insert(reviewModelRuns).values({
+        id: nanoid(), stageRunId: stageId, providerId: "openrouter",
+        modelId: "model-a", status: "completed",
+        inputTokens: 1000, outputTokens: 100, startedAt: ancient,
+      });
+    }
+    for (let i = 0; i < 5; i++) {
+      await db.insert(reviewModelRuns).values({
+        id: nanoid(), stageRunId: stageId, providerId: "openrouter",
+        modelId: "model-a", status: "completed",
+        inputTokens: 1000, outputTokens: 800, startedAt: recent,
+      });
+    }
+    const scores = await getModelHealthScores(db as any, { lookbackHours: 168, minRuns: 5 });
+    expect(scores.get("model-a")?.runs).toBe(5);
+    // Only recent rows count: 800 / (1000+800) ≈ 0.444
+    expect(scores.get("model-a")?.outputRatio).toBeCloseTo(0.444, 2);
+  });
+});
+
+describe("flagLowYieldModels", () => {
+  it("flags models with outputRatio below threshold and runs >= minRuns", () => {
+    const scores = new Map([
+      ["healthy-model", { runs: 10, outputRatio: 0.5, lastSeen: new Date() }],
+      ["bad-model", { runs: 10, outputRatio: 0.01, lastSeen: new Date() }],
+      ["new-model", { runs: 2, outputRatio: 0.01, lastSeen: new Date() }],
+    ]);
+    const flagged = flagLowYieldModels(
+      scores,
+      ["healthy-model", "bad-model", "new-model"],
+      { threshold: 0.05, minRuns: 5 },
+    );
+    expect(flagged).toEqual(["bad-model"]);
+  });
+
+  it("returns empty when no scores exist (fresh install)", () => {
+    const flagged = flagLowYieldModels(new Map(), ["any-model"], { threshold: 0.05, minRuns: 5 });
+    expect(flagged).toEqual([]);
+  });
+
+  it("does not flag models not present in the input list (caller filtered)", () => {
+    const scores = new Map([
+      ["bad-model", { runs: 10, outputRatio: 0.01, lastSeen: new Date() }],
+    ]);
+    const flagged = flagLowYieldModels(scores, ["healthy-model"], { threshold: 0.05, minRuns: 5 });
+    expect(flagged).toEqual([]);
+  });
+});

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -516,3 +516,22 @@ export function reviewFanoutFallbackUsedEvent(args: {
     },
   });
 }
+
+export function reviewModelLowOutputRatioEvent(args: {
+  modelId: string;
+  outputRatio: number;
+  runs: number;
+  threshold: number;
+}): AuditEvent {
+  return base({
+    eventType: "review.model_low_output_ratio",
+    actor: "system",
+    actorType: "system",
+    payload: {
+      modelId: args.modelId,
+      outputRatio: args.outputRatio,
+      runs: args.runs,
+      threshold: args.threshold,
+    },
+  });
+}

--- a/packages/core/src/executor/review/model-health.ts
+++ b/packages/core/src/executor/review/model-health.ts
@@ -1,0 +1,89 @@
+import { gte } from "drizzle-orm";
+import type { AnyDb } from "../../db/client.js";
+import { reviewModelRuns } from "../../db/schema.js";
+
+export interface ModelHealthScore {
+  runs: number;
+  outputRatio: number;
+  lastSeen: Date;
+}
+
+export interface HealthOptions {
+  lookbackHours: number;
+  minRuns: number;
+}
+
+export interface FlagOptions {
+  threshold: number;
+  minRuns: number;
+}
+
+/**
+ * Aggregate per-model health stats from review_model_runs over a rolling
+ * window. Only `status = 'completed'` runs contribute to the output-ratio
+ * computation — failed runs typically have zero in/out tokens and would
+ * dilute the signal.
+ */
+export async function getModelHealthScores(
+  db: AnyDb,
+  opts: HealthOptions,
+): Promise<Map<string, ModelHealthScore>> {
+  const cutoff = new Date(Date.now() - opts.lookbackHours * 3600_000);
+  const rows = await db
+    .select({
+      modelId: reviewModelRuns.modelId,
+      inputTokens: reviewModelRuns.inputTokens,
+      outputTokens: reviewModelRuns.outputTokens,
+      startedAt: reviewModelRuns.startedAt,
+      status: reviewModelRuns.status,
+    })
+    .from(reviewModelRuns)
+    .where(gte(reviewModelRuns.startedAt, cutoff));
+
+  const acc = new Map<
+    string,
+    { runs: number; sumIn: number; sumOut: number; lastSeen: Date }
+  >();
+  for (const r of rows) {
+    if (r.status !== "completed") continue;
+    const cur = acc.get(r.modelId) ?? {
+      runs: 0,
+      sumIn: 0,
+      sumOut: 0,
+      lastSeen: new Date(0),
+    };
+    cur.runs += 1;
+    cur.sumIn += r.inputTokens;
+    cur.sumOut += r.outputTokens;
+    if (r.startedAt && r.startedAt > cur.lastSeen) cur.lastSeen = r.startedAt;
+    acc.set(r.modelId, cur);
+  }
+
+  const result = new Map<string, ModelHealthScore>();
+  for (const [modelId, v] of acc) {
+    const denom = v.sumIn + v.sumOut;
+    const outputRatio = denom > 0 ? v.sumOut / denom : 0;
+    result.set(modelId, { runs: v.runs, outputRatio, lastSeen: v.lastSeen });
+  }
+  return result;
+}
+
+/**
+ * Filter a list of model IDs down to those that look low-yield given the
+ * health scores. Models with insufficient data (`runs < minRuns`) are NOT
+ * flagged — we don't want a single bad-luck call to suspend a model.
+ */
+export function flagLowYieldModels(
+  scores: Map<string, ModelHealthScore>,
+  models: string[],
+  opts: FlagOptions,
+): string[] {
+  const flagged: string[] = [];
+  for (const modelId of models) {
+    const s = scores.get(modelId);
+    if (!s) continue;
+    if (s.runs < opts.minRuns) continue;
+    if (s.outputRatio < opts.threshold) flagged.push(modelId);
+  }
+  return flagged;
+}

--- a/packages/core/src/pipeline/review-providers-runner.ts
+++ b/packages/core/src/pipeline/review-providers-runner.ts
@@ -7,8 +7,22 @@ import { insertReviewModelRuns } from "../db/review-model-runs.js";
 import type { AnyDb } from "../db/client.js";
 import type { ReviewFinding } from "../types.js";
 import { createLogger } from "../logger.js";
+import { logAuditEventUnchecked } from "../audit/writer.js";
+import { reviewModelLowOutputRatioEvent } from "../audit/events.js";
+import { getModelHealthScores, flagLowYieldModels } from "../executor/review/model-health.js";
 
 const log = createLogger({ component: "ReviewProvidersRunner" });
+
+function parseFloatOr(envValue: string | undefined, fallback: number): number {
+  if (!envValue) return fallback;
+  const n = parseFloat(envValue);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+function parseIntOr(envValue: string | undefined, fallback: number): number {
+  if (!envValue) return fallback;
+  const n = parseInt(envValue, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
 
 export interface RunReviewProvidersOpts {
   env: NodeJS.ProcessEnv;
@@ -44,6 +58,47 @@ export async function runReviewProviders(
 ): Promise<RunReviewProvidersResult> {
   const providers = getEnabledProviders(opts.env);
   const allRuns: ReviewModelRun[] = [];
+
+  // BEC-178 follow-up: low-yield review-model health check. Advisory only —
+  // emit a warn + audit event for models below threshold; operator removes
+  // from REVIEW_MODELS manually. Auto-suspend deliberately scoped out
+  // (transient outage feedback-loop risk).
+  const modelIds = (opts.env.REVIEW_MODELS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const healthThreshold = parseFloatOr(process.env.REVIEW_MODELS_MIN_OUTPUT_RATIO, 0.05);
+  const healthLookbackHours = parseIntOr(process.env.REVIEW_MODELS_HEALTH_LOOKBACK_HOURS, 168);
+  const healthMinRuns = parseIntOr(process.env.REVIEW_MODELS_MIN_RUNS, 5);
+
+  try {
+    const scores = await getModelHealthScores(opts.db, {
+      lookbackHours: healthLookbackHours,
+      minRuns: healthMinRuns,
+    });
+    const flagged = flagLowYieldModels(scores, modelIds, {
+      threshold: healthThreshold,
+      minRuns: healthMinRuns,
+    });
+    for (const modelId of flagged) {
+      const s = scores.get(modelId)!;
+      log.warn(
+        { modelId, outputRatio: s.outputRatio, runs: s.runs, threshold: healthThreshold },
+        `review model below output-ratio threshold — consider removing from REVIEW_MODELS`,
+      );
+      void logAuditEventUnchecked(
+        opts.db,
+        reviewModelLowOutputRatioEvent({
+          modelId,
+          outputRatio: s.outputRatio,
+          runs: s.runs,
+          threshold: healthThreshold,
+        }),
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "model-health probe failed — skipping flagging this tick");
+  }
 
   for (const p of providers) {
     try {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -432,7 +432,7 @@ export const AuditEventTypeSchema = z.enum([
   "release.tag_conflict", "release.partial",
   "slack.post_failed",
   "qa.run_triggered", "qa.run_completed", "qa.gap_issue_filed",
-  "review.fanout_fallback_used",
+  "review.fanout_fallback_used", "review.model_low_output_ratio",
 ]);
 export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
 


### PR DESCRIPTION
## Summary

Second half of the 2026-05-08 token-optimization design. Pre-fanout health check that flags review models with sub-threshold rolling output ratio and emits an audit event so the operator gets a visible signal in the dashboard.

**Spec**: `docs/superpowers/specs/2026-05-08-cache-telemetry-and-model-health.md`
**Plan**: `docs/superpowers/plans/2026-05-08-cache-telemetry-and-model-health.md`

## Why

Dogfood log scan showed `openai/gpt-oss-120b:free` at 1% output ratio over 10 runs (272K input → 3K output) — the model is consistently failing to produce parseable findings but still consuming input tokens. We want a visible alert when this happens, not silent token burn.

## What changes

- New module `packages/core/src/executor/review/model-health.ts` (already in main from B2 commit)
- New audit event `review.model_low_output_ratio` (already in main from B1 commit)
- `pipeline/review-providers-runner.ts` runs the health check before each fanout dispatch
- 3 new env knobs (all optional; sane defaults):
  - `REVIEW_MODELS_MIN_OUTPUT_RATIO` (default 0.05)
  - `REVIEW_MODELS_HEALTH_LOOKBACK_HOURS` (default 168)
  - `REVIEW_MODELS_MIN_RUNS` (default 5)
- `audit-immutability` allow-list updated for the new `logAuditEventUnchecked` emit-site

## Design choice: advisory only

Auto-suspend is deliberately out of scope. Flagged models still run; operator removes from `REVIEW_MODELS` based on the alert. This avoids the feedback-loop risk where a transient OpenRouter outage looks like a permanent model failure and silently disables half the fanout.

## Test plan

- [x] B1: audit-event factory unit test — 1/1
- [x] B2: model-health helpers (`getModelHealthScores`, `flagLowYieldModels`) — 6 tests covering ratio computation, status filter, lookback window, threshold + min-runs gating
- [x] Audit-immutability allow-list updated; both gates pass
- [x] Full `pnpm --filter @urateam/core test` clean (1473 passed, 0 failures)

## Soak verification (post-merge + v0.1.40 deploy)

Within ~1 hour of v0.1.40 deployment to dogfood, we expect `gpt-oss-120b:free` to be flagged in the audit log — its 7-day output ratio is well below 5%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)