### PR TITLE
fix(fanout): suppress upstream-provider failures from PR comments

### DIFF
--- a/packages/core/src/__tests__/post-fanout-comments.test.ts
+++ b/packages/core/src/__tests__/post-fanout-comments.test.ts
@@ -217,4 +217,51 @@ describe("postFanoutCommentsToPR", () => {
     const result = await postFanoutCommentsToPR({} as never, "o", "r", 1, [completedRun, rawOutputRun]);
     expect(result.suppressedEmptyCount).toBe(0);
   });
+
+  describe("upstream-provider failure suppression", () => {
+    const upstreamFault: ReviewModelRun = {
+      modelId: "nvidia/nemotron-3-super-120b-a12b:free",
+      providerId: "openrouter",
+      status: "failed",
+      findings: [],
+      inputTokens: 0,
+      outputTokens: 0,
+      durationMs: 120000,
+      errorMessage:
+        "openrouter response missing choices — provider returned 200 OK but no completion: Provider returned error",
+    };
+
+    it("does NOT post a PR comment for a 200 OK / no-completion provider failure", async () => {
+      addPRComment.mockResolvedValue(undefined);
+      const { postFanoutCommentsToPR } = await import(
+        "../executor/review/post-fanout-comments.js"
+      );
+      const result = await postFanoutCommentsToPR({} as never, "o", "r", 1, [upstreamFault]);
+      expect(addPRComment).not.toHaveBeenCalled();
+      expect(result.suppressedProviderFailureCount).toBe(1);
+    });
+
+    it("still posts comments for runs in the same batch that succeeded", async () => {
+      addPRComment.mockResolvedValue(undefined);
+      const { postFanoutCommentsToPR } = await import(
+        "../executor/review/post-fanout-comments.js"
+      );
+      const result = await postFanoutCommentsToPR({} as never, "o", "r", 1, [upstreamFault, completedRun]);
+      expect(addPRComment).toHaveBeenCalledTimes(1);
+      const body = addPRComment.mock.calls[0][4] as string;
+      expect(body).toContain("anthropic/claude-3.5-sonnet");
+      expect(body).not.toContain("nvidia/nemotron");
+      expect(result.suppressedProviderFailureCount).toBe(1);
+    });
+
+    it("still POSTS other failure types (e.g. rate-limit, auth) — only suppresses the missing-choices class", async () => {
+      addPRComment.mockResolvedValue(undefined);
+      const { postFanoutCommentsToPR } = await import(
+        "../executor/review/post-fanout-comments.js"
+      );
+      const result = await postFanoutCommentsToPR({} as never, "o", "r", 1, [failedRun]);
+      expect(addPRComment).toHaveBeenCalledTimes(1);
+      expect(result.suppressedProviderFailureCount).toBe(0);
+    });
+  });
 });

