### PR TITLE
chore(release): v0.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.46] — 2026-05-11
+
+Bumps:
+- `@urateam/core`: 0.1.31 → 0.1.32
+- `@urateam/cli`: 0.1.33 → 0.1.34
+- `@urateam/dashboard`: 0.1.31 → 0.1.32
+- `create-urateam`: 0.1.34 → 0.1.35
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.45] — 2026-05-11
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,15 @@ Bumps:
 - `@urateam/dashboard`: 0.1.31 → 0.1.32
 - `create-urateam`: 0.1.34 → 0.1.35
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Added (OSS+)
+- **Operator stop & container halt** ([#268](https://github.com/JonB32/urateam/pull/268)) — three coordinated surfaces for stopping pipeline runs. Cancel a single run mid-stream via a new `AbortController` wired into `consumeAgentStream` (throws new `StageCancelledError`); graceful-stop a run between stages; halt the entire container (pauses the PM Agent + cancels every active pipeline + feedback run). Surfaces: dashboard (`POST /runs/:id/{cancel,stop}`, `/admin/halt-all`, RBAC-gated `runs.stop`/`system.halt`, CSRF via `HX-Request`, confirm dialogs on the run-detail page), Slack (`/pm cancel|stop|halt` with parser + Haiku NL classifier), CLI (`ura stop <runId> [--graceful]`, `ura halt`, talking to `/cli/*` guarded by `URATEAM_CLI_TOKEN` shared secret with constant-time `timingSafeEqual` compare). New audit events `run.cancelled` and `system.halted` record actor + mode. Runs land in new `status: "cancelled"` (distinct from system-initiated `"aborted"`). Setup doc: `deploy/STOP_AND_HALT.md`.
+- **Slack thinking-emoji ack** ([#268](https://github.com/JonB32/urateam/pull/268)) — the bot now reacts with 🤔 on receipt of an `app_mention` / `message` event (swaps to ✅ / ⚠️ on completion), and slash commands return an immediate ephemeral "Working on it…" then post the real reply via `response_url` so slow commands don't trip Slack's 3-second slash-command timeout.
+
+### Fixed (OSS+)
+- **Quality Observer findings no longer burn implement-stage tokens** ([#268](https://github.com/JonB32/urateam/pull/268)) — Quality Observer files a fresh GH issue per pipeline run with >50 turns; the fingerprint includes the runId, so each flagged run became a new Linear ticket and the implement pipeline burned tokens trying to "fix" a non-actionable diagnostic. PM Agent triage now detects the observer body marker (`<!-- urateam-qo-observer:`, preserved by `gh-linear-sync`'s verbatim body copy) and routes the ticket to the `needs-design` pipeline, whose `await-approval` stage gates a human before any implement-stage work runs.
+
+### Chore (OSS+)
+- New env var `URATEAM_CLI_TOKEN` (documented in `.env.dogfood.example` and `deploy/STOP_AND_HALT.md`) — required for `ura stop` / `ura halt` to reach a running container's control plane.
 ## [0.1.45] — 2026-05-11
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.31
-ARG URATEAM_CLI_VERSION=0.1.33
-ARG URATEAM_DASHBOARD_VERSION=0.1.31
+ARG URATEAM_CORE_VERSION=0.1.32
+ARG URATEAM_CLI_VERSION=0.1.34
+ARG URATEAM_DASHBOARD_VERSION=0.1.32
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.31
-        URATEAM_CLI_VERSION: 0.1.33
-        URATEAM_DASHBOARD_VERSION: 0.1.31
+        URATEAM_CORE_VERSION: 0.1.32
+        URATEAM_CLI_VERSION: 0.1.34
+        URATEAM_DASHBOARD_VERSION: 0.1.32
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- Bumps `@urateam/{core,cli,dashboard}` and `create-urateam` per `pnpm cut-release patch`
- CHANGELOG fills in v0.1.46 entries (#268 — operator stop & halt, Slack thinking-emoji ack, Quality Observer triage gate, `URATEAM_CLI_TOKEN` env var)
- Dockerfile / `docker-compose.dogfood.yml` ARGs updated to the new package versions so the dogfood build pulls the published packages after merge + tag

## Test plan
- [x] `pnpm cut-release patch` ran cleanly on `main` at `f5ed8b2`
- [ ] After merge: tag `v0.1.46` + push tag fires `.github/workflows/publish.yml` → publishes all 4 npm packages
- [ ] Then `docker compose build && docker compose up -d` on the dogfood host

🤖 Generated with [Claude Code](https://claude.com/claude-code)