### PR TITLE
feat: Quality Observer triage gate + operator stop & container halt

### DIFF
--- a/.env.dogfood.example
+++ b/.env.dogfood.example
@@ -130,6 +130,13 @@ REVIEW_MODELS=anthropic/claude-3.5-sonnet,openai/gpt-4o,google/gemini-2.5-pro
 # === Logging ===
 # LOG_LEVEL=info
 
+# === Operator stop/halt controls (see deploy/STOP_AND_HALT.md) ===
+# Shared secret for the CLI control plane. The dashboard exposes /cli/* routes
+# guarded by this token so `ura stop <runId>` / `ura halt` can reach the live
+# runner from `docker exec`. When unset, /cli/* routes return 404 (CLI control
+# is opt-in). Pick a long random string; rotate when an operator leaves.
+# URATEAM_CLI_TOKEN=
+
 # === Notes ===
 # - URATEAM_QUALITY_OBSERVER_ENABLED is NOT consumed by the urateam product.
 #   BEC-137 Quality Observer runs out-of-process from a separate private repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,17 @@ Known limitations being addressed (don't compound these):
 - Guardrails: `setUserRole` wraps SELECT+COUNT+UPDATE in a transaction (SQLite `BEGIN IMMEDIATE`; Postgres `db.transaction()`) to prevent the TOCTOU race on last-admin demotion
 - Setup doc: `deploy/RBAC_SETUP.md`
 
+### Operator stop & container halt (`packages/core/src/pipeline/control-signals.ts`)
+- **Single-run stop** (`requestStop(runId, mode)`): two modes — `"cancel"` aborts the active Agent SDK stream via an `AbortController` wired into `consumeAgentStream`; `"graceful"` lets the current stage finish, then the runner skips remaining stages at the per-stage signal check at the top of the stage loop. Both land the run in `status: "cancelled"` (distinct from `"aborted"` which is reserved for system-initiated aborts).
+- **Container halt** (`PipelineRunner.haltAll()`): sets `setPmPaused(true)` (same flag as BEC-170 / Slack `/pm pause`) AND sends `cancel` to every entry in `activeRuns` + `activeFeedbackRuns`. Reversible via `/pm resume` (in-flight cancellations themselves stay cancelled).
+- **Three surfaces**, all funnel through `Runner.requestStop` / `Runner.haltAll`:
+  - **Dashboard**: `POST /runs/:id/cancel`, `POST /runs/:id/stop`, `POST /admin/halt-all` — RBAC-gated (`runs.stop`, `system.halt`), CSRF-protected via `HX-Request` header. Buttons in the run-detail meta card. Routes 404 when RBAC is unlicensed.
+  - **CLI**: `ura stop <runId> [--graceful]`, `ura halt` — POST to `/cli/runs/:id/{cancel,stop}` and `/cli/halt-all`. Auth: `URATEAM_CLI_TOKEN` shared secret in `X-Ura-Cli-Token`; routes 404 when the env var is unset. Works regardless of RBAC license.
+  - **Slack**: `/pm cancel <runId>`, `/pm stop <runId>`, `/pm halt`. Reacts with 🤔 on receipt of an app_mention / message; swaps to ✅ / ⚠️ on completion. Slash commands return an immediate ephemeral "Working on it…" and post the real reply via `response_url` so slow commands don't trip Slack's 3s timeout.
+- **Audit events**: `run.cancelled` per stopped run (`mode`, `actor`, `actorType`), and `system.halted` for halt-all (`cancelledRunIds`, `cancelledCount`). `actorType` distinguishes `dashboard-user` / `cli` / `slack`.
+- **Single-process state caveat**: signal map lives in memory; resets on container restart. Cross-container coordination (Redis) intentionally out of scope.
+- Setup doc: `deploy/STOP_AND_HALT.md`.
+
 ### Coordination (`packages/core/src/pm/coordination.ts`)
 - DB-backed `active_work` table tracks files modified by in-flight pipeline runs
 - `upsertActiveWork` uses atomic `onConflictDoUpdate` (requires UNIQUE on `run_id`)
@@ -291,6 +302,8 @@ Known limitations being addressed (don't compound these):
 - `QUALITY_OBSERVER_FIRST_TICK_FILE=true` env var bypasses seeding and files normally on first tick (CI / deliberate-reset use case). Also configurable programmatically via `ObserverSchedulerDeps.firstTickFile`.
 - SQLite tables: `observer_findings` (fingerprint + timestamp), `observer_meta` (key/value, stores `firstTickAt`)
 - `createObserverScheduler(deps)` accepts pluggable `computeFindings` and `fileGithubIssue` functions — the observers package does not depend on `@urateam/core`.
+- **PM Agent observer-origin gate:** Every GitHub issue filed by the quality observer embeds `<!-- urateam-qo-observer: <id> -->` in the body. `gh-linear-sync` copies the body verbatim into the Linear ticket description, so the marker survives the sync (the GH `urateam-quality-observer` label does NOT — gh-linear-sync drops labels). `triageNewIssues` in `pm/actions/triage.ts` short-circuits when it sees this marker: skips the Claude classifier, assigns the `needs-design` pipeline label, moves the ticket to Backlog with priority 3, and posts an explanatory comment. The `needs-design` pipeline runs `triage` → `await-approval` → ..., so the issue surfaces but blocks for human approval before any implement-stage tokens are spent. Rationale: observer findings ("Pipeline X deep-review loop hit Y turns", etc.) are diagnostic signals about past runs, not actionable coding tasks; auto-implementing them burns tokens with no useful outcome.
+- **Linear label requirement for the gate:** the operator's Linear workspace must have a label named `needs-design`. If absent, the gate still moves the ticket to Backlog but logs a warning and the promote step won't route it (no pipeline label resolved).
 
 ## Conventions
 - Use `execFile` (never `exec`) for shell commands

--- a/deploy/STOP_AND_HALT.md
+++ b/deploy/STOP_AND_HALT.md
@@ -1,0 +1,76 @@
+# Stop and halt runbook
+
+Operator emergency controls for stopping individual pipeline runs and
+container-wide halting. Three surfaces — dashboard, Slack, and CLI — all funnel
+through the same in-process signal map and emit the same audit events.
+
+## Scope
+
+| Action | What it does | Reversible? | Tokens lost |
+|---|---|---|---|
+| **Cancel a run** | Aborts the active Agent SDK stream mid-stage. Pipeline exits with `status: "cancelled"`; no PR. | The cancelled run stays cancelled. Use the retry button to start fresh. | Yes — current stage's tokens. |
+| **Graceful stop a run** | Lets the current stage finish, then skips remaining stages. No PR. | Same as cancel. | No additional — current stage's work completes. |
+| **Halt all** | Pauses the PM Agent (no new runs promoted/started) **and** sends `cancel` to every active pipeline + feedback run. | Reversible: `/pm resume` (or dashboard equivalent). Cancelled runs stay cancelled. | Yes — every in-flight stage's tokens. |
+
+`cancel` is for incident response (something is burning budget, ship a stop NOW). `graceful` is the polite version. `halt` is the big red button.
+
+## Surfaces
+
+### Dashboard
+
+Run detail page (`/runs/:id`):
+- **Stop…** button (operator+admin) opens a confirm dialog with two actions: *Graceful stop* and *Cancel immediately*.
+- **Halt all…** button (top-right of the meta block) opens a confirm dialog explaining the consequences before firing.
+
+Both routes are RBAC-gated (`runs.stop`, `system.halt`) and CSRF-protected via the standard `HX-Request` header. Routes return 404 when RBAC is unlicensed.
+
+### Slack
+
+In the PM channel or any DM with the bot:
+
+```
+/pm cancel <runId>        # interrupt the active stage immediately
+/pm stop <runId>          # let the current stage finish, then quit
+/pm halt                  # pause PM + cancel every in-flight run
+/pm resume                # unpause PM (does not un-cancel any cancelled runs)
+```
+
+Natural-language variants are supported via the Haiku classifier — "kill run X", "halt everything", "emergency stop", etc.
+
+On receipt the bot reacts with 🤔 (`:thinking_face:`) and swaps to ✅ on success / ⚠️ on failure once processing finishes. Slash commands get an immediate ephemeral "Working on it…" reply followed by the real result via `response_url`.
+
+### CLI
+
+```sh
+ura stop <runId>             # cancel mid-stream (default)
+ura stop <runId> --graceful  # let the current stage finish
+ura halt                     # pause PM + cancel all active runs
+```
+
+Setup:
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `URATEAM_CLI_TOKEN` | Shared secret matching the value set in the urateam container's environment. The dashboard's `/cli/*` routes 404 when this is unset, so CLI control is opt-in. | (unset → CLI disabled) |
+| `URATEAM_DASHBOARD_URL` | Dashboard URL the CLI POSTs to. | `http://localhost:3001` |
+
+The CLI uses HTTP (not the DB) so the signal reaches the runner's in-process map immediately. `docker exec urateam-dogfood ura halt` works because the CLI binary inside the container reaches the dashboard on `localhost:3001`.
+
+The CLI auth surface is intentionally separate from dashboard SSO/basic-auth: the same `/cli/*` endpoints are accessible whether RBAC is licensed or not, as long as the token matches.
+
+## Audit trail
+
+All three surfaces emit:
+
+- `run.cancelled` per stopped run: `{ runId, issueId, mode: "cancel" | "graceful", actor, actorType }`.
+- `system.halted` for halt-all: `{ actor, cancelledRunIds, cancelledCount }`. The per-run `run.cancelled` events are emitted in addition, each with `reason: "system.halt"`.
+
+`actorType` is one of `dashboard-user`, `cli`, `slack`. `actor` carries identifying detail (email for dashboard, OS username for CLI, Slack user id for Slack). Browse via the audit dashboard (`/audit`) or `audit_events` table.
+
+## Implementation notes
+
+- **In-memory signal map.** State lives in `packages/core/src/pipeline/control-signals.ts`. Single-process — matches the BEC-170 PM pause caveat. Cross-container coordination via Redis is out of scope.
+- **Cancel vs graceful semantics.** Cancel wires an `AbortController` into `consumeAgentStream`; the iterator's `.return()` fires and the executor throws `StageCancelledError`. Graceful polls the signal between stages so the running stage isn't interrupted.
+- **Run state transitions.** Cancelled runs land in `status: "cancelled"` (distinct from `"aborted"`, which is reserved for system-initiated aborts like token-budget violations).
+- **PM pause integration.** `haltAll()` sets the same `pmPaused` flag that the Slack `/pm pause` command uses (`setPmPaused(true)`). Unpause via `/pm resume`.
+- **Idempotency.** Repeated `requestStop` calls are no-ops; `cancel` after `graceful` upgrades; `graceful` after `cancel` is ignored.

--- a/packages/cli/src/commands/control.ts
+++ b/packages/cli/src/commands/control.ts
@@ -1,0 +1,133 @@
+/**
+ * `ura stop` / `ura halt` — operator emergency controls that talk to a
+ * running urateam container via its /cli/* HTTP endpoints.
+ *
+ * Why HTTP rather than direct DB writes: the stop/halt signal lives in the
+ * runner's in-memory map (single-process, BEC-170-style). A separate CLI
+ * process can't reach it via DB without a polling layer; HTTP to the live
+ * server is simpler and immediate.
+ *
+ * Auth: the CLI passes `X-Ura-Cli-Token: $URATEAM_CLI_TOKEN`; the server's
+ * `/cli/*` routes 404 when the env var is unset and 403 on token mismatch.
+ * Audit events record the OS user from `os.userInfo().username` as the
+ * actor.
+ */
+import { Command } from "commander";
+import * as os from "node:os";
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+
+function resolveDashboardUrl(override?: string): string {
+  const raw =
+    override ??
+    process.env.URATEAM_DASHBOARD_URL ??
+    "http://localhost:3001";
+  return raw.replace(/\/+$/, "");
+}
+
+function resolveToken(): string {
+  const token = process.env.URATEAM_CLI_TOKEN;
+  if (!token) {
+    fail(
+      "URATEAM_CLI_TOKEN is not set. Set it in the same environment as the " +
+        "urateam container (matches `URATEAM_CLI_TOKEN` in .env) and re-run.",
+    );
+  }
+  return token;
+}
+
+function actor(): string {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return "unknown";
+  }
+}
+
+async function controlPost(
+  url: string,
+  token: string,
+): Promise<{ ok: boolean; status: number; body: string }> {
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "x-ura-cli-token": token,
+        "x-ura-actor": actor(),
+      },
+    });
+  } catch (err) {
+    fail(
+      `Failed to reach ${url}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  const body = await resp.text();
+  return { ok: resp.ok, status: resp.status, body };
+}
+
+export const stopCommand = new Command("stop")
+  .description(
+    "Stop a single in-flight pipeline run. Defaults to immediate cancel; pass --graceful to let the current stage finish.",
+  )
+  .argument("<run-id>", "Pipeline run id (UUID) to stop")
+  .option(
+    "--graceful",
+    "Let the current stage finish, then skip remaining stages. Slower but leaves the worktree consistent.",
+    false,
+  )
+  .option(
+    "--url <url>",
+    "Dashboard URL (default: $URATEAM_DASHBOARD_URL or http://localhost:3001)",
+  )
+  .action(
+    async (
+      runId: string,
+      opts: { graceful?: boolean; url?: string },
+    ) => {
+      const base = resolveDashboardUrl(opts.url);
+      const token = resolveToken();
+      const path = opts.graceful ? "stop" : "cancel";
+      const url = `${base}/cli/runs/${encodeURIComponent(runId)}/${path}`;
+      const { ok, status, body } = await controlPost(url, token);
+      if (!ok) fail(`HTTP ${status}: ${body}`);
+      console.log(
+        opts.graceful
+          ? `Graceful stop requested for run ${runId}.`
+          : `Cancel signal sent to run ${runId}. The active stage will abort within a few seconds.`,
+      );
+    },
+  );
+
+export const haltCommand = new Command("halt")
+  .description(
+    "Halt the entire container: pause the PM Agent (no new runs) AND cancel every in-flight pipeline. Reversible via Slack `/pm resume`.",
+  )
+  .option(
+    "--url <url>",
+    "Dashboard URL (default: $URATEAM_DASHBOARD_URL or http://localhost:3001)",
+  )
+  .action(async (opts: { url?: string }) => {
+    const base = resolveDashboardUrl(opts.url);
+    const token = resolveToken();
+    const { ok, status, body } = await controlPost(
+      `${base}/cli/halt-all`,
+      token,
+    );
+    if (!ok) fail(`HTTP ${status}: ${body}`);
+    try {
+      const parsed = JSON.parse(body) as { cancelledRunIds: string[] };
+      console.log(
+        `Halted. PM Agent paused; cancelled ${parsed.cancelledRunIds.length} active run(s).`,
+      );
+      for (const id of parsed.cancelledRunIds) console.log(`  - ${id}`);
+    } catch {
+      console.log(body);
+    }
+    console.log(`\nUnpause the PM Agent with Slack \`/pm resume\` when ready.`);
+  });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -277,6 +277,12 @@ export const startCommand = new Command("start")
       auth: dashboardAuth,
       sso: ssoBootstrap?.sso,
       workos: ssoBootstrap?.workos,
