### PR TITLE
feat(executor,runner,prompts): BEC-182 cap review-feedback runs

### DIFF
--- a/packages/core/src/__tests__/executor/review-feedback-profile-override.test.ts
+++ b/packages/core/src/__tests__/executor/review-feedback-profile-override.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { applyReviewFeedbackProfileOverride } from "../../executor/executor.js";
+
+const baseProfile = {
+  tools: ["Read", "Write", "Edit"],
+  maxInputTokens: 100_000,
+  maxTurns: 100,
+  model: "claude-sonnet-4-6",
+};
+
+describe("applyReviewFeedbackProfileOverride (BEC-182)", () => {
+  it("caps maxTurns + maxInputTokens for implement stage when review-feedback context is present", () => {
+    const out = applyReviewFeedbackProfileOverride(baseProfile, "implement", true);
+    expect(out.maxTurns).toBe(30);
+    expect(out.maxInputTokens).toBe(60_000);
+    // Other fields preserved
+    expect(out.tools).toEqual(baseProfile.tools);
+    expect(out.model).toBe(baseProfile.model);
+  });
+
+  it("returns the profile unchanged on non-implement stages even with review-feedback context", () => {
+    const out = applyReviewFeedbackProfileOverride(baseProfile, "test", true);
+    expect(out).toEqual(baseProfile);
+  });
+
+  it("returns the profile unchanged when review-feedback context is absent", () => {
+    const out = applyReviewFeedbackProfileOverride(baseProfile, "implement", false);
+    expect(out).toEqual(baseProfile);
+  });
+
+  it("does not mutate the input profile", () => {
+    const before = JSON.parse(JSON.stringify(baseProfile));
+    applyReviewFeedbackProfileOverride(baseProfile, "implement", true);
+    expect(baseProfile).toEqual(before);
+  });
+});

--- a/packages/core/src/__tests__/executor/review-feedback-prompt.test.ts
+++ b/packages/core/src/__tests__/executor/review-feedback-prompt.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { implementTemplate } from "../../executor/prompt/templates.js";
+
+const baseIssue = { id: "BEC-999", identifier: "BEC-999", title: "T", description: "D", priority: 3, labels: [], slug: "bec-999-t" } as any;
+const baseRepo = { url: "https://github.com/x/y", defaultBranch: "main", testCommand: "pnpm test", buildCommand: "pnpm build" } as any;
+
+describe("implementTemplate — review-feedback prompt (BEC-182)", () => {
+  const feedback = {
+    prBranch: "agent/BEC-999-foo",
+    prUrl: "https://github.com/x/y/pull/42",
+    comments: [{ author: "reviewer", body: "rename foo to bar", file: "src/x.ts", line: 12, createdAt: "2026-05-08T00:00:00Z" }],
+  } as any;
+
+  it("includes the bounded-scope language", () => {
+    const out = implementTemplate(baseIssue, baseRepo, undefined, feedback);
+    expect(out).toMatch(/Address ONLY the listed comments/);
+    expect(out).toMatch(/Do NOT refactor adjacent code/);
+  });
+
+  it("instructs the agent to read the diff first", () => {
+    const out = implementTemplate(baseIssue, baseRepo, undefined, feedback);
+    expect(out).toMatch(/git diff origin\/main\.\.\.HEAD/);
+  });
+
+  it("makes build/test conditional on text-only changes", () => {
+    const out = implementTemplate(baseIssue, baseRepo, undefined, feedback);
+    expect(out).toMatch(/Skip build\/test ONLY if every change is text-only/);
+  });
+
+  it("instructs the agent to stop and report rather than spelunk on failure", () => {
+    const out = implementTemplate(baseIssue, baseRepo, undefined, feedback);
+    expect(out).toMatch(/stop and report what blocks the resolution/);
+  });
+});

