### PR TITLE
fix(openrouter): defend against missing choices in 200 OK responses

### DIFF
--- a/packages/core/src/__tests__/openrouter-client.test.ts
+++ b/packages/core/src/__tests__/openrouter-client.test.ts
@@ -58,6 +58,62 @@ describe("OpenRouterClient", () => {
     ).rejects.toThrow(/openrouter 429/);
   });
 
+  it("throws a meaningful error when response is 200 OK but choices is missing", async () => {
+    // Free-tier / community models on OpenRouter sometimes return 200 OK with
+    // an error body and no `choices` field. Without defensive parsing, the
+    // client crashes with "Cannot read properties of undefined (reading '0')"
+    // and the fanout surfaces that opaque JS error on the PR comment.
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { message: "Rate limit exceeded for this free model", code: 429 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    await expect(
+      client.chatCompletion(
+        "nvidia/nemotron-3-super-120b-a12b:free",
+        [{ role: "user", content: "x" }],
+        { signal: new AbortController().signal },
+      ),
+    ).rejects.toThrow(/missing choices.*Rate limit exceeded/);
+  });
+
+  it("throws a meaningful error when response has empty choices array", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ choices: [], usage: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    await expect(
+      client.chatCompletion("m", [{ role: "user", content: "x" }], {
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/missing choices/);
+  });
+
+  it("falls back to a generic provider-error message when error.message is absent", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ something_else: "no choices, no error field" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { OpenRouterClient } = await import("../executor/review/openrouter-client.js");
+    const client = new OpenRouterClient({ apiKey: "k", baseUrl: "https://example.test/api/v1" });
+    await expect(
+      client.chatCompletion("m", [{ role: "user", content: "x" }], {
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/no error message in response body/);
+  });
+
   it("propagates AbortController abort as a rejection", async () => {
     const ac = new AbortController();
     fetchMock.mockImplementation((_url, init: RequestInit) => {

--- a/packages/core/src/executor/review/openrouter-client.ts
+++ b/packages/core/src/executor/review/openrouter-client.ts
@@ -46,10 +46,21 @@ export class OpenRouterClient {
       const body = await res.text();
       throw new Error(`openrouter ${res.status} ${body.slice(0, 200)}`);
     }
+    // Some providers (notably free-tier / community models) return 200 OK with
+    // an error body and no `choices` field. Treat missing/empty choices as a
+    // failure with a meaningful message instead of letting `json.choices[0]`
+    // throw "Cannot read properties of undefined (reading '0')".
     const json = (await res.json()) as {
-      choices: Array<{ message: { content: string } }>;
-      usage: { prompt_tokens: number; completion_tokens: number };
+      choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+      error?: { message?: string; code?: string | number };
     };
+    if (!Array.isArray(json.choices) || json.choices.length === 0) {
+      const providerErr = json.error?.message ?? "no error message in response body";
+      throw new Error(
+        `openrouter response missing choices — provider returned 200 OK but no completion: ${providerErr}`,
+      );
+    }
     return {
       content: json.choices[0]?.message?.content ?? "",
       inputTokens: json.usage?.prompt_tokens ?? 0,


### PR DESCRIPTION
## Summary

Operator-reported error from the review fanout:
\`\`\`
Review by nvidia/nemotron-3-super-120b-a12b:free (via OpenRouter)
Status: failed · Cannot read properties of undefined (reading '0')
\`\`\`

## Root cause

\`packages/core/src/executor/review/openrouter-client.ts:54\`:
\`\`\`ts
content: json.choices[0]?.message?.content ?? "",
\`\`\`

Optional chaining is on \`[0]?.message\` but **not on \`choices\` itself**. The TypeScript declaration typed \`choices\` as non-optional, masking the runtime reality. Free-tier / community providers (nemotron in this case) sometimes return 200 OK with an error body and no \`choices\` field. Accessing \`json.choices[0]\` then throws TypeError: \`Cannot read properties of undefined (reading '0')\`.

The fanout catches the throw and surfaces it as a failed-status PR comment, but the opaque JS error gives the operator nothing actionable.

## Fix

Type \`choices\` and \`usage\` as optional, check \`Array.isArray(json.choices)\` + length, and throw a meaningful error message that includes the provider's \`error.message\` when present.

Before:
\`\`\`
Status: failed · Cannot read properties of undefined (reading '0')
\`\`\`

After:
\`\`\`
Status: failed · openrouter response missing choices — provider returned 200 OK but no completion: Rate limit exceeded for this free model
\`\`\`

## Test plan

- [x] 3 new regression tests:
  - 200 OK + \`error.message\` field → throws with provider message included
  - 200 OK + empty choices array → throws with "missing choices"
  - 200 OK + no error field at all → throws with fallback "no error message in response body"
- [x] Existing 3 tests still pass (happy path, non-2xx, abort propagation)
- [x] \`pnpm --filter @urateam/core build\` clean

## Out of scope

- Improving fanout-level retry on provider errors (currently a single attempt; could retry on transient errors with exponential backoff — separate ticket if useful)
- Pre-flight validation of model availability (BEC-171 does this for catalog presence; doesn't catch quota / rate-limit state)