+      runner: {
+        resume: runner.resume.bind(runner),
+        start: runner.start.bind(runner) as (...args: any[]) => Promise<void>,
+        requestStop: runner.requestStop.bind(runner),
+        haltAll: runner.haltAll.bind(runner),
+      },
     });
     if (ssoBootstrap) {
       console.log(`SSO: enabled (WorkOS client ${ssoBootstrap.sso.workosClientId})`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import { migrateCommand } from "./commands/migrate.js";
 import { getPackageVersion } from "./version.js";
 import { licenseCommand } from "./commands/license.js";
 import { adminCommand } from "./commands/admin.js";
+import { stopCommand, haltCommand } from "./commands/control.js";
 
 const program = new Command();
 
@@ -44,5 +45,7 @@ program.addCommand(startCommand);
 program.addCommand(migrateCommand);
 program.addCommand(licenseCommand, { hidden: true });
 program.addCommand(adminCommand);
+program.addCommand(stopCommand);
+program.addCommand(haltCommand);
 
 program.parse();

--- a/packages/core/src/__tests__/agent-stream.test.ts
+++ b/packages/core/src/__tests__/agent-stream.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { consumeAgentStream, StageStalledError } from "../executor/agent-stream.js";
+import {
+  consumeAgentStream,
+  StageStalledError,
+  StageCancelledError,
+} from "../executor/agent-stream.js";
 
 async function* fromArray(items: Array<unknown>): AsyncIterable<unknown> {
   for (const item of items) yield item;
@@ -97,5 +101,46 @@ describe("consumeAgentStream — stall watchdog (urateam#122)", () => {
     await expect(
       consumeAgentStream(zombieStream(), { progressTimeoutMs: 200 }),
     ).rejects.toBeInstanceOf(StageStalledError);
+  });
+});
+
+describe("consumeAgentStream — operator abort", () => {
+  it("throws StageCancelledError when the AbortController fires mid-stream", async () => {
+    const controller = new AbortController();
+    // Stream that emits one message, then waits forever. The abort below fires
+    // while the second .next() is pending so we hit the abort branch of the
+    // race instead of the stall branch.
+    async function* slow(): AsyncIterable<unknown> {
+      yield { type: "assistant", content: [{ type: "text", text: "first" }], usage: { output_tokens: 5 } };
+      await new Promise(() => {});
+    }
+    setTimeout(() => controller.abort(), 50);
+    await expect(
+      consumeAgentStream(slow(), {
+        abortSignal: controller.signal,
+        progressTimeoutMs: 60_000,
+      }),
+    ).rejects.toBeInstanceOf(StageCancelledError);
+  });
+
+  it("throws StageCancelledError immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    async function* never(): AsyncIterable<unknown> {
+      await new Promise(() => {});
+    }
+    await expect(
+      consumeAgentStream(never(), { abortSignal: controller.signal }),
+    ).rejects.toBeInstanceOf(StageCancelledError);
+  });
+
+  it("ignores the abort signal once the stream completes normally", async () => {
+    const controller = new AbortController();
+    async function* fast(): AsyncIterable<unknown> {
+      yield { type: "assistant", content: [{ type: "text", text: "done" }], usage: { output_tokens: 5 } };
+    }
+    const result = await consumeAgentStream(fast(), { abortSignal: controller.signal });
+    controller.abort(); // post-hoc, should not throw or matter
+    expect(result.lastText).toBe("done");
   });
 });

--- a/packages/core/src/__tests__/control-signals.test.ts
+++ b/packages/core/src/__tests__/control-signals.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  requestStop,
+  getStopSignal,
+  clearStopSignal,
+  onStop,
+  _clearAllSignals,
+} from "../pipeline/control-signals.js";
+
+describe("control-signals", () => {
+  beforeEach(() => _clearAllSignals());
+
+  it("records and retrieves a graceful signal", () => {
+    requestStop("run-1", "graceful");
+    expect(getStopSignal("run-1")).toBe("graceful");
+  });
+
+  it("records and retrieves a cancel signal", () => {
+    requestStop("run-2", "cancel");
+    expect(getStopSignal("run-2")).toBe("cancel");
+  });
+
+  it("upgrades graceful → cancel", () => {
+    requestStop("run-3", "graceful");
+    requestStop("run-3", "cancel");
+    expect(getStopSignal("run-3")).toBe("cancel");
+  });
+
+  it("never downgrades cancel → graceful", () => {
+    requestStop("run-4", "cancel");
+    requestStop("run-4", "graceful");
+    expect(getStopSignal("run-4")).toBe("cancel");
+  });
+
+  it("clearStopSignal removes the signal", () => {
+    requestStop("run-5", "cancel");
+    clearStopSignal("run-5");
+    expect(getStopSignal("run-5")).toBeUndefined();
+  });
+
+  it("onStop fires when a cancel signal is recorded", () => {
+    let fired = false;
+    onStop("run-6", () => {
+      fired = true;
+    });
+    requestStop("run-6", "cancel");
+    expect(fired).toBe(true);
+  });
+
+  it("onStop does NOT fire on a graceful signal", () => {
+    let fired = false;
+    onStop("run-7", () => {
+      fired = true;
+    });
+    requestStop("run-7", "graceful");
+    expect(fired).toBe(false);
+  });
+
+  it("onStop fires synchronously when a cancel signal is already pending", () => {
+    requestStop("run-8", "cancel");
+    let fired = false;
+    onStop("run-8", () => {
+      fired = true;
+    });
+    expect(fired).toBe(true);
+  });
+
+  it("unsubscribe stops further callbacks", () => {
+    const calls: number[] = [];
+    const unsubscribe = onStop("run-9", () => calls.push(1));
+    unsubscribe();
+    requestStop("run-9", "cancel");
+    expect(calls).toEqual([]);
+  });
+
+  it("scopes signals per run id", () => {
+    requestStop("run-a", "cancel");
+    requestStop("run-b", "graceful");
+    expect(getStopSignal("run-a")).toBe("cancel");
+    expect(getStopSignal("run-b")).toBe("graceful");
+    expect(getStopSignal("run-c")).toBeUndefined();
+  });
+
+  it("listener exception does not break other listeners", () => {
+    const calls: string[] = [];
+    onStop("run-d", () => {
+      calls.push("a");
+      throw new Error("boom");
+    });
+    onStop("run-d", () => calls.push("b"));
+    requestStop("run-d", "cancel");
+    expect(calls).toEqual(["a", "b"]);
+  });
+});

--- a/packages/core/src/__tests__/pm-slack-interface.test.ts
+++ b/packages/core/src/__tests__/pm-slack-interface.test.ts
@@ -503,3 +503,66 @@ describe("POST /slack/events", () => {
     expect(json.challenge).toBe("test-challenge-abc");
   });
 });
+
+describe("PM Slack — operator stop/halt commands", () => {
+  it('parses "halt"', () => {
+    expect(parsePmCommand("halt")).toEqual({ type: "halt" });
+    expect(parsePmCommand("  Halt  ")).toEqual({ type: "halt" });
+  });
+
+  it('parses "cancel <runId>" and "stop <runId>"', () => {
+    expect(parsePmCommand("cancel abc123def")).toEqual({ type: "cancel", runId: "abc123def" });
+    expect(parsePmCommand("STOP run_xyz-456")).toEqual({ type: "stop", runId: "run_xyz-456" });
+  });
+
+  it("rejects too-short run ids", () => {
+    expect(parsePmCommand("cancel ab").type).toBe("unknown");
+  });
+
+  it("does not confuse short pause/resume with cancel/stop", () => {
+    expect(parsePmCommand("pause")).toEqual({ type: "pause" });
+    expect(parsePmCommand("resume")).toEqual({ type: "resume" });
+  });
+
+  it("executes cancel through the runner with cancel mode", async () => {
+    const requestStop = vi.fn().mockReturnValue({ issueId: "BEC-1", mode: "cancel" });
+    const text = await executePmCommand(
+      { type: "cancel", runId: "run-abc" },
+      { runner: { requestStop }, slackUserId: "U42" },
+    );
+    expect(requestStop).toHaveBeenCalledWith("run-abc", "cancel");
+    expect(text).toMatch(/Cancel signal sent/);
+  });
+
+  it("executes stop through the runner with graceful mode", async () => {
+    const requestStop = vi.fn().mockReturnValue({ issueId: "BEC-2", mode: "graceful" });
+    const text = await executePmCommand(
+      { type: "stop", runId: "run-xyz" },
+      { runner: { requestStop }, slackUserId: "U42" },
+    );
+    expect(requestStop).toHaveBeenCalledWith("run-xyz", "graceful");
+    expect(text).toMatch(/Graceful stop/);
+  });
+
+  it("executes halt through the runner", async () => {
+    const haltAll = vi.fn().mockReturnValue({ cancelledRunIds: ["r1", "r2", "r3"] });
+    const text = await executePmCommand({ type: "halt" }, { runner: { haltAll }, slackUserId: "U42" });
+    expect(haltAll).toHaveBeenCalled();
+    expect(text).toMatch(/Halted/);
+    expect(text).toMatch(/3 active run/);
+  });
+
+  it("reports a config error when runner is missing", async () => {
+    const text = await executePmCommand(
+      { type: "cancel", runId: "run-abc" },
+      { slackUserId: "U42" },
+    );
+    expect(text).toMatch(/Runner not configured/);
+  });
+
+  it("help text lists the new commands when the input is unrecognized", async () => {
+    const text = await executePmCommand({ type: "unknown", original: "garbage" }, {});
+    expect(text).toMatch(/\/pm cancel/);
+    expect(text).toMatch(/\/pm halt/);
+  });
+});

--- a/packages/core/src/__tests__/pm-triage.test.ts
+++ b/packages/core/src/__tests__/pm-triage.test.ts
@@ -219,4 +219,126 @@ describe("triageNewIssues", () => {
     expect(results).toHaveLength(3);
     expect(callClaude).toHaveBeenCalledTimes(4);
   });
