### PR TITLE
deploy(dogfood): add quality-observer sidecar to compose (BEC-137)

### DIFF
--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -19,8 +19,63 @@ services:
       # localhost-only — remote access via SSH tunnel during soak
       - "127.0.0.1:3001:3001"
 
+  # BEC-137 — Quality Observer sidecar (urateam-quality-observer).
+  # Scans urateam-dogfood for anti-patterns and files GH Issues on
+  # JonB32/urateam (label: urateam-quality-observer). Internal-only;
+  # opt-in via QUALITY_OBSERVER_OBSERVERS env (default omits
+  # log-scanner). The observer source lives in a SEPARATE private repo
+  # at JonB32/urateam-quality-observer; clone it next to this repo
+  # (e.g. /home/deploy/urateam-quality-observer) before `docker compose
+  # build`. See docs/superpowers/runbooks/dogfood-observer-deploy.md.
+  #
+  # Claude auth: shares the dogfood's urateam-dogfood-claude OAuth volume
+  # read-only. ANTHROPIC_API_KEY is OPTIONAL (set in .env.observer to opt
+  # into the API key fallback for CI / hosted setups without OAuth).
+  quality-observer:
+    build:
+      # The observer repo is checked out next to this one on the deploy host.
+      # Override via OBSERVER_CONTEXT env when running `docker compose build`
+      # if your layout differs.
+      context: ${OBSERVER_CONTEXT:-../urateam-quality-observer}
+      dockerfile: deploy/Dockerfile
+    container_name: urateam-quality-observer
+    restart: unless-stopped
+    env_file: .env.observer
+    environment:
+      - QUALITY_OBSERVER_ENABLED=true
+      - QUALITY_OBSERVER_GITHUB_REPO=JonB32/urateam
+      - QUALITY_OBSERVER_CRON_INTERVAL_MS=3600000
+      - QUALITY_OBSERVER_DAILY_TOKEN_BUDGET=1000000
+      # log-scanner reads /host-docker-logs (mounted below) for json-file
+      # logs of the dogfood container. To disable, drop "log-scanner" from
+      # this list.
+      - QUALITY_OBSERVER_OBSERVERS=run-patterns,codebase,log-scanner
+      - QUALITY_OBSERVER_RUN_PATTERNS_LOOKBACK_HOURS=24
+      - QUALITY_OBSERVER_MAX_FINDINGS_PER_TICK=5
+      - URATEAM_DB_DRIVER=sqlite
+      - URATEAM_DB_CONNECTION_STRING=/observer-data/dogfood.db
+      - QUALITY_OBSERVER_CODEBASE_TARGET_DIR=/codebase
+      - QUALITY_OBSERVER_STORE_PATH=/observer-state/observer.db
+      - QUALITY_OBSERVER_AUDIT_LOG_PATH=/observer-state/audit.jsonl
+    volumes:
+      - urateam-dogfood-data:/observer-data:ro       # urateam's sqlite, read-only
+      - urateam-dogfood-claude:/root/.claude:ro      # Claude OAuth, shared read-only
+      # Codebase observer reads the urateam source. Override path via the
+      # OBSERVER_CODEBASE env if your layout differs.
+      - ${OBSERVER_CODEBASE:-./}:/codebase:ro
+      - urateam-observer-state:/observer-state       # observer's own state
+      # log-scanner reads Docker's json-file logs directly to scan the
+      # dogfood container's stdout. Mount is read-only and exposes ALL
+      # container logs+metadata on the host (acceptable on single-tenant
+      # dogfood boxes). Required for the log-scanner observer; safe to
+      # remove if log-scanner is dropped from QUALITY_OBSERVER_OBSERVERS.
+      - /var/lib/docker/containers:/host-docker-logs:ro
+    depends_on:
+      - urateam-dogfood
+
 volumes:
   urateam-dogfood-data:
   urateam-dogfood-work:
   urateam-dogfood-claude:
   urateam-dogfood-config:
+  urateam-observer-state:


### PR DESCRIPTION
## Summary

Lands the BEC-137 quality-observer sidecar service definition upstream. Until now, the observer has been running on the dogfood host configured directly in `/home/deploy/urateam/docker-compose.dogfood.yml`, diverged from this repo. A fresh deploy from this repo would have lost the observer setup.

## What's added

- `quality-observer` service:
  - Build context defaults to `../urateam-quality-observer` (override via `OBSERVER_CONTEXT`); operators clone the observer repo as a sibling checkout
  - Shares the dogfood's `urateam-dogfood-data` (sqlite) and `urateam-dogfood-claude` (Claude OAuth) volumes read-only
  - Codebase mount path defaults to `./` (override via `OBSERVER_CODEBASE`)
  - Default observers: `run-patterns,codebase,log-scanner` (operator opts out of `log-scanner` by editing the env line)
- New named volume `urateam-observer-state` for the observer's own state
- New bind mount `/var/lib/docker/containers:/host-docker-logs:ro` required by the log-scanner observer (BEC-180) — read-only Docker container logs+metadata exposure; acceptable on single-tenant dogfood boxes (no Docker socket)

## Out-of-scope (intentionally kept on host only)

- `caddy-dogfood` service (operator-specific Caddyfile + cert layout)
- `gh-app.pem` mount on `urateam-dogfood` (operator-specific secret)
- `3000`/`3001` port-mapping changes (host-specific networking)

These remain operator customizations on the dogfood host's local compose.

## Companion observer-side work

The observer source lives in a separate private repo `JonB32/urateam-quality-observer`:
- PR #1 (v0.1.1): error-pattern catalog + run-patterns DB scanner
- PR #3 (v0.2.0): log-scanner observer
- Hotfixes #2, #4 (v0.1.2, v0.2.1): completed_at column + Docker json-file unwrap
- PR #5 (v0.2.2, in flight): atomic UPSERT race fix

## Test plan

- [ ] CI green on the urateam side
- [ ] On a fresh deploy host: clone both repos as siblings, build + up → both services come up
- [ ] Observer files findings on JonB32/urateam (label urateam-quality-observer) within an hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)