### PR TITLE
fix(dashboard): retry endpoint uses HX-Redirect for HTMX submits

### DIFF
--- a/packages/dashboard/src/__tests__/retry-route.test.ts
+++ b/packages/dashboard/src/__tests__/retry-route.test.ts
@@ -147,6 +147,26 @@ describe("POST /runs/:id/retry", () => {
       });
       expect(res.status).toBe(404);
     });
+
+    it("HX-Request header → 200 with HX-Redirect, not a 302 (so HTMX does full-page nav instead of swapping into the open dialog)", async () => {
+      await db
+        .update(pipelineRuns)
+        .set({ resumePayload: JSON.stringify({ stageIndex: 1 }) })
+        .where(eq(pipelineRuns.id, "run_1"));
+      const runner = {
+        resume: vi.fn().mockResolvedValue(undefined),
+        start: vi.fn(),
+      };
+      const app = appWith("operator", runner);
+      const res = await app.request("/runs/run_1/retry", {
+        method: "POST",
+        headers: { "HX-Request": "true" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("HX-Redirect")).toBe("/runs/run_1");
+      expect(res.headers.get("Location")).toBeNull();
+      expect(runner.resume).toHaveBeenCalledWith("run_1");
+    });
   });
 });
 

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -193,7 +193,17 @@ export function createRunsRouter(
           }),
         );
       }
-      return c.redirect(`${effectiveBasePath}/runs/${id}`, 302);
+      // HTMX-driven submits (the real user path — CSRF requires HX-Request)
+      // need HX-Redirect for a full-page navigation. A plain 302 makes HTMX
+      // follow the redirect via XHR and swap the response into the originating
+      // form, leaving the <dialog> open with the run-detail page rendered
+      // inside the dialog's <form>.
+      const target = `${effectiveBasePath}/runs/${id}`;
+      if (c.req.header("HX-Request")) {
+        c.header("HX-Redirect", target);
+        return c.body(null, 200);
+      }
+      return c.redirect(target, 302);
     },
   );
 


### PR DESCRIPTION
## Summary

The dashboard "Confirm retry" button in the run-detail dialog is broken end-to-end: clicking it doesn't navigate, the dialog stays open, and the page appears to do nothing useful.

## Root cause

The retry POST handler in \`packages/dashboard/src/routes/runs.ts\` returned \`c.redirect(302)\` to \`/runs/:id\`. The user-facing path is HTMX-driven:

1. Form has \`hx-post\` + \`hx-headers='{\"HX-Request\":\"true\"}'\` — required because the dashboard's CSRF middleware rejects POSTs without \`HX-Request\`.
2. HTMX intercepts the submit, POSTs the retry, gets a \`302 Location: /runs/:id\`.
3. HTMX follows redirects **via XHR**, not as a browser navigation. It fetches \`/runs/:id\`, gets the full HTML page, and swaps it into the form's \`innerHTML\` (the form is the implicit target).
4. The form lives inside an open \`<dialog>\` — so the dialog stays modal and the run-detail page renders compressed inside the form's \`<button>Confirm retry</button>\` slot.

## Fix

When \`HX-Request\` header is present, return \`HX-Redirect: <url>\` + 200. HTMX treats this as a full-page navigation. Plain 302 retained for non-HTMX callers (curl, scripts).

\`\`\`ts
const target = \`\${effectiveBasePath}/runs/\${id}\`;
if (c.req.header(\"HX-Request\")) {
  c.header(\"HX-Redirect\", target);
  return c.body(null, 200);
}
return c.redirect(target, 302);
\`\`\`

## Test plan

- [x] New test: HX-Request → 200 + HX-Redirect header, no Location, runner still called
- [x] Existing tests still pass (10 total in retry-route.test.ts; the legacy 302-checking ones validate the non-HTMX fallback path)
- [x] \`pnpm --filter @urateam/dashboard test\`

## Note

Audited the layout's logout button (\`hx-post=/auth/logout hx-swap=\"none\" hx-push-url=\"true\"\`) for the same pattern — that one uses \`hx-swap=\"none\"\` to suppress the bad swap, so it's broken differently (URL pushes but page doesn't navigate until next click). Out of scope for this fix; logging-out worked well enough that nobody complained. Filed as a follow-up.