+
+  describe("observer-origin gate", () => {
+    function clientWithNeedsDesignLabel(issues: any[]) {
+      const c = mockLinearClient(issues);
+      c.issueLabels = vi.fn().mockResolvedValue({
+        nodes: [
+          { id: "lbl-bug", name: "bug" },
+          { id: "lbl-needs-design", name: "needs-design" },
+        ],
+      });
+      return c;
+    }
+
+    const observerDescription =
+      "Deep-review loop hit 90 turns. Inspect findings & implement-stage diffs.\n\n" +
+      "<!-- urateam-qo-fingerprint: abc123 -->\n" +
+      "<!-- urateam-qo-observer: run-patterns -->\n";
+
+    it("routes observer-origin issue to needs-design without calling Claude", async () => {
+      const client = clientWithNeedsDesignLabel([
+        {
+          id: "issue-qo-1",
+          identifier: "BEC-500",
+          title: "[GH#42] Pipeline urn-XYZ deep-review loop hit 90 turns",
+          description: observerDescription,
+          labels: { nodes: [] },
+          team: { id: "team-1" },
+        },
+      ]);
+      const callClaude = vi.fn();
+
+      const results = await triageNewIssues({
+        linearClient: client as any,
+        teamIds: ["team-1"],
+        callClaude,
+        sanitize: (s: string) => s,
+        stateMap: defaultStateMap,
+      });
+
+      expect(callClaude).not.toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+      expect(results[0].issueId).toBe("BEC-500");
+      expect(results[0].labels).toEqual(["needs-design"]);
+      expect(results[0].acceptanceCriteria).toEqual([]);
+      expect(client.updateIssue).toHaveBeenCalledWith(
+        "issue-qo-1",
+        expect.objectContaining({
+          priority: 3,
+          labelIds: ["lbl-needs-design"],
+          stateId: "state-backlog",
+        }),
+      );
+      // No acceptance-criteria section appended.
+      expect(client.updateIssue).toHaveBeenCalledWith(
+        "issue-qo-1",
+        expect.not.objectContaining({ description: expect.any(String) }),
+      );
+      expect(client.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issueId: "issue-qo-1",
+          body: expect.stringContaining("Quality Observer finding"),
+        }),
+      );
+    });
+
+    it("does not trigger the gate for normal issues without the marker", async () => {
+      const client = clientWithNeedsDesignLabel([
+        {
+          id: "issue-normal",
+          identifier: "BEC-501",
+          title: "Add retry to webhook handler",
+          description: "Webhook fails intermittently — add exponential backoff.",
+          labels: { nodes: [] },
+          team: { id: "team-1" },
+        },
+      ]);
+      const callClaude = mockClaude(JSON.stringify({
+        priority: 2,
+        labels: ["bug"],
+        complexity: "small",
+        rationale: "Retry logic missing",
+        acceptanceCriteria: ["Add backoff in webhook handler"],
+      }));
+
+      await triageNewIssues({
+        linearClient: client as any,
+        teamIds: ["team-1"],
+        callClaude,
+        sanitize: (s: string) => s,
+        stateMap: defaultStateMap,
+      });
+
+      expect(callClaude).toHaveBeenCalledTimes(1);
+    });
+
+    it("routes when only the observer marker is present, even amid other content", async () => {
+      const client = clientWithNeedsDesignLabel([
+        {
+          id: "issue-qo-2",
+          identifier: "BEC-502",
+          title: "[GH#43] Stage `review` is timing out repeatedly",
+          description:
+            "## Header\n\nSome content from observer.\n\n" +
+            "<!-- urateam-qo-observer: run-patterns -->\n",
+          labels: { nodes: [] },
+          team: { id: "team-1" },
+        },
+      ]);
+      const callClaude = vi.fn();
+
+      const results = await triageNewIssues({
+        linearClient: client as any,
+        teamIds: ["team-1"],
+        callClaude,
+        sanitize: (s: string) => s,
+        stateMap: defaultStateMap,
+      });
+
+      expect(callClaude).not.toHaveBeenCalled();
+      expect(results[0].labels).toEqual(["needs-design"]);
+    });
+  });
 });

--- a/packages/core/src/audit/events.ts
+++ b/packages/core/src/audit/events.ts
@@ -88,6 +88,52 @@ export function pmAgentBranchSweptEvent(args: {
   });
 }
 
