### PR TITLE
chore(release): v0.1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ notes call out when a change affects only a single package.
 ### Fixed (OSS+)
 - **BEC-185** — `gh-linear-sync`: multi-label `labelFilters` now use OR semantics. Previously, all labels were joined into a single comma-separated string and passed to the GitHub REST API, which treats this as AND (intersection) — so `["bug", "enhancement"]` returned only issues carrying *both* labels (zero in practice). Fix: when `labelFilters` has more than one entry, `runGhLinearSync` calls `listIssues` once per label and unions the results, deduplicating by issue number. Single-label and empty filters are unchanged.
 
+## [0.1.45] — 2026-05-11
+
+Bumps:
+- `@urateam/core`: 0.1.30 → 0.1.31
+- `@urateam/cli`: 0.1.32 → 0.1.33
+- `@urateam/dashboard`: 0.1.30 → 0.1.31
+- `create-urateam`: 0.1.33 → 0.1.34
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.44] — 2026-05-11
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
-### Fixed (OSS+)
-- **BEC-185** — `gh-linear-sync`: multi-label `labelFilters` now use OR semantics. Previously, all labels were joined into a single comma-separated string and passed to the GitHub REST API, which treats this as AND (intersection) — so `["bug", "enhancement"]` returned only issues carrying *both* labels (zero in practice). Fix: when `labelFilters` has more than one entry, `runGhLinearSync` calls `listIssues` once per label and unions the results, deduplicating by issue number. Single-label and empty filters are unchanged.
-
 ## [0.1.45] — 2026-05-11
 
 Bumps:
@@ -27,6 +24,14 @@ Bumps:
 - `@urateam/cli`: 0.1.32 → 0.1.33
 - `@urateam/dashboard`: 0.1.30 → 0.1.31
 - `create-urateam`: 0.1.33 → 0.1.34
+
+### Fixed (OSS+)
+- **OpenRouter fanout: defend against missing `choices` in 200 OK responses** ([#249](https://github.com/JonB32/urateam/pull/249)) — free-tier and community providers (observed: `nvidia/nemotron-3-super-120b-a12b:free`) sometimes return 200 OK with an error body and no `choices` field. The client's optional chaining only protected `[0]?.message` but not `choices` itself, so accessing `json.choices[0]` threw `TypeError: Cannot read properties of undefined (reading '0')`. The fanout caught it but surfaced the opaque JS error on the per-model PR comment. Now defensively validates `choices` is a non-empty array and throws a meaningful error including the provider's `error.message` when present.
+- **BEC-185** ([#247](https://github.com/JonB32/urateam/pull/247)) — `gh-linear-sync`: multi-label `labelFilters` now use OR semantics. Previously, all labels were joined into a single comma-separated string and passed to the GitHub REST API, which treats this as AND (intersection) — so `["bug", "enhancement"]` returned only issues carrying *both* labels (zero in practice). Fix: when `labelFilters` has more than one entry, `runGhLinearSync` calls `listIssues` once per label and unions the results, deduplicating by issue number. Single-label and empty filters are unchanged.
+
+### Docs (OSS+)
+- **`deploy/CLAUDE_AUTH.md`** ([#248](https://github.com/JonB32/urateam/pull/248)) — new guide covering the three Claude auth paths (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token`, and the local CLI session) with a recommendation matrix. Surfaces the long-lived programmatic OAuth token flow that we weren't previously documenting.
+- **CLAUDE.md additions** — new Claude Authentication subsection + new "Codebase Optimization Pass — In Flight" section enumerating BEC-187..207 and listing known limitations contributors should not compound.
 
 <!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.44] — 2026-05-11

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.30
-ARG URATEAM_CLI_VERSION=0.1.32
-ARG URATEAM_DASHBOARD_VERSION=0.1.30
+ARG URATEAM_CORE_VERSION=0.1.31
+ARG URATEAM_CLI_VERSION=0.1.33
+ARG URATEAM_DASHBOARD_VERSION=0.1.31
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.30
-        URATEAM_CLI_VERSION: 0.1.32
-        URATEAM_DASHBOARD_VERSION: 0.1.30
+        URATEAM_CORE_VERSION: 0.1.31
+        URATEAM_CLI_VERSION: 0.1.33
+        URATEAM_DASHBOARD_VERSION: 0.1.31
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.