--- a/packages/core/src/__tests__/review-feedback.test.ts
+++ b/packages/core/src/__tests__/review-feedback.test.ts
@@ -395,8 +395,9 @@ describe("implementTemplate with reviewFeedback", () => {
 
   it("instructs agent to address each comment and not refactor unrelated code", () => {
     const result = implementTemplate(issue, repo, undefined, feedback);
-    expect(result).toContain("Address each review comment");
-    expect(result).toContain("Do not refactor unrelated code");
+    // BEC-182: prompt rewritten with tighter scoping language
+    expect(result).toContain("Address ONLY the listed comments");
+    expect(result).toContain("Do NOT refactor adjacent code");
   });
 
   it("includes the review feedback block", () => {

--- a/packages/core/src/__tests__/runner-ralph-feedback-skip.test.ts
+++ b/packages/core/src/__tests__/runner-ralph-feedback-skip.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+
+// Pure-function refactor: extract the ralph-iteration computation so we can test it
+import { computeEffectiveRalphIterations } from "../pipeline/runner-ralph-helpers.js";
+
+describe("computeEffectiveRalphIterations (BEC-182)", () => {
+  it("returns 0 for review-feedback runs regardless of config or license", () => {
+    expect(computeEffectiveRalphIterations({ runType: "review-feedback" }, 2, true)).toBe(0);
+    expect(computeEffectiveRalphIterations({ runType: "review-feedback" }, 5, true)).toBe(0);
+    expect(computeEffectiveRalphIterations({ runType: "review-feedback" }, 2, false)).toBe(0);
+  });
+
+  it("uses config.ralphIterations when license unlocks deep-review on standard runs", () => {
+    expect(computeEffectiveRalphIterations({ runType: undefined as any }, 2, true)).toBe(2);
+    expect(computeEffectiveRalphIterations({ runType: undefined as any }, 3, true)).toBe(3);
+  });
+
+  it("clamps to max 1 iteration without deep-review license on standard runs", () => {
+    expect(computeEffectiveRalphIterations({ runType: undefined as any }, 5, false)).toBe(1);
+    expect(computeEffectiveRalphIterations({ runType: undefined as any }, 0, false)).toBe(0);
+  });
+
+  it("falls back to 2 (with license) / 1 (without) when ralphIterations is undefined", () => {
+    expect(computeEffectiveRalphIterations({ runType: undefined as any }, undefined, true)).toBe(2);
+    expect(computeEffectiveRalphIterations({ runType: undefined as any }, undefined, false)).toBe(1);
+  });
+});

--- a/packages/core/src/__tests__/templates.test.ts
+++ b/packages/core/src/__tests__/templates.test.ts
@@ -155,8 +155,10 @@ describe("Prompt templates", () => {
         comments: [],
       };
       const result = implementTemplate(issue, repo, undefined, reviewFeedback);
-      expect(result).toContain("Run the build command: npm run build");
-      expect(result).toContain("If either fails, fix the errors before declaring completion.");
+      // BEC-182: build/test are now conditional on non-text-only changes
+      expect(result).toContain("npm run build");
+      expect(result).toContain("npm test");
+      expect(result).toContain("Skip build/test ONLY if every change is text-only");
     });
   });
 

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -8,6 +8,7 @@ import type {
   StageResult,
   ReviewFeedbackContext,
   MergeConflictContext,
+  AgentProfile,
 } from "../types.js";
 import type { Db, AnyDb } from "../db/client.js";
 import { stageRuns, agentLogs } from "../db/schema.js";
@@ -21,6 +22,24 @@ import type { DevcontainerSession } from "../repo/devcontainer.js";
 import { createLogger } from "../logger.js";
 import { consumeAgentStream, type StreamMessage } from "./agent-stream.js";
 import { isClaudeAuthValid } from "./auth-check.js";
+
+/**
+ * BEC-182: review-feedback runs are bounded — N comments, push, done.
+ * Override the implement profile's maxTurns / maxInputTokens to prevent
+ * spelunking. Keep tools and model from the base profile.
+ *
+ * Exported as a pure function so it can be tested without mocking the Agent SDK.
+ */
+export function applyReviewFeedbackProfileOverride(
+  profile: AgentProfile,
+  stage: StageType,
+  hasReviewFeedback: boolean,
+): AgentProfile {
+  if (hasReviewFeedback && stage === "implement") {
+    return { ...profile, maxTurns: 30, maxInputTokens: 60_000 };
+  }
+  return profile;
+}
 
 export interface ExecuteStageContext {
   runId: string;
@@ -71,6 +90,12 @@ export async function executeStage(
   if (!profile) {
     throw new Error(`No agent profile for stage: ${stage}`);
   }
+
+  const effectiveProfile = applyReviewFeedbackProfileOverride(
+    profile,
+    stage,
+    !!context.reviewFeedback,
+  );
 
   // Bind runId, issueId and stage to every log line in this execution
   const log = createLogger({ component: "Executor", runId, issueId, stage });
@@ -144,12 +169,12 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
     const messages = query({
       prompt,
       options: {
-        allowedTools: profile.tools,
-        maxTurns: profile.maxTurns,
+        allowedTools: effectiveProfile.tools,
+        maxTurns: effectiveProfile.maxTurns,
         cwd: workdir,
         ...buildStagePermissionOptions(stage),
-        ...(context.stageModels?.[stage] ?? profile.model
-          ? { model: context.stageModels?.[stage] ?? profile.model! }
+        ...(context.stageModels?.[stage] ?? effectiveProfile.model
+          ? { model: context.stageModels?.[stage] ?? effectiveProfile.model! }
           : {}),
         ...(mcpServerNames.length > 0 ? { mcpServers: tooling.mcpServers } : {}),
         ...(tooling.plugins.length > 0 ? { plugins: tooling.plugins } : {}),

--- a/packages/core/src/executor/prompt/templates.ts
+++ b/packages/core/src/executor/prompt/templates.ts
@@ -253,7 +253,7 @@ The work is complete when \`git status\` shows no conflicted paths and no \`reba
   }
 
   if (reviewFeedback) {
-    return `You are the implement agent. Your job is to address PR review feedback on the existing implementation.
+    return `You are the implement agent. Your job is to address PR review feedback on an existing implementation. Scope is small and bounded.
 
 ${issueDataBlock(issue)}
 
@@ -265,13 +265,13 @@ ${handoffBlock(handoff)}
 
 Instructions:
 - Stay on the current branch (\`${reviewFeedback.prBranch}\`) — the worktree is already configured. Do NOT run \`git checkout\`; switching branches inside a worktree is unsafe and can corrupt other concurrent runs.
-- Address each review comment listed above. Do not refactor unrelated code.
-- Commit your changes with the message: fix: address review feedback on ${issue.id}
-- Push to the same branch (${reviewFeedback.prBranch}) — do NOT create a new PR.
-- Run the build command: ${repo.buildCommand}
-- Run the test command: ${repo.testCommand}
-- If either fails, fix the errors before declaring completion.
-- Keep changes minimal and focused on the specific feedback.
+- Read the existing diff first: \`git log --oneline origin/${repo.defaultBranch}..HEAD\` then \`git diff origin/${repo.defaultBranch}...HEAD\`. The reviewer is responding to THIS diff.
+- Address ONLY the listed comments. Do NOT refactor adjacent code, restructure files, or edit files that the comments don't reference. Each comment is bounded — keep changes minimal.
+- Commit with the message: \`fix: address review feedback on ${issue.id}\`
+- Push to the same branch (\`${reviewFeedback.prBranch}\`) — do NOT create a new PR.
+- Skip build/test ONLY if every change is text-only (docs, comments, string literals with no behavior change). Otherwise run: \`${repo.buildCommand}\` then \`${repo.testCommand}\`.
+- If a step fails (build, test, push), stop and report what blocks the resolution. Do NOT spelunk for a workaround or run unrelated commands.
+- You have a tight turn budget. Plan: read diff → make N small edits → commit → push → done.
 `.trim();
   }
 

--- a/packages/core/src/pipeline/runner-ralph-helpers.ts
+++ b/packages/core/src/pipeline/runner-ralph-helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure helper for RALPH iteration computation — extracted to enable unit testing
+ * without pulling in the full runner module. (BEC-182)
+ */
+
+export function computeEffectiveRalphIterations(
+  run: { runType?: string | null },
+  configIterations: number | undefined,
+  hasDeepReviewLicense: boolean,
+): number {
+  // BEC-182: skip RALPH for review-feedback runs — RALPH re-evaluates against
+  // the original issue ACs but feedback work is bounded to the comments, not
+  // the full ACs. RALPH adds turn cost without value here.
+  if (run.runType === "review-feedback") return 0;
+  if (hasDeepReviewLicense) return configIterations ?? 2;
+  return Math.min(configIterations ?? 1, 1);
+}

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -21,6 +21,7 @@ import { executeStage } from "../executor/executor.js";
 import { validateHandoff } from "../executor/validate.js";
 import { isFeatureLicensed } from "../license.js";
 import { checkRequirements, buildRalphContext } from "../executor/ralph.js";
+import { computeEffectiveRalphIterations } from "./runner-ralph-helpers.js";
 import { checkTestQuality } from "../executor/test-quality.js";
 import { buildDeepReviewContext } from "../executor/deep-review.js";
 import { runReviewProviders } from "./review-providers-runner.js";
@@ -593,6 +594,7 @@ export class PipelineRunner {
 
     const run = this.buildPipelineRun(runId, issue, pipelineKey, repoConfig, branch);
     run.prUrl = prUrl;
+    run.runType = "review-feedback";
 
     // Register in activeFeedbackRuns BEFORE enqueue so rate-limit check works
     this.activeFeedbackRuns.set(prUrl, runId);
@@ -815,9 +817,11 @@ export class PipelineRunner {
       // don't waste time hunting for a non-existent failed requirement.
       let ralphEvaluationFailed = false;
       let ralphEvaluationError: string | undefined;
-      const effectiveRalphIterations = isFeatureLicensed("deep-review")
-        ? config.ralphIterations ?? 2
-        : Math.min(config.ralphIterations ?? 1, 1);
+      const effectiveRalphIterations = computeEffectiveRalphIterations(
+        run,
+        config.ralphIterations,
+        isFeatureLicensed("deep-review"),
+      );
       const ralphIterations = effectiveRalphIterations;
 
       // Execute each stage

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -366,6 +366,12 @@ export interface PipelineRun {
    * DB) carry the count forward.
    */
   stageRetries?: Record<string, number>;
+  /**
+   * The type of run: "standard" for normal issue pipelines, "review-feedback"
+   * for runs triggered by PR review comments. Mirrors the DB `run_type` column.
+   * Used to skip RALPH for review-feedback runs (BEC-182).
+   */
+  runType?: string | null;
 }
 
 // --- Pipeline Result / Error ---


### PR DESCRIPTION
## Summary

Closes BEC-182. Review-feedback runs (triggered by GitHub PR review comments) were spelunking to the 100-turn cap because they reused the standard `implement` profile + RALPH iterations. Three coordinated fixes in one PR:

1. **Profile override**: `applyReviewFeedbackProfileOverride` caps `maxTurns: 30`, `maxInputTokens: 60_000` for implement stage when `context.reviewFeedback` is set
2. **Tighter prompt**: rewritten review-feedback `implementTemplate` — instructs to read the diff, address ONLY listed comments, conditional build/test, stop-and-report on failure (no spelunking)
3. **Skip RALPH**: extracted `computeEffectiveRalphIterations` returns 0 for `runType === "review-feedback"`

## Driven by

BEC-172 review-feedback hit `Reached maximum number of turns (100)`; BEC-181 stalled in flight. Filed during 2026-05-08 dogfood log scan + token-optimization brainstorm.

## Test plan

- [x] 4 tests on `applyReviewFeedbackProfileOverride`
- [x] 4 tests on the rewritten template (includes new scope language, diff instruction, conditional build/test, stop-and-report)
- [x] 4 tests on `computeEffectiveRalphIterations` (review-feedback → 0; standard → license-based)
- [x] Full `pnpm --filter @urateam/core test` clean (1478 pass, 11 skipped)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)