+/**
+ * Operator-initiated single-run stop. `mode` records whether the stage was
+ * interrupted mid-stream ("cancel") or allowed to finish before skipping the
+ * rest of the pipeline ("graceful").
+ */
+export function runCancelledEvent(args: {
+  runId: string;
+  issueId: string;
+  actor: string;
+  actorType: "dashboard-user" | "cli" | "slack" | "system";
+  mode: "cancel" | "graceful";
+  reason?: string;
+}): AuditEvent {
+  return base({
+    eventType: "run.cancelled",
+    actor: args.actor,
+    actorType: args.actorType,
+    runId: args.runId,
+    issueId: args.issueId,
+    payload: { mode: args.mode, reason: args.reason },
+  });
+}
+
+/**
+ * Operator-initiated container-wide halt. Records the count of in-flight runs
+ * that were cancelled at halt time (each individual cancel also emits its own
+ * `run.cancelled` event with the same actor).
+ */
+export function systemHaltedEvent(args: {
+  actor: string;
+  actorType: "dashboard-user" | "cli" | "slack" | "system";
+  cancelledRunIds: string[];
+  reason?: string;
+}): AuditEvent {
+  return base({
+    eventType: "system.halted",
+    actor: args.actor,
+    actorType: args.actorType,
+    payload: {
+      cancelledRunIds: args.cancelledRunIds,
+      cancelledCount: args.cancelledRunIds.length,
+      reason: args.reason,
+    },
+  });
+}
+
 export function pmTriageClassifiedEvent(args: {
   issueId: string;
   label: string;

--- a/packages/core/src/executor/agent-stream.ts
+++ b/packages/core/src/executor/agent-stream.ts
@@ -66,6 +66,19 @@ export class StagePreStreamStalledError extends Error {
 }
 
 /**
+ * Thrown when a stage's agent stream is interrupted via the abort signal
+ * (operator-initiated cancel). Distinct from the timeout errors because the
+ * runner uses the error class to decide how to mark the run (`aborted`, not
+ * `failed`).
+ */
+export class StageCancelledError extends Error {
+  constructor() {
+    super("stage cancelled by operator");
+    this.name = "StageCancelledError";
+  }
+}
+
+/**
  * Consume an Agent SDK message stream, accumulating token usage and
  * extracting the last assistant text content.
  *
@@ -100,8 +113,20 @@ export async function consumeAgentStream(
      * message). Set shorter than progressTimeoutMs to catch hangs early.
      */
     firstMessageTimeoutMs?: number;
+    /**
+     * AbortSignal for operator-initiated cancel. When the signal fires, the
+     * iterator's `.return()` is invoked and the function throws
+     * `StageCancelledError`. Pre-aborted signals fire on entry so the function
+     * exits before consuming any messages.
+     */
+    abortSignal?: AbortSignal;
   },
 ): Promise<ConsumeResult> {
+  // Honour a pre-aborted signal immediately so callers can short-circuit
+  // without paying for an iterator setup.
+  if (options?.abortSignal?.aborted) {
+    throw new StageCancelledError();
+  }
   let inputTokens = 0;
   let outputTokens = 0;
   let cacheCreationInputTokens = 0;
@@ -122,7 +147,9 @@ export async function consumeAgentStream(
 
   const iterator = (messages as AsyncIterable<unknown>)[Symbol.asyncIterator]();
   const STALLED = { __stalled: true } as const;
+  const ABORTED = { __aborted: true } as const;
   type StallSentinel = typeof STALLED;
+  type AbortSentinel = typeof ABORTED;
   while (true) {
     const stallRemaining = stallTimeoutMs - (Date.now() - lastTokenAdvanceAt);
     // First-message timeout: only active until the first real message arrives.
@@ -145,8 +172,33 @@ export async function consumeAgentStream(
       stallTimer = setTimeout(() => resolve(STALLED), remainingUntilTimeout);
     });
 
-    const raced = await Promise.race([next, stallPromise]);
+    // Race the abort signal in alongside next + stallPromise. We re-create the
+    // listener each iteration so it cleans up automatically (removeEventListener
+    // below) and an external abort fires within one iteration tick.
+    let abortListener: (() => void) | undefined;
+    const abortPromise = new Promise<AbortSentinel>((resolve) => {
+      if (!options?.abortSignal) return; // Promise never resolves — Promise.race ignores it
+      if (options.abortSignal.aborted) {
+        resolve(ABORTED);
+        return;
+      }
+      abortListener = () => resolve(ABORTED);
+      options.abortSignal.addEventListener("abort", abortListener, { once: true });
+    });
+
+    const raced = await Promise.race([next, stallPromise, abortPromise]);
     if (stallTimer) clearTimeout(stallTimer);
+    if (abortListener && options?.abortSignal) {
+      options.abortSignal.removeEventListener("abort", abortListener);
+    }
+
+    if (raced === ABORTED) {
+      // Operator-initiated cancel. Same .return() best-effort cleanup as the
+      // stall path; the agent generator may be parked on a never-resolving
+      // await, in which case GC handles eventual release.
+      iterator.return?.()?.catch((err) => log.debug({ err }, "iterator cleanup failed on abort"));
+      throw new StageCancelledError();
+    }
 
     if (raced === STALLED) {
       // Defensive race-loss check: if the iterator settled in the same tick

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -20,8 +20,14 @@ import { resolveTooling } from "./mcp-resolver.js";
 import type { TechStackProfile } from "../repo/tech-stack.js";
 import type { DevcontainerSession } from "../repo/devcontainer.js";
 import { createLogger } from "../logger.js";
-import { consumeAgentStream, StagePreStreamStalledError, type StreamMessage } from "./agent-stream.js";
+import {
+  consumeAgentStream,
+  StagePreStreamStalledError,
+  StageCancelledError,
+  type StreamMessage,
+} from "./agent-stream.js";
 import { isClaudeAuthValid } from "./auth-check.js";
+import { onStop } from "../pipeline/control-signals.js";
 
 /**
  * BEC-183: wall-clock stage timeouts. Independent of the in-stream watchdog
@@ -224,6 +230,17 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       },
     };
 
+    // Operator-cancel plumbing: an AbortController shared with consumeAgentStream
+    // fires when a `"cancel"` stop signal is recorded for this run. The
+    // subscription is set up before the stream is consumed so a signal recorded
+    // mid-import is honoured immediately (onStop also fires synchronously when
+    // a signal is already pending).
+    const abortController = new AbortController();
+    const unsubscribeStop = onStop(runId, () => {
+      log.info({ runId }, "cancel signal received — aborting stage stream");
+      abortController.abort();
+    });
+
     // BEC-183: wall-clock stage timeout — second defensive layer independent
     // of the in-stream watchdog. Fires as StagePreStreamStalledError so the
     // catch block below sets status=failed with a clear message.
@@ -252,6 +269,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
           }
         },
         firstMessageTimeoutMs: FIRST_MESSAGE_TIMEOUT_MS,
+        abortSignal: abortController.signal,
       }),
       stageTimeoutPromise,
     ]).catch((err: unknown) => {
@@ -268,6 +286,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       // or throws any other error — prevents the timer from dangling after the
       // stage exits the happy path.
       if (stageTimeoutTimer) clearTimeout(stageTimeoutTimer);
+      unsubscribeStop();
     });
 
     // Flush remaining log entries
@@ -320,21 +339,26 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       stageRunId,
     };
   } catch (error) {
+    const cancelled = error instanceof StageCancelledError;
     const errorMessage =
       error instanceof Error ? error.message : String(error);
-    log.error({ err: error }, "stage failed");
+    if (cancelled) {
+      log.info({ err: error }, "stage cancelled by operator");
+    } else {
+      log.error({ err: error }, "stage failed");
+    }
 
     await db.insert(agentLogs).values({
       id: nanoid(),
       stageRunId: stageRunId,
-      type: "error",
+      type: cancelled ? "cancelled" : "error",
       content: errorMessage.slice(0, 2048),
     });
 
     await db
       .update(stageRuns)
       .set({
-        status: "failed",
+        status: cancelled ? "cancelled" : "failed",
         completedAt: new Date(),
         inputTokens,
         outputTokens,
@@ -346,7 +370,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       .where(eq(stageRuns.id, stageRunId));
 
     return {
-      status: "failed",
+      status: cancelled ? "cancelled" : "failed",
       inputTokens,
       outputTokens,
       turns,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db } from ".
 export { pipelineRuns, stageRuns, agentLogs, activeWork, pmApprovals } from "./db/index.js";
 export { createApp, type ServerConfig } from "./server.js";
 export { PipelineRunner, type PipelineRunnerConfig, type LinearIssue } from "./pipeline/index.js";
+export { type StopMode, requestRunStop, getStopSignal, clearStopSignal } from "./pipeline/index.js";
 export {
   formatPRCostSummary,
   type StageCostBreakdown,

--- a/packages/core/src/pipeline/control-signals.ts
+++ b/packages/core/src/pipeline/control-signals.ts
@@ -1,0 +1,109 @@
+/**
+ * In-memory per-run stop signals for the pipeline runner.
+ *
+ * Surfaces (dashboard, Slack, CLI) all funnel through `requestStop()` and the
+ * runner consults `getStopSignal()` between stages. The executor subscribes via
+ * `onStop()` so that "cancel" mode can interrupt an in-flight Agent SDK stream
+ * (graceful stops simply skip the remaining stages once the current one ends).
+ *
+ * Single-process state: resets on container restart. Cross-container
+ * coordination (Redis) is intentionally out of scope — matches the existing
+ * BEC-170 pause caveat.
+ */
+
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "pipeline.control-signals" });
+
+/**
+ * Stop intent attached to a run.
+ *
+ * - `"cancel"` — interrupt the running stage immediately by aborting the Agent
+ *   SDK stream; mark the run as aborted. Tokens already spent on the current
+ *   stage are lost.
+ * - `"graceful"` — let the current stage finish, then skip remaining stages.
+ *   No PR, no fanout. Strictly cheaper to clean up after.
+ */
+export type StopMode = "cancel" | "graceful";
+
+const signals = new Map<string, StopMode>();
+const listeners = new Map<string, Set<() => void>>();
+
+/**
+ * Request a stop for `runId`. Idempotent. Calling with `"cancel"` after
+ * `"graceful"` upgrades the signal (cancel is strictly stronger). The reverse
+ * is a no-op so an in-flight cancel can't be downgraded mid-stream.
+ *
+ * Returns the effective mode after the call.
+ */
+export function requestStop(runId: string, mode: StopMode): StopMode {
+  const existing = signals.get(runId);
+  if (existing === "cancel") {
+    // Already at strongest — no-op.
+    return existing;
+  }
+  signals.set(runId, mode);
+  log.info({ runId, mode, previous: existing ?? null }, "stop signal recorded");
+  // Notify listeners only on `"cancel"` — graceful is polled at stage boundaries
+  // and doesn't need to interrupt a running stream.
+  if (mode === "cancel") {
+    const subs = listeners.get(runId);
+    if (subs) {
+      for (const cb of subs) {
+        try {
+          cb();
+        } catch (err) {
+          log.warn({ runId, err }, "stop listener threw");
+        }
+      }
+    }
+  }
+  return mode;
+}
+
+/** Returns the current stop signal for `runId`, or `undefined` if none set. */
+export function getStopSignal(runId: string): StopMode | undefined {
+  return signals.get(runId);
+}
+
+/**
+ * Clears any signal for `runId`. Called by the runner once it has finished
+ * processing the stop (e.g. after marking the run aborted).
+ */
+export function clearStopSignal(runId: string): void {
+  signals.delete(runId);
+  listeners.delete(runId);
+}
+
+/**
+ * Subscribe a listener that fires when a `"cancel"` signal is recorded for
+ * `runId`. Returns an unsubscribe function. Use this in the executor to call
+ * `.return()` on the SDK iterator and break out of the stream.
+ *
+ * If a `"cancel"` signal is already pending when this is called, the listener
+ * is invoked synchronously so subscribers can't miss an early request.
+ */
+export function onStop(runId: string, listener: () => void): () => void {
+  if (signals.get(runId) === "cancel") {
+    try {
+      listener();
+    } catch (err) {
+      log.warn({ runId, err }, "stop listener threw on immediate fire");
+    }
+  }
+  let set = listeners.get(runId);
+  if (!set) {
+    set = new Set();
+    listeners.set(runId, set);
+  }
+  set.add(listener);
+  return () => {
+    set?.delete(listener);
+  };
+}
+
+/** Test/reset helper. Not exported from the package barrel. */
+export function _clearAllSignals(): void {
+  signals.clear();
+  listeners.clear();
+}

--- a/packages/core/src/pipeline/feedback-pipeline.ts
+++ b/packages/core/src/pipeline/feedback-pipeline.ts
@@ -11,6 +11,7 @@ import type {
 import type { AnyDb } from "../db/client.js";
 import { pipelineRuns } from "../db/schema.js";
 import { executeStage } from "../executor/executor.js";
+import { getStopSignal } from "./control-signals.js";
 import {
   cloneRepo,
   createWorktreeFromRemote,
@@ -171,6 +172,19 @@ export interface FeedbackPipelineContext {
     retriesExhausted: boolean,
   ): Promise<void>;
   injectAgentConfig(worktreePath: string): Promise<void>;
+  /**
+   * Operator-initiated stop. Mirrors the main pipeline's path so feedback
+   * runs honour cancel/graceful signals. Passes the prUrl so the per-PR
+   * rate-limit slot is freed immediately rather than waiting on the queue's
+   * `finally` block.
+   */
+  markRunCancelled(
+    db: AnyDb,
+    runId: string,
+    run: PipelineRun,
+    mode: "cancel" | "graceful",
+    feedbackPrUrl?: string,
+  ): Promise<void>;
 }
 
 /**
@@ -327,6 +341,18 @@ export async function executeFeedbackPipeline(
       currentStage = stage;
       runLog.info({ stage: stageType }, "feedback: executing stage");
 
+      // Operator stop check (graceful path) — mirrors the main pipeline at
+      // runner.ts ~L840. Mid-stream cancel surfaces as result.status below.
+      const preStageStopSignal = getStopSignal(runId);
+      if (preStageStopSignal) {
+        runLog.info(
+          { stage: stageType, mode: preStageStopSignal },
+          "feedback: stop requested — aborting remaining stages",
+        );
+        await ctx.markRunCancelled(db, runId, run, preStageStopSignal, prUrl);
+        return;
+      }
+
       await upsertActiveWork(db, {
         runId,
         issueId: sanitizedIssue.id,
@@ -353,6 +379,18 @@ export async function executeFeedbackPipeline(
         reviewFeedback: stageReviewFeedback,
         stageModels: config.stageModels,
       });
+
+      // Mid-stream cancel: AbortController inside consumeAgentStream fired
+      // and the executor returned status="cancelled". Without this branch
+      // the loop would fall through to `if (result.status === "failed")` —
+      // which doesn't match — and continue to the next stage with an
+      // undefined handoff, eventually pushing partial work.
+      if (result.status === "cancelled") {
+        const mode = getStopSignal(runId) ?? "cancel";
+        runLog.info({ stage: stageType, mode }, "feedback: stage cancelled by operator");
+        await ctx.markRunCancelled(db, runId, run, mode, prUrl);
+        return;
+      }
 
       run.totalInputTokens += result.inputTokens;
       run.totalOutputTokens += result.outputTokens;

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -9,6 +9,12 @@ export { resolvePipeline } from "./router.js";
 export { createQueue, type WorkQueue } from "./queue.js";
 export { PipelineRunner, type PipelineRunnerConfig, type LinearIssue } from "./runner.js";
 export {
+  requestStop as requestRunStop,
+  getStopSignal,
+  clearStopSignal,
+  type StopMode,
+} from "./control-signals.js";
+export {
   withBranchLock,
   createBranchLockAdapter,
   createPgLockAdapter,

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -23,6 +23,8 @@ import { checkRequirements, buildRalphContext } from "../executor/ralph.js";
 import { computeEffectiveRalphIterations } from "./runner-ralph-helpers.js";
 import { checkTestQuality } from "../executor/test-quality.js";
 import { buildDeepReviewContext } from "../executor/deep-review.js";
+import { getStopSignal, requestStop, clearStopSignal, type StopMode } from "./control-signals.js";
+import { setPmPaused } from "../pm/pause-state.js";
 import { runReviewProviders } from "./review-providers-runner.js";
 import { postFanoutCommentsToPR } from "../executor/review/post-fanout-comments.js";
 import type { ReviewModelRun } from "../executor/review/review-provider.js";
@@ -476,6 +478,101 @@ export class PipelineRunner {
     this.activeRuns.delete(issueId);
   }
 
+  /**
+   * Operator-initiated stop for a single run, addressed by runId.
+   *
+   * - `"cancel"` aborts the active Agent SDK stream immediately. The current
+   *   stage exits with `status: "cancelled"`; the pipeline marks the run
+   *   `cancelled` and returns without creating a PR.
+   * - `"graceful"` lets the current stage complete, then skips remaining
+   *   stages. Slower than cancel but leaves the worktree consistent.
+   *
+   * Idempotent. Returns the issueId resolved from the active map (or null if
+   * the runId isn't currently active). The caller is responsible for emitting
+   * the audit event since it knows the actor.
+   */
+  requestStop(runId: string, mode: StopMode): { issueId: string | null; mode: StopMode } {
+    let issueId: string | null = null;
+    for (const [iss, rid] of this.activeRuns) {
+      if (rid === runId) {
+        issueId = iss;
+        break;
+      }
+    }
+    const effective = requestStop(runId, mode);
+    return { issueId, mode: effective };
+  }
+
+  /**
+   * Halt the whole container's autonomous work:
+   *  1. Pauses the PM Agent (BEC-170 mechanism) so no new runs get promoted.
+   *  2. Sends a `"cancel"` signal to every active pipeline + feedback run.
+   *
+   * Returns the set of run ids that were cancelled — the caller emits the
+   * audit event. Reversible: PM Agent can be unpaused via `/pm resume` and
+   * individual runs can be re-triggered via the retry button. Cancelled runs
+   * stay cancelled.
+   */
+  haltAll(): { cancelledRunIds: string[] } {
+    setPmPaused(true);
+    const cancelled = new Set<string>();
+    for (const runId of this.activeRuns.values()) {
+      requestStop(runId, "cancel");
+      cancelled.add(runId);
+    }
+    for (const runId of this.activeFeedbackRuns.values()) {
+      requestStop(runId, "cancel");
+      cancelled.add(runId);
+    }
+    log.info(
+      { count: cancelled.size, runIds: [...cancelled] },
+      "haltAll: PM paused and cancel signals sent to active runs",
+    );
+    return { cancelledRunIds: [...cancelled] };
+  }
+
+  /**
+   * Mark a run as cancelled in the DB and clean up bookkeeping. Shared by the
+   * pre-stage graceful path and the mid-stream cancel path.
+   *
+   * For feedback-pipeline runs, pass `feedbackPrUrl` so the per-PR rate-limit
+   * slot is freed immediately rather than waiting on the queue's `finally`
+   * block. The queue's `finally` still fires (idempotent — Map.delete on a
+   * missing key is a no-op), this just shortens the window during which a new
+   * feedback comment on the same PR is rejected as "already active".
+   */
+  markRunCancelled(
+    db: AnyDb,
+    runId: string,
+    run: PipelineRun,
+    mode: StopMode,
+    feedbackPrUrl?: string,
+  ): Promise<void> {
+    return this.markRunCancelledImpl(db, runId, run, mode, feedbackPrUrl);
+  }
+
+  private async markRunCancelledImpl(
+    db: AnyDb,
+    runId: string,
+    run: PipelineRun,
+    mode: StopMode,
+    feedbackPrUrl?: string,
+  ): Promise<void> {
+    await removeActiveWork(db, runId);
+    await db
+      .update(pipelineRuns)
+      .set({
+        status: "cancelled",
+        errorMessage: `cancelled by operator (${mode})`,
+        completedAt: new Date(),
+      })
+      .where(eq(pipelineRuns.id, runId));
+    run.status = "cancelled";
+    this.activeRuns.delete(run.issueId);
+    if (feedbackPrUrl) this.activeFeedbackRuns.delete(feedbackPrUrl);
+    clearStopSignal(runId);
+  }
+
   isActive(issueId: string): boolean {
     return this.activeRuns.has(issueId);
   }
@@ -519,6 +616,7 @@ export class PipelineRunner {
       checkTokenBudget: this.checkTokenBudget.bind(this),
       failPipeline: this.failPipeline.bind(this),
       injectAgentConfig: this.injectAgentConfig.bind(this),
+      markRunCancelled: this.markRunCancelled.bind(this),
       activeFeedbackRuns: this.activeFeedbackRuns,
       queue: this.queue,
       buildPipelineRun: this.buildPipelineRun.bind(this),
@@ -726,6 +824,20 @@ export class PipelineRunner {
         lastStageIndex = config.stages.indexOf(stage);
         runLog.info({ stage: stageType }, "executing stage");
 
+        // Operator stop check (graceful path) — fires between stages so the
+        // previous stage's work is preserved. The "cancel" path is interrupted
+        // mid-stream by the executor's AbortController and surfaces below as
+        // result.status === "cancelled".
+        const preStageStopSignal = getStopSignal(runId);
+        if (preStageStopSignal) {
+          runLog.info(
+            { stage: stageType, mode: preStageStopSignal },
+            "pipeline stop requested — aborting remaining stages",
+          );
+          await this.markRunCancelled(db, runId, run, preStageStopSignal);
+          return;
+        }
+
         if (stageType === "await-approval") {
           // Save the full resume context so resume() can re-attach the worktree
           // and continue from the next stage with the correct handoff artifact.
@@ -791,6 +903,17 @@ export class PipelineRunner {
           devcontainerSession,
           stageModels: config.stageModels,
         });
+
+        // Operator stop check (cancel path) — the AbortController inside the
+        // executor surfaces as result.status === "cancelled". Don't try to use
+        // the (possibly partial) handoff; exit immediately like the pre-stage
+        // graceful check above.
+        if (result.status === "cancelled") {
+          const mode = getStopSignal(runId) ?? "cancel";
+          runLog.info({ stage: stageType, mode }, "stage cancelled by operator — aborting pipeline");
+          await this.markRunCancelled(db, runId, run, mode);
+          return;
+        }
 
         // BEC-134: track the most recent review stage_run id so fanout
         // persistence can reuse it.

--- a/packages/core/src/pm/actions/triage.ts
+++ b/packages/core/src/pm/actions/triage.ts
@@ -11,6 +11,29 @@ const log = createLogger({ component: "PmAgent:triage" });
 const MAX_ISSUES_PER_TICK = 10;
 const DEFAULT_BATCH_SIZE = 3;
 
+/**
+ * Marker embedded in the body of every GitHub issue filed by the urateam
+ * quality-observer. `gh-linear-sync` copies the GitHub body verbatim into the
+ * Linear ticket description, so the marker survives the sync and is the
+ * authoritative way to detect observer-origin tickets on the Linear side
+ * (labels are not propagated by gh-linear-sync).
+ *
+ * Source of truth: urateam-quality-observer/src/github-issue-writer.ts.
+ */
+const OBSERVER_BODY_MARKER = "<!-- urateam-qo-observer:";
+
+/**
+ * Pipeline label assigned to observer-origin tickets. `needs-design` includes
+ * an `await-approval` stage that blocks until a human approves, so these
+ * findings surface without burning implement-stage tokens on a non-actionable
+ * diagnostic. See CLAUDE.md "Quality Observer" for the rationale.
+ */
+const OBSERVER_PIPELINE_LABEL = "needs-design";
+
+function isObserverOriginIssue(description: string | null | undefined): boolean {
+  return typeof description === "string" && description.includes(OBSERVER_BODY_MARKER);
+}
+
 export interface TriageInput {
   linearClient: any; // LinearClient from @linear/sdk
   teamIds: string[];
@@ -68,6 +91,61 @@ export async function triageNewIssues(input: TriageInput): Promise<TriageResult[
     batchSize,
     async (issue: any) => {
       try {
+        if (isObserverOriginIssue(issue.description)) {
+          const team = await issue.team;
+          const teamId = team?.id;
+          const backlogStateId = teamId ? stateMap.get(`${teamId}:Backlog`) : undefined;
+
+          const issueLabels = [OBSERVER_PIPELINE_LABEL];
+          const labelIds = issueLabels
+            .map((l) => labelMap.get(l.toLowerCase()))
+            .filter(Boolean);
+          if (labelIds.length === 0) {
+            log.warn(
+              { issueId: issue.identifier, label: OBSERVER_PIPELINE_LABEL },
+              "observer-origin gate: '" + OBSERVER_PIPELINE_LABEL +
+                "' label not found in Linear — issue will move to Backlog without pipeline label and won't be routed by promote",
+            );
+          }
+
+          const rationale =
+            "Observer-origin finding (body marker detected) — routed to needs-design so the await-approval stage gates a human before any implement-stage work runs.";
+
+          const updatePayload: any = { priority: 3 };
+          if (labelIds.length > 0) updatePayload.labelIds = labelIds;
+          if (backlogStateId) updatePayload.stateId = backlogStateId;
+
+          await linearClient.updateIssue(issue.id, updatePayload);
+          await linearClient.createComment({
+            issueId: issue.id,
+            body:
+              `🤖 **PM Agent — Triaged (Quality Observer finding)**\n\n` +
+              `**Pipeline:** ${OBSERVER_PIPELINE_LABEL}\n` +
+              `**Rationale:** ${rationale}`,
+          });
+
+          const result: TriageResult = {
+            issueId: issue.identifier,
+            priority: 3,
+            labels: issueLabels,
+            complexity: "medium",
+            rationale,
+            acceptanceCriteria: [],
+          };
+          if (input.db) {
+            void logAuditEventUnchecked(input.db, pmTriageClassifiedEvent({
+              issueId: issue.identifier,
+              label: OBSERVER_PIPELINE_LABEL,
+              rationale,
+            }));
+          }
+          log.info(
+            { issueId: issue.identifier, pipelineLabel: OBSERVER_PIPELINE_LABEL },
+            "triaged observer-origin issue (skipped Claude classification)",
+          );
+          return result;
+        }
+
         const sanitizedDesc = sanitize(issue.description ?? "");
         const prompt =
           `Classify this software issue and generate acceptance criteria. Respond with ONLY a JSON object, no other text.\n\n` +

--- a/packages/core/src/pm/slack-commands.ts
+++ b/packages/core/src/pm/slack-commands.ts
@@ -47,6 +47,10 @@ export type PmCommand =
   | { type: "pause" }
   | { type: "resume" }
   | { type: "assign"; issueId: string }
+  /** Operator-initiated stop. `runId` is a pipeline_runs row id (nanoid). */
+  | { type: "cancel"; runId: string }
+  | { type: "stop"; runId: string }
+  | { type: "halt" }
   | { type: "unknown"; original: string };
 
 /**
@@ -73,6 +77,19 @@ export interface CommandExecutorDeps {
   teamIds?: string[];
   /** Sonnet-model callable required for the `bulk_create` command. */
   callClaudeSonnet?: (prompt: string) => Promise<string>;
+  /**
+   * Reference to the live pipeline runner. Required for `cancel`/`stop`/`halt`
+   * commands; if absent, those commands report a clear configuration error
+   * rather than silently succeeding.
+   */
+  runner?: {
+    requestStop?: (runId: string, mode: "cancel" | "graceful") => { issueId: string | null; mode: "cancel" | "graceful" };
+    haltAll?: () => { cancelledRunIds: string[] };
+  };
+  /** DB handle for audit-event writes. */
+  db?: any;
+  /** Slack user id (e.g. "U123") for audit attribution. */
+  slackUserId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -153,6 +170,65 @@ export async function executePmCommand(
       setPmPaused(false);
       log.info("PM Agent resumed via Slack");
       return "▶️ PM Agent autonomous assignment has been *resumed*.";
+    }
+
+    case "cancel":
+    case "stop": {
+      if (!deps.runner?.requestStop) {
+        return `⚠️ Runner not configured — cannot ${cmd.type} run *${cmd.runId}*.`;
+      }
+      const mode: "cancel" | "graceful" = cmd.type === "cancel" ? "cancel" : "graceful";
+      const { issueId } = deps.runner.requestStop(cmd.runId, mode);
+      if (deps.db) {
+        const { logAuditEvent, runCancelledEvent } = await import("../audit/index.js");
+        void logAuditEvent(
+          deps.db,
+          runCancelledEvent({
+            runId: cmd.runId,
+            issueId: issueId ?? "(unknown)",
+            actor: `slack:${deps.slackUserId ?? "unknown"}`,
+            actorType: "slack",
+            mode,
+          }),
+        );
+      }
+      log.info({ runId: cmd.runId, mode, slackUserId: deps.slackUserId }, "run stop requested via Slack");
+      return mode === "cancel"
+        ? `🛑 Cancel signal sent to run *${cmd.runId}*. The active stage will abort within a few seconds.`
+        : `⏹ Graceful stop requested for run *${cmd.runId}*. The current stage will finish, then the pipeline will stop.`;
+    }
+
+    case "halt": {
+      if (!deps.runner?.haltAll) {
+        return "⚠️ Runner not configured — cannot halt.";
+      }
+      const { cancelledRunIds } = deps.runner.haltAll();
+      if (deps.db) {
+        const { logAuditEvent, systemHaltedEvent, runCancelledEvent } = await import("../audit/index.js");
+        void logAuditEvent(
+          deps.db,
+          systemHaltedEvent({
+            actor: `slack:${deps.slackUserId ?? "unknown"}`,
+            actorType: "slack",
+            cancelledRunIds,
+          }),
+        );
+        for (const rid of cancelledRunIds) {
+          void logAuditEvent(
+            deps.db,
+            runCancelledEvent({
+              runId: rid,
+              issueId: "(halt)",
+              actor: `slack:${deps.slackUserId ?? "unknown"}`,
+              actorType: "slack",
+              mode: "cancel",
+              reason: "system.halt",
+            }),
+          );
+        }
+      }
+      log.warn({ count: cancelledRunIds.length, slackUserId: deps.slackUserId }, "container halt requested via Slack");
+      return `🚨 *Halted.* PM Agent paused; cancelled ${cancelledRunIds.length} active run(s). Use \`/pm resume\` when ready.`;
     }
 
     case "prioritize": {
@@ -312,7 +388,7 @@ export async function executePmCommand(
     }
 
     case "unknown":
-      return `🤔 I didn't understand that. Try:\n• \`/pm status\`\n• \`/pm prioritize BEC-25\`\n• \`/pm create "title" "description"\`\n• \`/pm assign BEC-13\`\n• \`/pm pause\` / \`/pm resume\``;
+      return `🤔 I didn't understand that. Try:\n• \`/pm status\`\n• \`/pm prioritize BEC-25\`\n• \`/pm create "title" "description"\`\n• \`/pm assign BEC-13\`\n• \`/pm pause\` / \`/pm resume\`\n• \`/pm cancel <runId>\` (interrupt immediately) / \`/pm stop <runId>\` (graceful)\n• \`/pm halt\` (pause PM + cancel all active runs)`;
 
     default:
       return `Unknown command.`;

--- a/packages/core/src/pm/slack-helpers.ts
+++ b/packages/core/src/pm/slack-helpers.ts
@@ -21,3 +21,40 @@ export async function postSlackMessage(botToken: string, payload: object): Promi
     return null;
   }
 }
+
+/**
+ * React to a Slack message (or any thing that has a channel + ts) with the
+ * given emoji name (no surrounding colons). Fire-and-forget — failures are
+ * logged at info because they're best-effort UX and we never want a missed
+ * reaction to surface as a user-visible error.
+ *
+ * Slash commands have no `ts` to react to, so for those the caller uses
+ * `chat.postEphemeral` instead. See `postSlackEphemeral` below.
+ */
+export async function reactToSlackMessage(
+  botToken: string,
+  channel: string,
+  ts: string,
+  emoji: string,
+): Promise<void> {
+  try {
+    const resp = await fetch("https://slack.com/api/reactions.add", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${botToken}`,
+      },
+      body: JSON.stringify({ channel, timestamp: ts, name: emoji }),
+    });
+    const data = (await resp.json()) as any;
+    if (!data?.ok) {
+      // `already_reacted` is benign — operator re-mentioned the bot in the
+      // same thread. Other errors are worth logging for ops visibility.
+      const benign = data?.error === "already_reacted";
+      const level = benign ? "info" : "warn";
+      log[level]({ error: data?.error, channel, ts, emoji }, "Slack reactions.add returned ok:false");
+    }
+  } catch (err) {
+    log.error({ err, channel, ts, emoji }, "Slack reactions.add failed");
+  }
+}

--- a/packages/core/src/pm/slack-interface.ts
+++ b/packages/core/src/pm/slack-interface.ts
@@ -20,7 +20,7 @@ import { createLogger } from "../logger.js";
 import { sanitize } from "../executor/prompt/sanitizer.js";
 import { parseJsonObject } from "../executor/agent-stream.js";
 import { makeCallClaude, makeCallClaudeSonnet } from "./call-claude.js";
-import { postSlackMessage } from "./slack-helpers.js";
+import { postSlackMessage, reactToSlackMessage } from "./slack-helpers.js";
 import { executePmCommand } from "./slack-commands.js";
 import type { CommandExecutorDeps, PmCommand } from "./slack-commands.js";
 
@@ -64,6 +64,9 @@ const VALID_PM_COMMAND_TYPES = [
   "pause",
   "resume",
   "assign",
+  "cancel",
+  "stop",
+  "halt",
   "unknown",
 ] as const satisfies readonly PmCommandType[];
 
@@ -112,6 +115,17 @@ export interface SlackInterfaceConfig {
   callClaudeSonnet?: (prompt: string) => Promise<string>;
   /** BEC-135: optional handler for /release subcommands. */
   releaseHandler?: (params: { text: string; userId: string }) => Promise<{ text: string; responseType: "ephemeral" | "in_channel" }>;
+  /**
+   * Live runner reference. Required for the `cancel`/`stop`/`halt` Slack
+   * commands. When absent, those commands report a clear configuration error
+   * instead of silently no-op'ing.
+   */
+  runner?: {
+    requestStop?: (runId: string, mode: "cancel" | "graceful") => { issueId: string | null; mode: "cancel" | "graceful" };
+    haltAll?: () => { cancelledRunIds: string[] };
+  };
+  /** DB handle for audit-event writes from stop/halt commands. */
+  db?: any;
 }
 
 export interface AssignedNotification {
@@ -233,6 +247,15 @@ export function parsePmCommand(text: string): PmCommand {
   if (/^status$/i.test(trimmed)) return { type: "status" };
   if (/^pause$/i.test(trimmed)) return { type: "pause" };
   if (/^resume$/i.test(trimmed)) return { type: "resume" };
+  if (/^halt$/i.test(trimmed)) return { type: "halt" };
+
+  // `cancel <runId>` and `stop <runId>` — runId is a nanoid (URL-safe chars,
+  // 8+ in practice). Not validated against the DB here; the executor reports
+  // "not found" for invalid ids so the operator sees a clear failure.
+  const cancelMatch = trimmed.match(/^cancel\s+([A-Za-z0-9_-]{6,})$/i);
+  if (cancelMatch) return { type: "cancel", runId: cancelMatch[1] };
+  const stopMatch = trimmed.match(/^stop\s+([A-Za-z0-9_-]{6,})$/i);
+  if (stopMatch) return { type: "stop", runId: stopMatch[1] };
 
   return { type: "unknown", original: text };
 }
@@ -250,7 +273,7 @@ export async function interpretNaturalLanguage(
   callClaude: (prompt: string) => Promise<string>,
 ): Promise<PmCommand> {
   const safe = sanitize(message);
-  const prompt = `You are a PM Agent assistant. The following Slack message was sent to you:\n\n"${safe}"\n\nClassify it as exactly ONE of these JSON responses (no other text):\n{"type":"prioritize","issueId":"<id>"}\n{"type":"create","title":"<t>","description":"<d>"}\n{"type":"bulk_create","request":"<original request>"}\n{"type":"status"}\n{"type":"pause"}\n{"type":"resume"}\n{"type":"assign","issueId":"<id>"}\n{"type":"unknown","original":"${safe}"}\n\nRules:\n- Issue IDs look like BEC-25, ENG-42, etc.\n- "more urgent" / "higher priority" → prioritize\n- "add", "open a ticket", "create" → create (single issue with clear title)\n- "create issues for", "find gaps and create", "generate issues", "analyze and create multiple", "create tickets for all" → bulk_create (multiple issues from analysis)\n- "what's running", "show queue" → status\n- "stop", "pause" → pause\n- "start again", "unpause", "resume" → resume\n- "move to todo", "assign" → assign\n- Use bulk_create when the request implies analysis or generating multiple issues, not a single specific issue\n\nRespond ONLY with the JSON object.`;
+  const prompt = `You are a PM Agent assistant. The following Slack message was sent to you:\n\n"${safe}"\n\nClassify it as exactly ONE of these JSON responses (no other text):\n{"type":"prioritize","issueId":"<id>"}\n{"type":"create","title":"<t>","description":"<d>"}\n{"type":"bulk_create","request":"<original request>"}\n{"type":"status"}\n{"type":"pause"}\n{"type":"resume"}\n{"type":"assign","issueId":"<id>"}\n{"type":"cancel","runId":"<runId>"}\n{"type":"stop","runId":"<runId>"}\n{"type":"halt"}\n{"type":"unknown","original":"${safe}"}\n\nRules:\n- Issue IDs look like BEC-25, ENG-42, etc. Run IDs are longer alphanumeric (nanoid).\n- "more urgent" / "higher priority" → prioritize\n- "add", "open a ticket", "create" → create (single issue with clear title)\n- "create issues for", "find gaps and create", "generate issues", "analyze and create multiple", "create tickets for all" → bulk_create (multiple issues from analysis)\n- "what's running", "show queue" → status\n- "pause the agent" / "stop assigning" → pause\n- "start again", "unpause", "resume" → resume\n- "move to todo", "assign" → assign\n- "cancel run <id>", "kill run <id>", "abort run <id>" → cancel (mid-stream interrupt)\n- "stop run <id>", "graceful stop <id>", "wind down run <id>" → stop (finish current stage, then quit)\n- "halt everything", "stop everything", "emergency stop", "pause all and cancel" → halt\n- Use bulk_create when the request implies analysis or generating multiple issues, not a single specific issue\n- Treat \`pause\` (single-word, no runId) as the PM-agent pause, NOT halt. Halt is the explicit "halt the whole container" intent.\n\nRespond ONLY with the JSON object.`;
 
   try {
     const raw = await callClaude(prompt);
@@ -376,11 +399,18 @@ export function createSlackInterface(config: SlackInterfaceConfig): {
 
   const callClaude = config.callClaude ?? makeCallClaude();
   const callClaudeSonnet = config.callClaudeSonnet ?? makeCallClaudeSonnet();
-  const executorDeps: CommandExecutorDeps = {
+  const baseExecutorDeps: CommandExecutorDeps = {
     linearApiKey: config.linearApiKey,
     teamIds: config.teamIds,
     callClaudeSonnet,
+    runner: config.runner,
+    db: config.db,
   };
+  // Per-request deps thread the Slack user id through for audit attribution.
+  const withSlackUser = (slackUserId: string): CommandExecutorDeps => ({
+    ...baseExecutorDeps,
+    slackUserId,
+  });
 
   // Helper: verify Slack signature and return 401 on failure
   async function checkSignature(c: any): Promise<string | null> {
@@ -427,24 +457,46 @@ export function createSlackInterface(config: SlackInterfaceConfig): {
       return c.json({ response_type: r.responseType, text: r.text });
     }
 
-    // Default: /pm path (preserves existing behavior).
-    let cmd = parsePmCommand(commandText);
+    // Default: /pm path. When a response_url is present (the normal case in
+    // production), ack immediately with a :thinking_face: line and post the
+    // real reply asynchronously — this lets slow commands (bulk_create,
+    // anything that hits Linear/Sonnet) take their time without tripping
+    // Slack's 3s slash-command timeout. When no response_url is available
+    // (rare; only legacy/non-production callers), fall back to the
+    // synchronous path so the operator still sees a result.
+    if (responseUrl) {
+      void (async () => {
+        try {
+          let cmd = parsePmCommand(commandText);
+          if (cmd.type === "unknown" && commandText.length > 0) {
+            cmd = await interpretNaturalLanguage(commandText, callClaude);
+          }
+          const replyText = await executePmCommand(cmd, withSlackUser(userId));
+          await postToResponseUrl(responseUrl, replyText);
+        } catch (err) {
+          log.error({ err }, "async slash command processing failed");
+          try {
+            await postToResponseUrl(
+              responseUrl,
+              ":warning: Something went wrong while processing that command. Check the urateam logs.",
+            );
+          } catch {
+            // already logged above
+          }
+        }
+      })();
+      return c.json({
+        response_type: "ephemeral",
+        text: ":thinking_face: Working on it…",
+      });
+    }
 
-    // Fall back to NL interpretation if command is unknown
+    // No response_url — process synchronously.
+    let cmd = parsePmCommand(commandText);
     if (cmd.type === "unknown" && commandText.length > 0) {
       cmd = await interpretNaturalLanguage(commandText, callClaude);
     }
-
-    const replyText = await executePmCommand(cmd, executorDeps);
-
-    // If a response_url is provided, post back asynchronously
-    if (responseUrl) {
-      postToResponseUrl(responseUrl, replyText).catch((err) =>
-        log.error({ err }, "failed to post to Slack response_url"),
-      );
-    }
-
-    // Immediate acknowledgement (required within 3s)
+    const replyText = await executePmCommand(cmd, withSlackUser(userId));
     return c.json({ response_type: "ephemeral", text: replyText });
   });
 
@@ -494,9 +546,27 @@ export function createSlackInterface(config: SlackInterfaceConfig): {
 
         log.info({ messageText }, "received Slack message event");
 
-        // Process asynchronously — acknowledge immediately
-        processMessageAsync(messageText, event.channel ?? config.channelId, config.botToken, callClaude, executorDeps)
-          .catch((err) => log.error({ err }, "async message processing failed"));
+        // UX: react with :thinking_face: immediately so the user sees the bot
+        // picked up the mention. processMessageAsync swaps it for
+        // :white_check_mark: on success or :warning: on failure. The reaction
+        // is best-effort — failure logs but never blocks the actual work.
+        const channelForReact = event.channel ?? config.channelId;
+        const ts = typeof event.ts === "string" ? event.ts : null;
+        if (ts) {
+          void reactToSlackMessage(config.botToken, channelForReact, ts, "thinking_face");
+        }
+
+        // Process asynchronously — acknowledge immediately. Use the Slack
+        // event's user id for audit attribution (mentions in the PM channel).
+        const eventUserId = typeof event.user === "string" ? event.user : "";
+        processMessageAsync(
+          messageText,
+          channelForReact,
+          config.botToken,
+          callClaude,
+          withSlackUser(eventUserId),
+          ts,
+        ).catch((err) => log.error({ err }, "async message processing failed"));
       }
     }
 
@@ -528,8 +598,52 @@ async function processMessageAsync(
   botToken: string,
   callClaude: (prompt: string) => Promise<string>,
   deps: CommandExecutorDeps,
+  /** Optional message ts so reactions can be swapped after processing completes. */
+  ts: string | null = null,
 ): Promise<void> {
-  const cmd = await interpretNaturalLanguage(text, callClaude);
-  const replyText = await executePmCommand(cmd, deps);
-  await postSlackMessage(botToken, { channel, text: replyText });
+  let success = false;
+  try {
+    const cmd = await interpretNaturalLanguage(text, callClaude);
+    const replyText = await executePmCommand(cmd, deps);
+    await postSlackMessage(botToken, { channel, text: replyText });
+    success = true;
+  } finally {
+    if (ts) {
+      // Best-effort reaction swap. Removing :thinking_face: is non-fatal: if
+      // the remove fails (e.g. someone manually removed it), the add still
+      // runs — the user just sees one more reaction than expected.
+      void removeReaction(botToken, channel, ts, "thinking_face");
+      void reactToSlackMessage(
+        botToken,
+        channel,
+        ts,
+        success ? "white_check_mark" : "warning",
+      );
+    }
+  }
 }
+
+async function removeReaction(
+  botToken: string,
+  channel: string,
+  ts: string,
+  emoji: string,
+): Promise<void> {
+  try {
+    const resp = await fetch("https://slack.com/api/reactions.remove", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${botToken}`,
+      },
+      body: JSON.stringify({ channel, timestamp: ts, name: emoji }),
+    });
+    const data = (await resp.json()) as any;
+    if (!data?.ok && data?.error !== "no_reaction") {
+      log.info({ error: data?.error, channel, ts, emoji }, "Slack reactions.remove returned ok:false");
+    }
+  } catch (err) {
+    log.info({ err, channel, ts, emoji }, "Slack reactions.remove failed (non-fatal)");
+  }
+}
+

--- a/packages/core/src/rbac/matrix.ts
+++ b/packages/core/src/rbac/matrix.ts
@@ -7,6 +7,8 @@ const log = createLogger({ component: "rbac" });
 export const PERMISSION_MATRIX = {
   "runs.view":         ["admin", "operator", "viewer"],
   "runs.retry":        ["admin", "operator"],
+  "runs.stop":         ["admin", "operator"],
+  "system.halt":       ["admin", "operator"],
   "tokens.view":       ["admin", "operator", "viewer"],
   "audit.view":        ["admin", "operator"],
   "audit.export":      ["admin", "operator"],

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -139,6 +139,13 @@ export async function createApp(config: ServerConfig) {
         channelId: config.pmSlack.channelId,
         linearApiKey: config.linearApiKey,
         teamIds: config.pmSlack.teamIds,
+        // Wire the live runner so `/pm cancel|stop|halt` fire real signals;
+        // db is threaded through for audit-event writes from those commands.
+        runner: {
+          requestStop: runner.requestStop.bind(runner),
+          haltAll: runner.haltAll.bind(runner),
+        },
+        db: db as any,
       });
       app.route("/", slackRouter);
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -325,9 +325,18 @@ export interface TokenBudget {
 }
 
 // --- Run Status ---
-export type PipelineRunStatus = "queued" | "running" | "completed" | "failed" | "aborted" | "paused";
-export type StageRunStatus = "running" | "completed" | "failed" | "skipped";
-export type AgentLogType = "tool_call" | "tool_result" | "message" | "error";
+export type PipelineRunStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "aborted"
+  | "paused"
+  /** Operator-initiated stop (cancel/graceful via dashboard, Slack, or CLI).
+   *  Distinct from "aborted" (system-initiated, e.g. token budget). */
+  | "cancelled";
+export type StageRunStatus = "running" | "completed" | "failed" | "skipped" | "cancelled";
+export type AgentLogType = "tool_call" | "tool_result" | "message" | "error" | "cancelled";
 
 // --- Sanitized Issue ---
 export interface SanitizedIssue {
@@ -342,7 +351,7 @@ export interface SanitizedIssue {
 
 // --- Stage Result ---
 export interface StageResult {
-  status: "completed" | "failed";
+  status: "completed" | "failed" | "cancelled";
   handoffArtifact?: HandoffArtifact;
   /** True when the agent produced a valid structured handoff JSON block.
    *  NOTE: not persisted to DB yet — runtime-only. Add a column if needed for dashboards/queries. */
@@ -450,6 +459,10 @@ export interface SandboxConfig {
 export const AuditEventTypeSchema = z.enum([
   "run.started", "run.completed", "run.failed",
   "run.auto_merged", "run.auto_merge_skipped",
+  /** Operator-initiated stop of a single run (mode: "cancel" | "graceful"). */
+  "run.cancelled",
+  /** Operator-initiated container-wide halt (pause PM + cancel all in-flight). */
+  "system.halted",
   "pm.approval_requested", "pm.approval_resolved",
   "pm.issue_promoted", "pm.issue_deprioritized", "pm.issue_cancelled",
   "pm.triage_classified",
@@ -473,6 +486,8 @@ export type AuditEventType = z.infer<typeof AuditEventTypeSchema>;
 export const AuditActorTypeSchema = z.enum([
   "system", "pm-agent", "webhook", "dashboard-user", "cli",
   "release-manager",
+  /** Slack-initiated action (slash command or DM/@mention). */
+  "slack",
 ]);
 export type AuditActorType = z.infer<typeof AuditActorTypeSchema>;
 

--- a/packages/dashboard/src/__tests__/cli-stop-routes.test.ts
+++ b/packages/dashboard/src/__tests__/cli-stop-routes.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createDb } from "@urateam/core";
+import { pipelineRuns } from "@urateam/core/dist/db/schema.js";
+import { createRunsRouter } from "../routes/runs.js";
+
+let db: any;
+
+beforeEach(async () => {
+  db = await createDb({ connectionString: ":memory:" });
+  await db.insert(pipelineRuns).values({
+    id: "run_active",
+    issueId: "BEC-1",
+    issueTitle: "in flight",
+    pipelineKey: "auto-implement",
+    repoUrl: "https://github.com/acme/api",
+    status: "running",
+    startedAt: new Date(),
+  });
+  process.env.URATEAM_CLI_TOKEN = "test-token-1234567890-secret";
+});
+
+afterEach(() => {
+  delete process.env.URATEAM_CLI_TOKEN;
+});
+
+function appWith(runner: any) {
+  const app = new Hono();
+  app.route("/", createRunsRouter({ db, runner, basePath: "" }));
+  return app;
+}
+
+describe("CLI /cli/* routes — token check", () => {
+  it("returns 404 when URATEAM_CLI_TOKEN is unset", async () => {
+    delete process.env.URATEAM_CLI_TOKEN;
+    const app = appWith({ resume: vi.fn(), start: vi.fn() });
+    const res = await app.request("/cli/runs/run_active/cancel", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 on missing token", async () => {
+    const app = appWith({ resume: vi.fn(), start: vi.fn() });
+    const res = await app.request("/cli/runs/run_active/cancel", { method: "POST" });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 on wrong token", async () => {
+    const app = appWith({ resume: vi.fn(), start: vi.fn() });
+    const res = await app.request("/cli/runs/run_active/cancel", {
+      method: "POST",
+      headers: { "x-ura-cli-token": "wrong" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 on token that is the right LENGTH but wrong value (catches non-constant-time regression)", async () => {
+    const app = appWith({ resume: vi.fn(), start: vi.fn() });
+    const wrong = "x".repeat(process.env.URATEAM_CLI_TOKEN!.length);
+    const res = await app.request("/cli/runs/run_active/cancel", {
+      method: "POST",
+      headers: { "x-ura-cli-token": wrong },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("happy path: valid token → runner.requestStop called with cancel mode", async () => {
+    const requestStop = vi.fn().mockReturnValue({ issueId: "BEC-1", mode: "cancel" });
+    const app = appWith({ resume: vi.fn(), start: vi.fn(), requestStop });
+    const res = await app.request("/cli/runs/run_active/cancel", {
+      method: "POST",
+      headers: {
+        "x-ura-cli-token": process.env.URATEAM_CLI_TOKEN!,
+        "x-ura-actor": "alice",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(requestStop).toHaveBeenCalledWith("run_active", "cancel");
+    const body = await res.json() as any;
+    expect(body.runId).toBe("run_active");
+    expect(body.mode).toBe("cancel");
+  });
+
+  it("happy path: /cli/runs/:id/stop uses graceful mode", async () => {
+    const requestStop = vi.fn().mockReturnValue({ issueId: "BEC-1", mode: "graceful" });
+    const app = appWith({ resume: vi.fn(), start: vi.fn(), requestStop });
+    const res = await app.request("/cli/runs/run_active/stop", {
+      method: "POST",
+      headers: { "x-ura-cli-token": process.env.URATEAM_CLI_TOKEN! },
+    });
+    expect(res.status).toBe(200);
+    expect(requestStop).toHaveBeenCalledWith("run_active", "graceful");
+  });
+
+  it("happy path: /cli/halt-all calls runner.haltAll and returns cancelledRunIds", async () => {
+    const haltAll = vi.fn().mockReturnValue({ cancelledRunIds: ["r1", "r2"] });
+    const app = appWith({ resume: vi.fn(), start: vi.fn(), haltAll });
+    const res = await app.request("/cli/halt-all", {
+      method: "POST",
+      headers: { "x-ura-cli-token": process.env.URATEAM_CLI_TOKEN! },
+    });
+    expect(res.status).toBe(200);
+    expect(haltAll).toHaveBeenCalled();
+    const body = await res.json() as any;
+    expect(body.cancelledRunIds).toEqual(["r1", "r2"]);
+  });
+
+  it("returns 409 when run is already in a terminal status", async () => {
+    await db.update(pipelineRuns).set({ status: "completed" });
+    const requestStop = vi.fn();
+    const app = appWith({ resume: vi.fn(), start: vi.fn(), requestStop });
+    const res = await app.request("/cli/runs/run_active/cancel", {
+      method: "POST",
+      headers: { "x-ura-cli-token": process.env.URATEAM_CLI_TOKEN! },
+    });
+    expect(res.status).toBe(409);
+    expect(requestStop).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for unknown runId", async () => {
+    const requestStop = vi.fn();
+    const app = appWith({ resume: vi.fn(), start: vi.fn(), requestStop });
+    const res = await app.request("/cli/runs/missing/cancel", {
+      method: "POST",
+      headers: { "x-ura-cli-token": process.env.URATEAM_CLI_TOKEN! },
+    });
+    expect(res.status).toBe(404);
+    expect(requestStop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/middleware/sso.ts
+++ b/packages/dashboard/src/middleware/sso.ts
@@ -30,12 +30,17 @@ export function createSsoMiddleware(
   const basePath = (deps.basePath ?? "").replace(/\/+$/, "");
   const authPrefix = `${basePath}/auth/`;
   const webhookPrefix = `${basePath}/webhooks/`;
+  // /cli/* endpoints use a shared-secret token check inside the route handler
+  // rather than session-cookie auth; skipping SSO here lets `ura stop`/`ura
+  // halt` work without a logged-in user.
+  const cliPrefix = `${basePath}/cli/`;
   const loginPath = `${basePath}/auth/login`;
 
   return async (c, next) => {
     const path = c.req.path;
     if (path.startsWith(authPrefix)) return next();
     if (path.startsWith(webhookPrefix)) return next();
+    if (path.startsWith(cliPrefix)) return next();
 
     const cookie = getCookie(c, deps.sso.cookieName);
     if (!cookie) {

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { desc, eq, inArray, count } from "drizzle-orm";
+import { timingSafeEqual } from "node:crypto";
 import type { Db } from "@urateam/core";
 import {
   pipelineRuns,
@@ -7,9 +8,12 @@ import {
   agentLogs,
   logAuditEvent,
   dashboardRetryRunEvent,
+  runCancelledEvent,
+  systemHaltedEvent,
   isFeatureLicensed,
   canAccess,
   type Role,
+  type StopMode,
 } from "@urateam/core";
 import { layout } from "../views/layout.js";
 import { runFeedView, type RunRow } from "../views/run-feed.js";
@@ -23,6 +27,10 @@ export interface RunsRouterDeps {
   runner?: {
     resume: (runOrIssueId: string) => Promise<void>;
     start: (...args: any[]) => Promise<void>;
+    /** Single-run stop. Looks up the issueId for the runId and records a stop signal. */
+    requestStop?: (runId: string, mode: StopMode) => { issueId: string | null; mode: StopMode };
+    /** Container-wide halt: pauses PM Agent + cancels every active run. */
+    haltAll?: () => { cancelledRunIds: string[] };
   };
   basePath?: string;
 }
@@ -130,7 +138,16 @@ export function createRunsRouter(
     const canRetry = isFeatureLicensed("rbac")
       ? canAccess((user?.role ?? "viewer") as Role, "runs.retry")
       : false;
-    const content = runDetailView(run, stages, logs, page, totalLogs, canRetry);
+    const canStop = isFeatureLicensed("rbac")
+      ? canAccess((user?.role ?? "viewer") as Role, "runs.stop")
+      : false;
+    const canHalt = isFeatureLicensed("rbac")
+      ? canAccess((user?.role ?? "viewer") as Role, "system.halt")
+      : false;
+    const content = runDetailView(run, stages, logs, page, totalLogs, canRetry, {
+      canStop,
+      canHalt,
+    });
     return c.html(layout(`Run ${id}`, content, effectiveBasePath, { userEmail: user?.email }));
   });
 
@@ -206,6 +223,220 @@ export function createRunsRouter(
       return c.redirect(target, 302);
     },
   );
+
+  /**
+   * Single-run stop. Two modes:
+   *  - POST /runs/:id/cancel  — interrupt the active stage stream immediately.
+   *  - POST /runs/:id/stop    — let the current stage finish, then stop.
+   *
+   * Both share the same handler factory; `mode` is bound at registration. The
+   * RBAC gate is `runs.stop` (operator+admin). Idempotent — calling on a run
+   * that's already terminal returns 409 so the operator gets feedback instead
+   * of silently accumulating audit events.
+   */
+  const stopHandler = (mode: StopMode) => async (c: any) => {
+    const id = c.req.param("id");
+    const rows = await d.select().from(pipelineRuns).where(eq(pipelineRuns.id, id)).limit(1);
+    if (rows.length === 0) return c.text("Run not found", 404);
+    const run = rows[0] as any;
+    const terminal = ["completed", "failed", "aborted", "cancelled"];
+    if (terminal.includes(run.status)) {
+      return c.text(`Cannot stop a run in status ${run.status}`, 409);
+    }
+
+    if (!runner?.requestStop) return c.text("Runner not configured", 500);
+    const { issueId } = runner.requestStop(id, mode);
+
+    const user = c.get("user" as never) as { id: string; email: string } | undefined;
+    if (user) {
+      void logAuditEvent(
+        db as any,
+        runCancelledEvent({
+          runId: id,
+          issueId: issueId ?? run.issueId,
+          actor: `dashboard:${user.email}`,
+          actorType: "dashboard-user",
+          mode,
+        }),
+      );
+    }
+
+    const target = `${effectiveBasePath}/runs/${id}`;
+    if (c.req.header("HX-Request")) {
+      c.header("HX-Redirect", target);
+      return c.body(null, 200);
+    }
+    return c.redirect(target, 302);
+  };
+
+  router.post(
+    "/runs/:id/cancel",
+    async (c, next) => {
+      if (!isFeatureLicensed("rbac")) return c.notFound();
+      return next();
+    },
+    requirePermission("runs.stop"),
+    stopHandler("cancel"),
+  );
+
+  router.post(
+    "/runs/:id/stop",
+    async (c, next) => {
+      if (!isFeatureLicensed("rbac")) return c.notFound();
+      return next();
+    },
+    requirePermission("runs.stop"),
+    stopHandler("graceful"),
+  );
+
+  /**
+   * Container-wide halt: pauses the PM Agent and cancels every active run.
+   * Reversible — operators can unpause via Slack `/pm resume` (or the planned
+   * dashboard equivalent) and re-trigger individual runs via retry. Cancelled
+   * runs themselves stay cancelled.
+   */
+  router.post(
+    "/admin/halt-all",
+    async (c, next) => {
+      if (!isFeatureLicensed("rbac")) return c.notFound();
+      return next();
+    },
+    requirePermission("system.halt"),
+    async (c) => {
+      if (!runner?.haltAll) return c.text("Runner not configured", 500);
+      const { cancelledRunIds } = runner.haltAll();
+
+      const user = c.get("user" as never) as { id: string; email: string } | undefined;
+      if (user) {
+        void logAuditEvent(
+          db as any,
+          systemHaltedEvent({
+            actor: `dashboard:${user.email}`,
+            actorType: "dashboard-user",
+            cancelledRunIds,
+          }),
+        );
+        // Per-run audit trail so each affected run shows the cancel reason in
+        // the audit feed alongside the halt event.
+        for (const runId of cancelledRunIds) {
+          const [row] = await d
+            .select({ issueId: pipelineRuns.issueId })
+            .from(pipelineRuns)
+            .where(eq(pipelineRuns.id, runId))
+            .limit(1);
+          if (row?.issueId) {
+            void logAuditEvent(
+              db as any,
+              runCancelledEvent({
+                runId,
+                issueId: row.issueId,
+                actor: `dashboard:${user.email}`,
+                actorType: "dashboard-user",
+                mode: "cancel",
+                reason: "system.halt",
+              }),
+            );
+          }
+        }
+      }
+
+      const target = `${effectiveBasePath}/`;
+      if (c.req.header("HX-Request")) {
+        c.header("HX-Redirect", target);
+        return c.body(null, 200);
+      }
+      return c.redirect(target, 302);
+    },
+  );
+
+  /**
+   * CLI-facing endpoints. Auth: shared secret in `X-Ura-Cli-Token` matching
+   * `URATEAM_CLI_TOKEN`. No RBAC dependency so this works in OSS deployments.
+   * Disabled (404) when `URATEAM_CLI_TOKEN` is unset — the absence of the
+   * secret is treated as "CLI control is opt-in", not "any caller is allowed".
+   *
+   * Actor in audit events is `cli:<x-ura-actor>` where the header is provided
+   * by the CLI from the local OS user so emergency stops are traceable.
+   */
+  const requireCliToken = async (c: any, next: any) => {
+    const expected = process.env.URATEAM_CLI_TOKEN;
+    if (!expected) return c.notFound();
+    const got = c.req.header("x-ura-cli-token") ?? "";
+    // Constant-time comparison — matches `verifyLinearSignature` and the SSO
+    // state-HMAC check. Length-mismatch short-circuits before timingSafeEqual
+    // because it requires equal-length buffers.
+    let ok = false;
+    if (got.length === expected.length) {
+      try {
+        ok = timingSafeEqual(Buffer.from(got), Buffer.from(expected));
+      } catch {
+        ok = false;
+      }
+    }
+    if (!ok) return c.text("invalid CLI token", 403);
+    return next();
+  };
+  const cliActor = (c: any): string => `cli:${c.req.header("x-ura-actor") ?? "unknown"}`;
+
+  const cliStopHandler = (mode: StopMode) => async (c: any) => {
+    const id = c.req.param("id");
+    const rows = await d.select().from(pipelineRuns).where(eq(pipelineRuns.id, id)).limit(1);
+    if (rows.length === 0) return c.text("Run not found", 404);
+    const run = rows[0] as any;
+    if (["completed", "failed", "aborted", "cancelled"].includes(run.status)) {
+      return c.json({ error: `Cannot stop a run in status ${run.status}` }, 409);
+    }
+    if (!runner?.requestStop) return c.text("Runner not configured", 500);
+    const { issueId } = runner.requestStop(id, mode);
+    void logAuditEvent(
+      db as any,
+      runCancelledEvent({
+        runId: id,
+        issueId: issueId ?? run.issueId,
+        actor: cliActor(c),
+        actorType: "cli",
+        mode,
+      }),
+    );
+    return c.json({ runId: id, mode, issueId: issueId ?? run.issueId });
+  };
+
+  router.post("/cli/runs/:id/cancel", requireCliToken, cliStopHandler("cancel"));
+  router.post("/cli/runs/:id/stop", requireCliToken, cliStopHandler("graceful"));
+
+  router.post("/cli/halt-all", requireCliToken, async (c) => {
+    if (!runner?.haltAll) return c.text("Runner not configured", 500);
+    const { cancelledRunIds } = runner.haltAll();
+    void logAuditEvent(
+      db as any,
+      systemHaltedEvent({
+        actor: cliActor(c),
+        actorType: "cli",
+        cancelledRunIds,
+      }),
+    );
+    for (const runId of cancelledRunIds) {
+      const [row] = await d
+        .select({ issueId: pipelineRuns.issueId })
+        .from(pipelineRuns)
+        .where(eq(pipelineRuns.id, runId))
+        .limit(1);
+      if (row?.issueId) {
+        void logAuditEvent(
+          db as any,
+          runCancelledEvent({
+            runId,
+            issueId: row.issueId,
+            actor: cliActor(c),
+            actorType: "cli",
+            mode: "cancel",
+            reason: "system.halt",
+          }),
+        );
+      }
+    }
+    return c.json({ cancelledRunIds });
+  });
 
   return router;
 }

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -30,6 +30,19 @@ export interface DashboardConfig {
   db: Db;
   pipelineConfigs: Record<string, PipelineConfig>;
   repoConfigs: Record<string, RepoConfig>;
+  /**
+   * Optional reference to the pipeline runner. Wires the stop/halt buttons
+   * (and the audit-logged routes behind them) to the live in-process runner.
+   * When absent (e.g. read-only dashboard deployments), the buttons render
+   * only if the user has the right role but the POST handlers respond 500
+   * with "Runner not configured" — visible failure rather than silent no-op.
+   */
+  runner?: {
+    resume: (runOrIssueId: string) => Promise<void>;
+    start: (...args: any[]) => Promise<void>;
+    requestStop?: (runId: string, mode: "cancel" | "graceful") => { issueId: string | null; mode: "cancel" | "graceful" };
+    haltAll?: () => { cancelledRunIds: string[] };
+  };
   /** Optional costs config for the Cost & ROI dashboard (enterprise). */
   costs?: CostsConfig;
   auth?: { username: string; password: string };
@@ -137,9 +150,14 @@ export function createDashboard(config: DashboardConfig): Hono {
     // a logout.
     const path = c.req.path;
     const csrfExempt = csrfExemptPaths.has(path);
+    // /cli/* endpoints carry their own shared-secret auth (X-Ura-Cli-Token)
+    // and are not browser-reachable forms — CSRF doesn't apply. The token
+    // check inside the /cli/* router rejects unauthenticated requests.
+    const isCliPath = path.startsWith(`${csrfExemptBase}/cli/`);
     if (
       ["POST", "PUT", "DELETE", "PATCH"].includes(method) &&
-      !csrfExempt
+      !csrfExempt &&
+      !isCliPath
     ) {
       // Require HX-Request header on HTMX-driven state-changing endpoints
       if (!c.req.header("HX-Request")) {
@@ -205,13 +223,17 @@ export function createDashboard(config: DashboardConfig): Hono {
       createSsoMiddleware({ db: config.db, sso: config.sso!, basePath }),
     );
   } else if (config.auth?.username && config.auth?.password) {
-    app.use(
-      "*",
-      basicAuth({
-        username: config.auth.username,
-        password: config.auth.password,
-      }),
-    );
+    // Skip basic auth for /cli/* — those routes guard themselves with the
+    // X-Ura-Cli-Token shared secret. Without this skip, the CLI would have
+    // to know DASHBOARD_PASSWORD on top of URATEAM_CLI_TOKEN.
+    const cliPrefix = `${basePath}/cli/`;
+    app.use("*", async (c, next) => {
+      if (c.req.path.startsWith(cliPrefix)) return next();
+      return basicAuth({
+        username: config.auth!.username,
+        password: config.auth!.password,
+      })(c, next);
+    });
     // BEC-156: synthesize an admin user after basicAuth verifies credentials.
     // Without this, the RBAC middleware (`requirePermission`) on Enterprise
     // tier looks for c.user — which only the SSO middleware sets — and 401's
@@ -238,7 +260,12 @@ export function createDashboard(config: DashboardConfig): Hono {
       await next();
     });
   } else {
-    app.use("*", async (c) => {
+    const cliPrefix = `${basePath}/cli/`;
+    app.use("*", async (c, next) => {
+      // Even with no dashboard auth configured, /cli/* must still be reachable
+      // (its own token check enforces access). Without this carve-out the
+      // 503 here would shadow the CLI control plane.
+      if (c.req.path.startsWith(cliPrefix)) return next();
       return c.text(
         "Dashboard authentication is required but not configured. " +
           "Set DASHBOARD_USER and DASHBOARD_PASSWORD environment variables and restart.",
@@ -277,7 +304,11 @@ export function createDashboard(config: DashboardConfig): Hono {
   // Mount each sub-router at the basePath prefix. basePath also continues to
   // get passed INTO each router so layout() emits correct hrefs — the two
   // concerns (mount vs. link generation) are separate but share the value.
-  const runsRouter = createRunsRouter(config.db, basePath);
+  const runsRouter = createRunsRouter({
+    db: config.db,
+    runner: config.runner,
+    basePath,
+  });
   app.route(mountPrefix, runsRouter);
 
   const tokensRouter = createTokensRouter(config.db, basePath);

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -80,6 +80,11 @@ function formatJson(raw: string | null): string {
   }
 }
 
+export interface RunDetailExtraOptions {
+  canStop?: boolean;
+  canHalt?: boolean;
+}
+
 export function runDetailView(
   run: RunInfo,
   stages: StageInfo[],
@@ -87,12 +92,15 @@ export function runDetailView(
   page: number,
   totalLogs: number,
   canRetry: boolean = false,
+  extra: RunDetailExtraOptions = {},
 ): string {
   const basePath = getBasePath();
   const logsPerPage = 50;
   const totalPages = Math.max(1, Math.ceil(totalLogs / logsPerPage));
   const duration = formatDuration(run.startedAt, run.completedAt);
   const isInFlight = run.status === "running" || run.status === "queued";
+  const canStop = !!extra.canStop;
+  const canHalt = !!extra.canHalt;
 
   const metaHtml = `<div class="card">
     <h2>Run Details</h2>
@@ -121,6 +129,70 @@ export function runDetailView(
                   </form>
                   <form method="post" action="${action}" hx-post="${action}" hx-headers='{"HX-Request":"true"}' style="margin:0;">
                     <button type="submit" class="button-primary">Confirm retry</button>
+                  </form>
+                </div>
+              </dialog>`;
+            })()
+          : ""
+      }
+      ${
+        canStop && isInFlight
+          ? (() => {
+              const dialogId = `stop-confirm-${run.id}`;
+              const cancelAction = `${basePath}/runs/${encodeURIComponent(run.id)}/cancel`;
+              const stopAction = `${basePath}/runs/${encodeURIComponent(run.id)}/stop`;
+              return `<button
+                type="button"
+                class="button-secondary"
+                data-open-dialog="${escapeHtml(dialogId)}"
+                title="Stop this run"
+              >Stop…</button>
+              <dialog id="${escapeHtml(dialogId)}" class="retry-confirm-dialog">
+                <h3 style="margin-top:0;">Stop this run</h3>
+                <p style="margin:0.5rem 0 0.5rem;color:var(--color-text-muted);">
+                  <strong>Cancel (immediate):</strong> interrupts the current stage mid-stream. Tokens already spent are lost. Use for incident response.
+                </p>
+                <p style="margin:0 0 1rem;color:var(--color-text-muted);">
+                  <strong>Graceful:</strong> lets the current stage finish, then skips the rest. Slower; consistent worktree state. Cheapest cleanup.
+                </p>
+                <div style="display:flex;gap:0.5rem;justify-content:flex-end;flex-wrap:wrap;">
+                  <form method="dialog" style="margin:0;">
+                    <button type="submit" class="button-secondary">Keep running</button>
+                  </form>
+                  <form method="post" action="${stopAction}" hx-post="${stopAction}" hx-headers='{"HX-Request":"true"}' style="margin:0;">
+                    <button type="submit" class="button-secondary">Graceful stop</button>
+                  </form>
+                  <form method="post" action="${cancelAction}" hx-post="${cancelAction}" hx-headers='{"HX-Request":"true"}' style="margin:0;">
+                    <button type="submit" class="button-primary" style="background:var(--color-red);">Cancel immediately</button>
+                  </form>
+                </div>
+              </dialog>`;
+            })()
+          : ""
+      }
+      ${
+        canHalt
+          ? (() => {
+              const dialogId = `halt-all-confirm`;
+              const action = `${basePath}/admin/halt-all`;
+              return `<button
+                type="button"
+                class="button-secondary"
+                data-open-dialog="${escapeHtml(dialogId)}"
+                title="Halt the entire container"
+                style="margin-left:auto;color:var(--color-red);border-color:var(--color-red);"
+              >Halt all…</button>
+              <dialog id="${escapeHtml(dialogId)}" class="retry-confirm-dialog">
+                <h3 style="margin-top:0;">Halt entire container</h3>
+                <p style="margin:0.5rem 0 1rem;color:var(--color-text-muted);">
+                  Pauses the PM Agent (no new runs promoted) <strong>and</strong> cancels every in-flight pipeline + feedback run. Reversible: unpause via Slack <code>/pm resume</code>; cancelled runs themselves stay cancelled.
+                </p>
+                <div style="display:flex;gap:0.5rem;justify-content:flex-end;">
+                  <form method="dialog" style="margin:0;">
+                    <button type="submit" class="button-secondary">Never mind</button>
+                  </form>
+                  <form method="post" action="${action}" hx-post="${action}" hx-headers='{"HX-Request":"true"}' style="margin:0;">
+                    <button type="submit" class="button-primary" style="background:var(--color-red);">Halt all</button>
                   </form>
                 </div>
               </dialog>`;


### PR DESCRIPTION
## Summary

Two coordinated features:

**1. Quality Observer → `needs-design` triage gate** (`85cc2ff`)

Quality Observer was filing a new GH issue (synced to Linear) for every pipeline run with >50 turns. The fingerprint includes the runId, so each flagged run became a new ticket — and the implement pipeline then burned tokens trying to "fix" what was a non-actionable diagnostic finding. PM Agent triage now short-circuits when it detects the observer body marker (`<!-- urateam-qo-observer:`, preserved through gh-linear-sync's verbatim body copy) and routes the ticket to `needs-design`. That pipeline's `await-approval` stage gates a human before any implement-stage tokens are spent.

**2. Operator stop & container halt across three surfaces** (`4c963db`, `d914030`)

- **Cancel a run**: aborts the active Agent SDK stream mid-stage via an `AbortController` wired into `consumeAgentStream`. New `StageCancelledError` distinguishes operator cancels from system aborts.
- **Graceful stop a run**: lets the current stage finish, then skips remaining stages at the per-stage signal check.
- **Halt all**: pauses the PM Agent (reuses BEC-170 flag) AND sends cancel to every active pipeline + feedback run.

Three surfaces, all funnel through `Runner.requestStop` / `Runner.haltAll`:
- **Dashboard**: `POST /runs/:id/{cancel,stop}` and `/admin/halt-all`, RBAC-gated (`runs.stop`, `system.halt`), CSRF via `HX-Request`. Buttons + confirm dialogs on the run-detail page.
- **CLI**: `ura stop <runId> [--graceful]`, `ura halt`. Talks to `/cli/*` guarded by `URATEAM_CLI_TOKEN` (constant-time compare); works in any license tier.
- **Slack**: `/pm cancel|stop|halt` with parser + Haiku NL classifier. Reacts with 🤔 on app_mention / message (swaps to ✅ / ⚠️ on completion); slash commands return immediate ephemeral "Working on it…" and post real reply via `response_url` so slow commands don't trip Slack's 3s timeout.

Audit events `run.cancelled` and `system.halted` record actor and mode.

## Test plan

- [x] `pnpm test` green (1639 tests pass; the 5 "failed" reported by bare `npx vitest run` are pre-existing integration timeouts + 2 empty test files + 1 missing tarball build artifact — none from this PR)
- [x] 11 new control-signals tests, 3 new agent-stream abort tests, 7 new Slack stop/halt tests, 3 new triage gate tests, 9 new dashboard `/cli/*` route tests (including a non-constant-time regression guard sending a wrong token of the right length)
- [ ] Manual smoke test on dogfood: trigger `/pm cancel <runId>` mid-stage, verify run lands in `cancelled` status
- [ ] Manual smoke test: `ura halt`, verify all in-flight runs cancel + PM pauses
- [ ] Verify the dashboard Stop… / Halt all… confirm dialogs render and submit correctly

## Docs

- New `deploy/STOP_AND_HALT.md` runbook
- `CLAUDE.md` updated with both features
- `.env.dogfood.example` documents `URATEAM_CLI_TOKEN`

## Review

Sonnet reviewed; three findings addressed in `d914030`:
1. CLI token compare now uses `timingSafeEqual` (matches `verifyLinearSignature` and the SSO state-HMAC check)
2. `executeFeedbackPipeline` now honours stop signals (pre-stage graceful + post-`executeStage` cancel handling)
3. `markRunCancelled` accepts optional `prUrl` so feedback rate-limit slot is freed immediately

The third Sonnet finding (haltAll audit-trail edge case for a run that self-completes during iteration) was acknowledged as cosmetic — no code fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)