### PR TITLE
chore(release): v0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ notes call out when a change affects only a single package.
 ### Added (OSS+)
 - **PR change-summary comment for review-feedback runs** — after a successful PR-trigger pipeline run (review-feedback `runType`), the bot posts a "🤖 Addressed PR feedback" comment with the HandoffArtifact summary, per-comment responses linking each triggering PR review comment to what was changed for it, files modified, and a run-link footer. Always-on (no env flag) — a review-feedback run only exists because a human asked for changes. Renderer falls back gracefully when the agent does not populate `context.addressedComments`. Best-effort posting — `addPRComment` failures log at level 40 and never fail pipeline completion. Run link respects `URATEAM_DASHBOARD_URL` (omits the link when unset).
 
+## [0.1.44] — 2026-05-11
+
+Bumps:
+- `@urateam/core`: 0.1.29 → 0.1.30
+- `@urateam/cli`: 0.1.31 → 0.1.32
+- `@urateam/dashboard`: 0.1.29 → 0.1.30
+- `create-urateam`: 0.1.32 → 0.1.33
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.43] — 2026-05-10
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
-### Added (OSS+)
-- **PR change-summary comment for review-feedback runs** — after a successful PR-trigger pipeline run (review-feedback `runType`), the bot posts a "🤖 Addressed PR feedback" comment with the HandoffArtifact summary, per-comment responses linking each triggering PR review comment to what was changed for it, files modified, and a run-link footer. Always-on (no env flag) — a review-feedback run only exists because a human asked for changes. Renderer falls back gracefully when the agent does not populate `context.addressedComments`. Best-effort posting — `addPRComment` failures log at level 40 and never fail pipeline completion. Run link respects `URATEAM_DASHBOARD_URL` (omits the link when unset).
-
 ## [0.1.44] — 2026-05-11
 
 Bumps:
@@ -28,7 +25,8 @@ Bumps:
 - `@urateam/dashboard`: 0.1.29 → 0.1.30
 - `create-urateam`: 0.1.32 → 0.1.33
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Added (OSS+)
+- **PR change-summary comment for review-feedback runs** ([#243](https://github.com/JonB32/urateam/pull/243)) — after a successful PR-trigger pipeline run (`runType: "review-feedback"`), the bot posts a "🤖 Addressed PR feedback" comment with the HandoffArtifact summary, per-comment responses linking each triggering PR review comment to what was changed for it, files modified, and a run-link footer. Always-on (no env flag) — a review-feedback run only exists because a human asked for changes. Renderer falls back gracefully when the agent does not populate `context.addressedComments`. Best-effort posting — `addPRComment` failures log at level 40 and never fail pipeline completion. Run link respects `URATEAM_DASHBOARD_URL` (omits the link when unset). Extends `HandoffArtifact.context` schema with optional `addressedComments: { commentId, response }[]`; adds optional `htmlUrl` to `ReviewFeedbackComment`; updates the review-feedback implement-stage prompt to require agent-emitted per-comment responses.
 ## [0.1.43] — 2026-05-10
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.29
-ARG URATEAM_CLI_VERSION=0.1.31
-ARG URATEAM_DASHBOARD_VERSION=0.1.29
+ARG URATEAM_CORE_VERSION=0.1.30
+ARG URATEAM_CLI_VERSION=0.1.32
+ARG URATEAM_DASHBOARD_VERSION=0.1.30
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.29
-        URATEAM_CLI_VERSION: 0.1.31
-        URATEAM_DASHBOARD_VERSION: 0.1.29
+        URATEAM_CORE_VERSION: 0.1.30
+        URATEAM_CLI_VERSION: 0.1.32
+        URATEAM_DASHBOARD_VERSION: 0.1.30
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.