### PR TITLE
feat(db): BEC-187 — add 5 missing hot-path indexes (clean rebranch)

### DIFF
--- a/packages/core/src/__tests__/db-migrations.test.ts
+++ b/packages/core/src/__tests__/db-migrations.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { eq, gte, lt } from "drizzle-orm";
+import { createDb, type AnyDb, pipelineRuns, pmApprovals } from "../db/index.js";
+import { loadMigrationFiles, runMigrationsSqlite, getMigrationStatusSqlite } from "../db/migrator.js";
+
+function tmpDbPath(): string {
+  const id = randomBytes(8).toString("hex");
+  return `/tmp/laf-migration-test-${id}.sqlite`;
+}
+
+describe("database migrations", () => {
+  const paths: string[] = [];
+
+  async function makeDb(): Promise<AnyDb> {
+    const path = tmpDbPath();
+    paths.push(path);
+    return createDb({ driver: "sqlite", connectionString: path });
+  }
+
+  afterEach(() => {
+    for (const p of paths) {
+      try {
+        unlinkSync(p);
+        unlinkSync(p + "-wal");
+        unlinkSync(p + "-shm");
+      } catch {
+        // ignore
+      }
+    }
+    paths.length = 0;
+  });
+
+  it("loads migration files in alphabetical order", () => {
+    const migrations = loadMigrationFiles("sqlite");
+    expect(migrations.length).toBeGreaterThan(0);
+
+    // Verify migrations are sorted by name
+    const names = migrations.map(m => m.name);
+    const sorted = [...names].sort();
+    expect(names).toEqual(sorted);
+  });
+
+  it("includes the new missing_indexes migration", () => {
+    const migrations = loadMigrationFiles("sqlite");
+    const migrationNames = migrations.map(m => m.name);
+    expect(migrationNames).toContain("013_missing_indexes");
+  });
+
+  it("migration file contains CREATE INDEX IF NOT EXISTS statements", () => {
+    const migrations = loadMigrationFiles("sqlite");
+    const missingIndexesMigration = migrations.find(m => m.name === "013_missing_indexes");
+
+    expect(missingIndexesMigration).toBeDefined();
+    expect(missingIndexesMigration!.sql).toContain("CREATE INDEX IF NOT EXISTS");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_pr_url");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_branch");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_started_at");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_completed_at");
+    expect(missingIndexesMigration!.sql).toContain("idx_pm_approvals_issue_id");
+  });
+
+  it("runs all migrations successfully during db initialization", async () => {
+    const db = await makeDb();
+    expect(db).toBeDefined();
+  });
+
+  it("migrations are idempotent (can be run multiple times safely)", async () => {
+    const path = tmpDbPath();
+    paths.push(path);
+
+    // Import sqlite for raw access
+    const Database = (await import("better-sqlite3")).default;
+    const sqliteDb = new Database(path);
+
+    try {
+      // Run migrations first time
+      runMigrationsSqlite(sqliteDb);
+
+      // Get status after first run
+      const statusAfterFirstRun = getMigrationStatusSqlite(sqliteDb);
+      const appliedCountFirstRun = statusAfterFirstRun.filter(s => s.applied).length;
+      expect(appliedCountFirstRun).toBeGreaterThan(0);
+
+      // Run migrations again (should be idempotent)
+      runMigrationsSqlite(sqliteDb);
+
+      // Get status after second run
+      const statusAfterSecondRun = getMigrationStatusSqlite(sqliteDb);
+      const appliedCountSecondRun = statusAfterSecondRun.filter(s => s.applied).length;
+
+      // Should have same number of applied migrations
+      expect(appliedCountSecondRun).toBe(appliedCountFirstRun);
+
+      // All migrations should be marked as applied
+      const allApplied = statusAfterSecondRun.every(s => s.applied);
+      expect(allApplied).toBe(true);
+    } finally {
+      sqliteDb.close();
+    }
+  });
+
+  it("can query pipeline_runs by pr_url (indexed column)", async () => {
+    const db = await makeDb();
+    const now = new Date();
+
+    // Insert test data
+    await db.insert(pipelineRuns).values({
+      id: "pr-index-test-1",
+      issueId: "ISSUE-1",
+      issueTitle: "Test PR URL indexing",
+      pipelineKey: "default",
+      repoUrl: "https://github.com/org/repo",
+      prUrl: "https://github.com/org/repo/pull/123",
+      status: "completed",
+      startedAt: now,
+      completedAt: now,
+    });
+
+    // Query by pr_url
+    const rows = await db.select().from(pipelineRuns).where(eq(pipelineRuns.prUrl, "https://github.com/org/repo/pull/123"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("pr-index-test-1");
+  });
+
+  it("can query pipeline_runs by branch (indexed column)", async () => {
+    const db = await makeDb();
+    const now = new Date();
+
+    await db.insert(pipelineRuns).values({
+      id: "pr-branch-test-1",
+      issueId: "ISSUE-2",
+      issueTitle: "Test branch indexing",
+      pipelineKey: "default",
+      repoUrl: "https://github.com/org/repo",
+      branch: "agent/issue-2-fix-bug",
+      status: "completed",
+      startedAt: now,
+      completedAt: now,
+    });
+
+    const rows = await db.select().from(pipelineRuns).where(eq(pipelineRuns.branch, "agent/issue-2-fix-bug"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("pr-branch-test-1");
+  });
+
+  it("can range query pipeline_runs by started_at (indexed column)", async () => {
+    const db = await makeDb();
+    const baseTime = new Date("2026-05-11T10:00:00Z");
+    const later = new Date("2026-05-11T11:00:00Z");
+
+    await db.insert(pipelineRuns).values([
+      {
+        id: "pr-time-test-1",
+        issueId: "ISSUE-3",
+        issueTitle: "Early run",
+        pipelineKey: "default",
+        repoUrl: "https://github.com/org/repo",
+        status: "completed",
+        startedAt: baseTime,
+        completedAt: baseTime,
+      },
+      {
+        id: "pr-time-test-2",
+        issueId: "ISSUE-4",
+        issueTitle: "Late run",
+        pipelineKey: "default",
+        repoUrl: "https://github.com/org/repo",
+        status: "completed",
+        startedAt: later,
+        completedAt: later,
+      },
+    ]);
+
+    // Range query on started_at
+    const rows = await db.select().from(pipelineRuns).where(
+      lt(pipelineRuns.startedAt, later)
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("pr-time-test-1");
+  });
+
+  it("can range query pipeline_runs by completed_at (indexed column)", async () => {
+    const db = await makeDb();
+    const baseTime = new Date("2026-05-11T10:00:00Z");
+    const midTime = new Date("2026-05-11T11:00:00Z");
+
+    await db.insert(pipelineRuns).values([
+      {
+        id: "pr-complete-test-1",
+        issueId: "ISSUE-5",
+        issueTitle: "Completed early",
+        pipelineKey: "default",
+        repoUrl: "https://github.com/org/repo",
+        status: "completed",
+        startedAt: baseTime,
+        completedAt: baseTime,
+      },
+      {
+        id: "pr-complete-test-2",
+        issueId: "ISSUE-6",
+        issueTitle: "Still running",
+        pipelineKey: "default",
+        repoUrl: "https://github.com/org/repo",
+        status: "running",
+        startedAt: baseTime,
+        completedAt: null,
+      },
+    ]);
+
+    // Range query on completed_at
+    const rows = await db.select().from(pipelineRuns).where(
+      gte(pipelineRuns.completedAt, baseTime)
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("pr-complete-test-1");
+  });
+
+  it("can query pm_approvals by issue_id (indexed column)", async () => {
+    const db = await makeDb();
+    const now = new Date();
+
+    await db.insert(pmApprovals).values([
+      {
+        id: "approval-1",
+        issueId: "ISSUE-100",
+        action: "deprioritize",
+        reason: "Need more context",
+        slackMessageTs: "ts-1",
+        status: "pending",
+        createdAt: now,
+      },
+      {
+        id: "approval-2",
+        issueId: "ISSUE-100",
+        action: "cancel",
+        reason: "User cancelled",
+        slackMessageTs: "ts-2",
+        status: "resolved",
+        createdAt: now,
+        resolvedAt: now,
+      },
+      {
+        id: "approval-3",
+        issueId: "ISSUE-101",
+        action: "deprioritize",
+        reason: "Different issue",
+        slackMessageTs: "ts-3",
+        status: "pending",
+        createdAt: now,
+      },
+    ]);
+
+    // Query by issue_id
+    const rows = await db.select().from(pmApprovals).where(eq(pmApprovals.issueId, "ISSUE-100"));
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r: { issueId: string }) => r.issueId === "ISSUE-100")).toBe(true);
+  });
+
+  it("postgres migration file also includes all 5 indexes", async () => {
+    const pgMigrations = loadMigrationFiles("postgres");
+    const missingIndexesMigration = pgMigrations.find(m => m.name === "014_missing_indexes");
+
+    expect(missingIndexesMigration).toBeDefined();
+    expect(missingIndexesMigration!.sql).toContain("CREATE INDEX IF NOT EXISTS");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_pr_url");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_branch");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_started_at");
+    expect(missingIndexesMigration!.sql).toContain("idx_pipeline_runs_completed_at");
+    expect(missingIndexesMigration!.sql).toContain("idx_pm_approvals_issue_id");
+  });
+});

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -131,6 +131,12 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
   CREATE INDEX IF NOT EXISTS idx_agent_logs_stage_run_id ON agent_logs(stage_run_id);
   CREATE INDEX IF NOT EXISTS idx_pipeline_runs_issue_id ON pipeline_runs(issue_id);
   CREATE INDEX IF NOT EXISTS idx_pipeline_runs_status ON pipeline_runs(status);