--- a/packages/core/src/executor/review/post-fanout-comments.ts
+++ b/packages/core/src/executor/review/post-fanout-comments.ts
@@ -15,6 +15,28 @@ export interface PostFanoutResult {
    * Audit events (`review.fanout_model_completed`) still fire for suppressed runs.
    */
   suppressedEmptyCount: number;
+  /**
+   * Number of failed runs suppressed from PR comments because the failure is
+   * an upstream-provider fault (200 OK but no completion / `Provider returned
+   * error` from OpenRouter free-tier models). The run still records as failed
+   * in the DB and emits its audit event — we just don't post a noisy "Status:
+   * failed" comment on the PR for something the operator can't act on.
+   */
+  suppressedProviderFailureCount: number;
+}
+
+/**
+ * Match the error class introduced by the openrouter-client when the upstream
+ * provider returns 200 OK with `{ error: ... }` and no `choices`. Repeats
+ * regularly for free-tier / community models (notably the nvidia free tier).
+ * Surfacing each such failure as a per-model PR comment was creating noise
+ * with no operator action — the right fix is to remove the model from
+ * REVIEW_MODELS, which the model-health probe already flags advisorily.
+ */
+function isUpstreamProviderError(run: ReviewModelRun): boolean {
+  if (run.status !== "failed") return false;
+  const msg = run.errorMessage ?? "";
+  return msg.includes("openrouter response missing choices");
 }
 
 export async function postFanoutCommentsToPR(
@@ -26,17 +48,25 @@ export async function postFanoutCommentsToPR(
 ): Promise<PostFanoutResult> {
   const toPost: ReviewModelRun[] = [];
   let suppressedEmptyCount = 0;
+  let suppressedProviderFailureCount = 0;
 
   for (const run of runs) {
-    const shouldSuppress =
+    const isEmptySuccess =
       run.status !== "failed" &&
       run.findings.length === 0 &&
       run.rawOutput === undefined;
-    if (shouldSuppress) {
+    const isUpstreamFault = isUpstreamProviderError(run);
+    if (isEmptySuccess) {
       suppressedEmptyCount++;
       log.debug(
         { modelId: run.modelId },
         "fanout: suppressing empty-findings comment (no findings, no rawOutput)",
+      );
+    } else if (isUpstreamFault) {
+      suppressedProviderFailureCount++;
+      log.info(
+        { modelId: run.modelId, err: run.errorMessage },
+        "fanout: suppressing upstream-provider failure from PR comment (DB row + audit event still recorded)",
       );
     } else {
       toPost.push(run);
@@ -58,7 +88,7 @@ export async function postFanoutCommentsToPR(
     }
   });
   const fallbackCount = runs.filter((r) => r.rawOutput !== undefined).length;
-  return { fallbackCount, suppressedEmptyCount };
+  return { fallbackCount, suppressedEmptyCount, suppressedProviderFailureCount };
 }
 
 export function renderRunMarkdown(run: ReviewModelRun): string {

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -1983,7 +1983,13 @@ export class PipelineRunner {
                 pendingFanoutRuns,
               );
               runLog.info(
-                { prNumber: fanoutPrNumber, count: pendingFanoutRuns.length, fallbackCount: fanoutResult.fallbackCount, suppressedEmptyCount: fanoutResult.suppressedEmptyCount },
+                {
+                  prNumber: fanoutPrNumber,
+                  count: pendingFanoutRuns.length,
+                  fallbackCount: fanoutResult.fallbackCount,
+                  suppressedEmptyCount: fanoutResult.suppressedEmptyCount,
+                  suppressedProviderFailureCount: fanoutResult.suppressedProviderFailureCount,
+                },
                 "fanout: posted per-model PR comments",
               );
               if (fanoutResult.fallbackCount > 0) {


### PR DESCRIPTION
## Problem
PR #249 added a defensive guard for OpenRouter responses that return 200 OK without a `choices` field — common for free-tier / community models (notably `nvidia/nemotron-3-super-120b-a12b:free`). That guard correctly surfaces a clean error message, but every such failure was still being posted as a per-model "Status: failed" comment on the PR.

Observed noise example:
> Status: failed · openrouter response missing choices — provider returned 200 OK but no completion: Provider returned error · 120.2s

The operator can't act on this — the provider itself is broken.

## Fix
`postFanoutCommentsToPR` now recognises the "missing choices" error class via `isUpstreamProviderError()` and suppresses the per-model PR comment. The DB row and audit event still fire (so the failure remains visible in the dashboard + audit log) — only the noisy PR comment is dropped.

New `suppressedProviderFailureCount` field returned so the runner log line distinguishes upstream-provider suppression from the existing empty-findings suppression.

## Test plan
- [x] 3 new cases in `post-fanout-comments.test.ts`:
  - Upstream fault → no PR comment, `suppressedProviderFailureCount: 1`
  - Mixed batch: upstream fault + successful run → only successful one posts
  - Other failure classes (rate limit, etc.) still post normally
- [x] All 14 tests in the file pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)