### PR TITLE
feat(pm): BEC-181 emit audit event when consecutive-failure circuit breaker engages

### DIFF
--- a/packages/core/src/__tests__/audit/pm-skipped-circuit-breaker-event.test.ts
+++ b/packages/core/src/__tests__/audit/pm-skipped-circuit-breaker-event.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { pmSkippedCircuitBreakerEvent } from "../../audit/events.js";
+
+describe("pmSkippedCircuitBreakerEvent (BEC-181)", () => {
+  it("returns an audit event with the documented shape", () => {
+    const event = pmSkippedCircuitBreakerEvent({
+      issueId: "BEC-157",
+      failureCount: 4,
+      threshold: 3,
+      source: "promote",
+    });
+    expect(event.eventType).toBe("pm.skipped_circuit_breaker");
+    expect(event.actor).toBe("pm-agent");
+    expect(event.actorType).toBe("pm-agent");
+    expect(event.issueId).toBe("BEC-157");
+    expect(event.payload).toEqual({
+      failureCount: 4,
+      threshold: 3,
+      source: "promote",
+    });
+    expect(event.id).toMatch(/^evt_/);
+  });
+
+  it("captures source as 'start-todo' when fired from start-todo path", () => {
+    const event = pmSkippedCircuitBreakerEvent({
+      issueId: "BEC-999",
+      failureCount: 5,
+      threshold: 3,
+      source: "start-todo",
+    });
+    expect((event.payload as { source: string }).source).toBe("start-todo");
+  });
+});

--- a/packages/core/src/__tests__/bec-181-circuit-breaker-audit-gap.test.ts
+++ b/packages/core/src/__tests__/bec-181-circuit-breaker-audit-gap.test.ts
@@ -170,7 +170,7 @@ async function assertPromoteBreakerSkip(opts: {
   expect(auditRows[0].issueId).toBe(opts.issueId);
   expect(JSON.parse(auditRows[0].payload).failureCount).toBe(opts.failureCount);
   expect(JSON.parse(auditRows[0].payload).threshold).toBe(opts.threshold);
-  expect(JSON.parse(auditRows[0].payload).action).toBe("promote");
+  expect(JSON.parse(auditRows[0].payload).source).toBe("promote");
 }
 
 describe("BEC-181 Part 2: promoteReadyIssues circuit-breaker skip (working correctly)", () => {
@@ -266,7 +266,7 @@ describe("BEC-181 Part 3: startTodoIssues circuit-breaker skip (working correctl
     expect(auditRows[0].issueId).toBe("BEC-147");
     expect(JSON.parse(auditRows[0].payload).failureCount).toBe(4);
     expect(JSON.parse(auditRows[0].payload).threshold).toBe(3);
-    expect(JSON.parse(auditRows[0].payload).action).toBe("start-todo");
+    expect(JSON.parse(auditRows[0].payload).source).toBe("start-todo");
   });
 });
 

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -106,7 +106,7 @@ export function pmSkippedCircuitBreakerEvent(args: {
   issueId: string;
   failureCount: number;
   threshold: number;
-  action: "promote" | "start-todo";
+  source: "promote" | "start-todo";
 }): AuditEvent {
   return base({
     eventType: "pm.skipped_circuit_breaker",
@@ -116,7 +116,7 @@ export function pmSkippedCircuitBreakerEvent(args: {
     payload: {
       failureCount: args.failureCount,
       threshold: args.threshold,
-      action: args.action,
+      source: args.source,
     },
   });
 }

--- a/packages/core/src/pm/actions/promote.ts
+++ b/packages/core/src/pm/actions/promote.ts
@@ -143,7 +143,7 @@ export async function promoteReadyIssues(input: PromoteInput): Promise<PromoteRe
               issueId: candidate.identifier,
               failureCount,
               threshold: input.maxConsecutiveFailures,
-              action: "promote",
+              source: "promote",
             }),
           );
         }

--- a/packages/core/src/pm/actions/start-todo.ts
+++ b/packages/core/src/pm/actions/start-todo.ts
@@ -151,7 +151,7 @@ export async function startTodoIssues(
             issueId: issue.identifier,
             failureCount,
             threshold: input.maxConsecutiveFailures,
-            action: "start-todo",
+            source: "start-todo",
           }),
         );
         results.push({


### PR DESCRIPTION
## Summary

Closes BEC-181. The BEC-161 consecutive-failure circuit breaker (in \`promote.ts\` and \`start-todo.ts\`) engages silently — only a WARN log, no audit event. This makes breaker activity invisible in the dashboard / audit trail. Adds a new audit event \`pm.skipped_circuit_breaker\` emitted from both call sites whenever the breaker fires.

## Investigation against dogfood DB (2026-05-08)

- BEC-147 had 4 failed runs followed by a successful one — count reset, breaker had no reason to engage
- BEC-157 had 3 failed runs and went \`Done\` in Linear — issue left the candidate pool before breaker could test against it
- Conclusion: breaker is **working** but **silent**. Audit emission closes the visibility gap.

## What changes

| File | Change |
|---|---|
| \`types.ts\` | \`AuditEventTypeSchema\` extended with \`pm.skipped_circuit_breaker\` (already present on branch) |
| \`audit/events.ts\` | \`pmSkippedCircuitBreakerEvent\` factory — renamed payload field from \`action\` → \`source\` to match spec |
| \`pm/actions/promote.ts\` | Emit on breaker engagement with \`source: "promote"\` |
| \`pm/actions/start-todo.ts\` | Emit on breaker engagement with \`source: "start-todo"\` |
| \`__tests__/audit/pm-skipped-circuit-breaker-event.test.ts\` | New factory unit tests (2 tests) |
| \`__tests__/bec-181-circuit-breaker-audit-gap.test.ts\` | Updated assertions: \`action\` → \`source\` |

## Test plan

- [x] 2 new unit tests on the factory (promote source + start-todo source) in \`audit/pm-skipped-circuit-breaker-event.test.ts\`
- [x] Existing breaker integration tests in \`bec-181-circuit-breaker-audit-gap.test.ts\` continue to pass (updated assertions)
- [x] Full \`pnpm --filter @urateam/core test\` clean: **161 passed | 2 skipped (163 files), 1479 tests passed | 11 skipped (1490)**

## How to verify post-deploy

After v0.1.40 hits the dogfood, the next time an issue accumulates ≥3 consecutive failures and then re-enters the promote candidate pool (e.g. via recover-stuck), the audit log will record:

\`\`\`
event_type: pm.skipped_circuit_breaker
issue_id:   BEC-NNN
payload:    { "failureCount": 3, "threshold": 3, "source": "promote" }
\`\`\`

Operators can grep for it: \`SELECT * FROM audit_events WHERE event_type = 'pm.skipped_circuit_breaker' ORDER BY timestamp DESC\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)