+  -- BEC-187: hot-path indexes kept in sync with db/migrations/sqlite + postgres
+  -- so fresh installs and existing deployments converge on the same schema.
+  CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pr_url ON pipeline_runs(pr_url);
+  CREATE INDEX IF NOT EXISTS idx_pipeline_runs_branch ON pipeline_runs(branch);
+  CREATE INDEX IF NOT EXISTS idx_pipeline_runs_started_at ON pipeline_runs(started_at);
+  CREATE INDEX IF NOT EXISTS idx_pipeline_runs_completed_at ON pipeline_runs(completed_at);
 
   CREATE TABLE IF NOT EXISTS pm_approvals (
     id TEXT PRIMARY KEY,
@@ -144,6 +150,8 @@ export function getCreateTablesDDL(driver: "sqlite" | "postgres"): string {
   );
 
   CREATE INDEX IF NOT EXISTS idx_pm_approvals_status ON pm_approvals(status);
+  -- BEC-187: hot-path index — kept in sync with migration files.
+  CREATE INDEX IF NOT EXISTS idx_pm_approvals_issue_id ON pm_approvals(issue_id);
 
   CREATE TABLE IF NOT EXISTS active_work (
     id TEXT PRIMARY KEY,

--- a/packages/core/src/db/migrations/postgres/014_missing_indexes.sql
+++ b/packages/core/src/db/migrations/postgres/014_missing_indexes.sql
@@ -1,0 +1,28 @@
+-- Migration: BEC-187 — Add 5 missing hot-path indexes to pipeline_runs + pm_approvals
+-- Idempotent: all statements use CREATE INDEX IF NOT EXISTS (supported since Postgres 9.5).
+
+-- pipeline_runs.pr_url: queried on every check_suite, pull_request, and review
+-- event in webhook/github-handler.ts to look up the run by PR URL.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pr_url
+  ON pipeline_runs(pr_url);
+
+-- pipeline_runs.branch: queried alongside pr_url in webhook/github-handler.ts
+-- to find runs by branch name on push/CI events.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_branch
+  ON pipeline_runs(branch);
+
+-- pipeline_runs.started_at: range-scanned by pm/actions/db-queries.ts,
+-- pm/budget.ts, audit/reader.ts, cost/csv.ts, and runner.ts on every PM tick
+-- (60s cadence) and dashboard page load.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_started_at
+  ON pipeline_runs(started_at);
+
+-- pipeline_runs.completed_at: range-scanned by pm/actions/db-queries.ts and
+-- cost/aggregate.ts for active-run detection and cost rollup windows.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_completed_at
+  ON pipeline_runs(completed_at);
+
+-- pm_approvals.issue_id: queried by approval-helpers.ts:batchFetchPendingApprovals
+-- on every PM tick to find pending approvals for a batch of issue IDs.
+CREATE INDEX IF NOT EXISTS idx_pm_approvals_issue_id
+  ON pm_approvals(issue_id);

--- a/packages/core/src/db/migrations/sqlite/013_missing_indexes.sql
+++ b/packages/core/src/db/migrations/sqlite/013_missing_indexes.sql
@@ -1,0 +1,28 @@
+-- Migration: BEC-187 — Add 5 missing hot-path indexes to pipeline_runs + pm_approvals
+-- Idempotent: all statements use CREATE INDEX IF NOT EXISTS.
+
+-- pipeline_runs.pr_url: queried on every check_suite, pull_request, and review
+-- event in webhook/github-handler.ts to look up the run by PR URL.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pr_url
+  ON pipeline_runs(pr_url);
+
+-- pipeline_runs.branch: queried alongside pr_url in webhook/github-handler.ts
+-- to find runs by branch name on push/CI events.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_branch
+  ON pipeline_runs(branch);
+
+-- pipeline_runs.started_at: range-scanned by pm/actions/db-queries.ts,
+-- pm/budget.ts, audit/reader.ts, cost/csv.ts, and runner.ts on every PM tick
+-- (60s cadence) and dashboard page load.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_started_at
+  ON pipeline_runs(started_at);
+
+-- pipeline_runs.completed_at: range-scanned by pm/actions/db-queries.ts and
+-- cost/aggregate.ts for active-run detection and cost rollup windows.
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_completed_at
+  ON pipeline_runs(completed_at);
+
+-- pm_approvals.issue_id: queried by approval-helpers.ts:batchFetchPendingApprovals
+-- on every PM tick to find pending approvals for a batch of issue IDs.
+CREATE INDEX IF NOT EXISTS idx_pm_approvals_issue_id
+  ON pm_approvals(issue_id);


### PR DESCRIPTION
## Summary
Replaces #258. The original BEC-187 agent branch was based on v0.1.45 — far behind main with extensive drift, plus 5 committed artifact files (FINAL_CHECKLIST.md, etc.) flagged blocking in code review. Branched cleanly from current main with only the 5 useful files + the additional getCreateTablesDDL() update flagged in review.

## What lands
- `packages/core/src/db/migrations/sqlite/013_missing_indexes.sql`
- `packages/core/src/db/migrations/postgres/014_missing_indexes.sql`
- `packages/core/src/__tests__/db-migrations.test.ts` (11 tests)
- `packages/core/src/db/client.ts` — adds the same 5 indexes to `getCreateTablesDDL()` so fresh installs converge on the same schema (gap flagged by code review on #258).

## Indexes
| column | callers |
|---|---|
| `pipeline_runs.pr_url` | webhook PR lookup on every check_suite/pull_request/review event |
| `pipeline_runs.branch` | webhook branch lookup on push/CI events |
| `pipeline_runs.started_at` | pm/actions/db-queries, pm/budget, audit/reader, cost/csv, runner — range scans on every PM tick |
| `pipeline_runs.completed_at` | pm/actions/db-queries, cost/aggregate — active-run detection + cost rollup windows |
| `pm_approvals.issue_id` | batchFetchPendingApprovals — every PM tick |

All migrations are idempotent (`CREATE INDEX IF NOT EXISTS`).

## Test plan
- [x] 11/11 tests in `db-migrations.test.ts` pass (idempotency, both drivers, schema-migrations tracking, smoke query)
- [x] Core typechecks clean

## Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)