### PR TITLE
chore(release): v0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ notes call out when a change affects only a single package.
 - **BEC-173** ([#191](https://github.com/JonB32/urateam/pull/191)) — `runGhLinearSync` utility + `.github/workflows/gh-linear-sync.yml` hourly cron. Open GitHub issues are scanned and synced as Linear tickets in the Triage state, with idempotency via `<!-- gh-linear-sync:NNN -->` markers. Optional `bidirectionalClose` mode closes GH issues when their Linear counterpart reaches Done. DI for SDK clients keeps the engine testable.
 - **BEC-177** ([#198](https://github.com/JonB32/urateam/pull/198)) — `selectRepoConfig(pipelineLabel, teamId, projectId, repoConfigs)` enables multi-repo PM routing. RepoConfigs can declare a `labelPattern`; tickets matching that label clone the corresponding repo. Backwards compatible — no labelPattern means the existing teamId/projectId key lookup. Wired in at the webhook handler `start` path and the PM scheduler's `start-todo` action.
 
+## [0.1.42] — 2026-05-10
+
+Bumps:
+- `@urateam/core`: 0.1.27 → 0.1.28
+- `@urateam/cli`: 0.1.29 → 0.1.30
+- `@urateam/dashboard`: 0.1.27 → 0.1.28
+- `create-urateam`: 0.1.30 → 0.1.31
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.41] — 2026-05-09
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
-### Added (OSS+)
-- **BEC-173** ([#191](https://github.com/JonB32/urateam/pull/191)) — `runGhLinearSync` utility + `.github/workflows/gh-linear-sync.yml` hourly cron. Open GitHub issues are scanned and synced as Linear tickets in the Triage state, with idempotency via `<!-- gh-linear-sync:NNN -->` markers. Optional `bidirectionalClose` mode closes GH issues when their Linear counterpart reaches Done. DI for SDK clients keeps the engine testable.
-- **BEC-177** ([#198](https://github.com/JonB32/urateam/pull/198)) — `selectRepoConfig(pipelineLabel, teamId, projectId, repoConfigs)` enables multi-repo PM routing. RepoConfigs can declare a `labelPattern`; tickets matching that label clone the corresponding repo. Backwards compatible — no labelPattern means the existing teamId/projectId key lookup. Wired in at the webhook handler `start` path and the PM scheduler's `start-todo` action.
-
 ## [0.1.42] — 2026-05-10
 
 Bumps:
@@ -29,7 +25,9 @@ Bumps:
 - `@urateam/dashboard`: 0.1.27 → 0.1.28
 - `create-urateam`: 0.1.30 → 0.1.31
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Added (OSS+)
+- **BEC-173** ([#191](https://github.com/JonB32/urateam/pull/191)) — `runGhLinearSync` utility + `.github/workflows/gh-linear-sync.yml` hourly cron. Open GitHub issues are scanned and synced as Linear tickets in the Triage state, with idempotency via `<!-- gh-linear-sync:NNN -->` markers. Optional `bidirectionalClose` mode closes GH issues when their Linear counterpart reaches Done. DI for SDK clients keeps the engine testable.
+- **BEC-177** ([#198](https://github.com/JonB32/urateam/pull/198)) — `selectRepoConfig(pipelineLabel, teamId, projectId, repoConfigs)` enables multi-repo PM routing. RepoConfigs can declare a `labelPattern`; tickets matching that label clone the corresponding repo. Backwards compatible — no labelPattern means the existing teamId/projectId key lookup. Wired in at the webhook handler `start` path and the PM scheduler's `start-todo` action.
 ## [0.1.41] — 2026-05-09
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.27
-ARG URATEAM_CLI_VERSION=0.1.29
-ARG URATEAM_DASHBOARD_VERSION=0.1.27
+ARG URATEAM_CORE_VERSION=0.1.28
+ARG URATEAM_CLI_VERSION=0.1.30
+ARG URATEAM_DASHBOARD_VERSION=0.1.28
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.27
-        URATEAM_CLI_VERSION: 0.1.29
-        URATEAM_DASHBOARD_VERSION: 0.1.27
+        URATEAM_CORE_VERSION: 0.1.28
+        URATEAM_CLI_VERSION: 0.1.30
+        URATEAM_DASHBOARD_VERSION: 0.1.28
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.