### PR TITLE
chore(release): v0.1.40 — BEC-178/180/181/182 + model-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,15 @@ Bumps:
 - `@urateam/dashboard`: 0.1.25 → 0.1.26
 - `create-urateam`: 0.1.28 → 0.1.29
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Added
+- **BEC-178 follow-up — cache telemetry on `stage_runs`** ([#206](https://github.com/JonB32/urateam/pull/206)) — captures `cache_creation_input_tokens` and `cache_read_input_tokens` from each Anthropic Agent SDK turn, persists to `stage_runs`, renders a per-stage `cache hit: X% — read X.XK / created X.XK` line in the BEC-175 PR cost summary. Prerequisite for any further caching tuning since the SDK already caches but the rate was previously invisible.
+- **Low-yield review-model health check** ([#207](https://github.com/JonB32/urateam/pull/207)) — pre-fanout probe queries `review_model_runs` for rolling output ratio per model; emits a WARN log + `review.model_low_output_ratio` audit event for models below threshold. Advisory only — operator manually drops flagged models from `REVIEW_MODELS`. Configurable via `REVIEW_MODELS_MIN_OUTPUT_RATIO` (default `0.05`), `REVIEW_MODELS_HEALTH_LOOKBACK_HOURS` (default `168`), `REVIEW_MODELS_MIN_RUNS` (default `5`).
+- **BEC-181 — `pm.skipped_circuit_breaker` audit event** ([#209](https://github.com/JonB32/urateam/pull/209)) — emitted from `promote.ts` and `start-todo.ts` whenever the BEC-161 consecutive-failure breaker engages. Closes the visibility gap where the breaker was working but invisible (only WARN log, no audit trail).
+
+### Fixed
+- **BEC-180 — worktree-prune skips non-git sibling dirs** ([#202](https://github.com/JonB32/urateam/pull/202)) — runner's pre-tick `git worktree prune` no longer iterates `.agent-sweep/` (BEC-174 sweep parent dir). Eliminates noisy `level: 50` ERROR logs every restart and every cleanup tick. Whitelists by `.git/` presence (file or directory).
+- **BEC-182 — review-feedback runs no longer spelunk to max turns** ([#208](https://github.com/JonB32/urateam/pull/208)) — three coordinated fixes: (1) profile override caps `maxTurns: 30`, `maxInputTokens: 60_000` for the implement stage when `context.reviewFeedback` is set; (2) tighter prompt template (read diff first, address ONLY listed comments, conditional build/test, stop-and-report on failure instead of spelunking); (3) skip RALPH iterations entirely for `runType === "review-feedback"` runs (RALPH evaluates against issue ACs but feedback work is bounded to the comments). Driven by BEC-172 / BEC-181 stalls hitting the 100-turn cap.
+
 ## [0.1.39] — 2026-05-08
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions below refer to the workspace version published to npm. Per-package
 notes call out when a change affects only a single package.
 
+## [0.1.40] — 2026-05-09
+
+Bumps:
+- `@urateam/core`: 0.1.25 → 0.1.26
+- `@urateam/cli`: 0.1.27 → 0.1.28
+- `@urateam/dashboard`: 0.1.25 → 0.1.26
+- `create-urateam`: 0.1.28 → 0.1.29
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.39] — 2026-05-08
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.25
-ARG URATEAM_CLI_VERSION=0.1.27
-ARG URATEAM_DASHBOARD_VERSION=0.1.25
+ARG URATEAM_CORE_VERSION=0.1.26
+ARG URATEAM_CLI_VERSION=0.1.28
+ARG URATEAM_DASHBOARD_VERSION=0.1.26
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.25
-        URATEAM_CLI_VERSION: 0.1.27
-        URATEAM_DASHBOARD_VERSION: 0.1.25
+        URATEAM_CORE_VERSION: 0.1.26
+        URATEAM_CLI_VERSION: 0.1.28
+        URATEAM_DASHBOARD_VERSION: 0.1.26
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Cuts v0.1.40 with five PRs from the 2026-05-08 / 2026-05-09 token-optimization + reliability arc:

- **#206** — cache telemetry on `stage_runs` + cost-summary integration (BEC-178 follow-up)
- **#207** — low-yield review-model health check + audit alert
- **#208** — review-feedback runs no longer spelunk to max turns (BEC-182)
- **#209** — `pm.skipped_circuit_breaker` audit event (BEC-181)
- **#202** — worktree-prune skips non-git dirs (BEC-180)

## Bumps

| Package | From | To |
|---|---|---|
| `@urateam/core` | 0.1.25 | 0.1.26 |
| `@urateam/cli` | 0.1.27 | 0.1.28 |
| `@urateam/dashboard` | 0.1.25 | 0.1.26 |
| `create-urateam` | 0.1.28 | 0.1.29 |

## Cut via

`pnpm cut-release patch --push` (BEC-176 helper, 2nd production use).

## Test plan

- [x] All 5 component PRs CI green pre-merge
- [x] CHANGELOG fill committed
- [x] Bumps consistent across `package.json` / `Dockerfile` / `docker-compose.dogfood.yml`

After merge → tag `v0.1.40` → fires OIDC publish → `gh release create v0.1.40` → deploy to dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)