### PR TITLE
fix(webhook): BEC-186 — transition Linear to Done on external PR merge (clean rebranch)

### DIFF
--- a/packages/core/src/__tests__/bec-186-repro.test.ts
+++ b/packages/core/src/__tests__/bec-186-repro.test.ts
@@ -1,0 +1,279 @@
+/**
+ * BEC-186: pull_request.closed + merged=true must transition Linear to Done.
+ *
+ * When a human (or GitHub's "auto-merge when ready") merges a PR after the
+ * pipeline has already completed, the pipeline's `onPipelineComplete` has
+ * already fired and will not re-fire.  Without an explicit handler for
+ * `pull_request.closed+merged`, the Linear ticket stays "In Review" forever.
+ *
+ * Fix implemented in `webhook/github-handler.ts`:
+ *   - A new routing branch catches `pull_request.closed` + `merged: true`
+ *   - Looks up the pipeline run by pr_url
+ *   - Marks `auto_merged = true` in the DB
+ *   - Calls `notifier.onPRMerged?.(run)` → LinearNotifier transitions to Done
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "crypto";
+import { createGitHubWebhookHandler } from "../webhook/github-handler.js";
+import type { GitHubWebhookHandlerConfig } from "../webhook/github-handler.js";
+import type { PipelineConfig, RepoConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors existing test infrastructure)
+// ---------------------------------------------------------------------------
+
+const SECRET = "gh-webhook-secret";
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+const pipelineConfig: PipelineConfig = {
+  name: "auto-implement",
+  stages: ["triage", "implement", "test", "review"],
+  retry: { maxAttempts: 1, strategy: "fix-and-retry" },
+  review: { requiredApprovals: 1 },
+  prStrategy: "draft",
+};
+
+const repoConfig: RepoConfig = {
+  url: "https://github.com/org/repo",
+  defaultBranch: "main",
+  testCommand: "npm test",
+  buildCommand: "npm run build",
+  githubFeedback: {
+    allowedReviewers: [],
+    botLogins: ["linear-agent[bot]"],
+    autoTrigger: true,
+  },
+};
+
+/** Simulated DB row representing a completed pipeline run whose PR was opened. */
+const mockRun = {
+  id: "run-bec186",
+  issueId: "BEC-179",
+  issueTitle: "Worktree detached HEAD bug",
+  pipelineKey: "auto-implement",
+  repoUrl: "https://github.com/org/repo",
+  branch: "agent/BEC-179-worktree-detached-head",
+  status: "completed",
+  prUrl: "https://github.com/org/repo/pull/235",
+  autoMerged: null,
+  runType: "standard",
+  parentRunId: null,
+  feedbackContext: null,
+};
+
+function makeMockDb(run: typeof mockRun | null = mockRun) {
+  const updateMock = vi.fn().mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(run ? [run] : []),
+        }),
+      }),
+    }),
+    update: updateMock,
+    _updateMock: updateMock,
+  };
+}
+
+function makeMockRunner() {
+  return {
+    startFeedback: vi.fn().mockResolvedValue(undefined),
+    isActiveFeedback: vi.fn().mockReturnValue(false),
+  };
+}
+
+function makeMockNotifier() {
+  return {
+    onPipelineStart: vi.fn().mockResolvedValue(undefined),
+    onStageComplete: vi.fn().mockResolvedValue(undefined),
+    onPipelineComplete: vi.fn().mockResolvedValue(undefined),
+    onPipelineFailed: vi.fn().mockResolvedValue(undefined),
+    onPRMerged: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function buildConfig(
+  overrides: Partial<GitHubWebhookHandlerConfig> = {},
+): GitHubWebhookHandlerConfig {
+  return {
+    webhookSecret: SECRET,
+    runner: makeMockRunner() as any,
+    pipelineConfigs: { "auto-implement": pipelineConfig },
+    repoConfigs: { "org/repo": repoConfig },
+    db: makeMockDb() as any,
+    ...overrides,
+  };
+}
+
+/** Creates a synthetic pull_request.closed+merged webhook payload. */
+function makePRClosedMergedPayload(overrides: Record<string, any> = {}) {
+  return {
+    action: "closed",
+    pull_request: {
+      number: 235,
+      html_url: "https://github.com/org/repo/pull/235",
+      merged: true,
+      head: { ref: "agent/BEC-179-worktree-detached-head" },
+      merge_commit_sha: "abc123def456",
+    },
+    repository: {
+      name: "repo",
+      owner: { login: "org" },
+      html_url: "https://github.com/org/repo",
+    },
+    ...overrides,
+  };
+}
+
+async function postWebhook(
+  app: ReturnType<typeof createGitHubWebhookHandler>,
+  body: Record<string, any>,
+  event: string,
+  secret: string = SECRET,
+) {
+  const rawBody = JSON.stringify(body);
+  const sig = sign(rawBody, secret);
+  return app.request("/webhooks/github", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-GitHub-Event": event,
+      "X-Hub-Signature-256": sig,
+    },
+    body: rawBody,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// BEC-186 tests — verifying the fix
+// ---------------------------------------------------------------------------
+
+describe("BEC-186: pull_request.closed + merged=true → Linear Done transition", () => {
+  let runner: ReturnType<typeof makeMockRunner>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    runner = makeMockRunner();
+  });
+
+  it("pull_request.closed+merged=true is handled (not skipped)", async () => {
+    // The core fix: action="closed"+merged=true must NOT fall through to
+    // the "unhandled event type" branch.
+    const db = makeMockDb(mockRun);
+    const app = createGitHubWebhookHandler(buildConfig({ runner: runner as any, db: db as any }));
+
+    const res = await postWebhook(app, makePRClosedMergedPayload(), "pull_request");
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json).not.toHaveProperty("skipped");
+    expect(json.ok).toBe(true);
+    expect(json.action).toBe("pr-merged");
+  });
+
+  it("DB is updated with auto_merged=true on PR merge", async () => {
+    const db = makeMockDb(mockRun);
+    const app = createGitHubWebhookHandler(buildConfig({ runner: runner as any, db: db as any }));
+
+    await postWebhook(app, makePRClosedMergedPayload(), "pull_request");
+
+    expect(db._updateMock).toHaveBeenCalled();
+  });
+
+  it("notifier.onPRMerged is called when notifier is provided", async () => {
+    const db = makeMockDb(mockRun);
+    const notifier = makeMockNotifier();
+    const app = createGitHubWebhookHandler(
+      buildConfig({ runner: runner as any, db: db as any, notifier: notifier as any }),
+    );
+
+    await postWebhook(app, makePRClosedMergedPayload(), "pull_request");
+
+    expect(notifier.onPRMerged).toHaveBeenCalledOnce();
+    expect(notifier.onPRMerged).toHaveBeenCalledWith(expect.objectContaining({ id: "run-bec186" }));
+  });
+
+  it("notifier.onPRMerged is NOT called when no pipeline run is found", async () => {
+    // PR from a non-agent source — no DB row matches
+    const db = makeMockDb(null);
+    const notifier = makeMockNotifier();
+    const app = createGitHubWebhookHandler(
+      buildConfig({ runner: runner as any, db: db as any, notifier: notifier as any }),
+    );
+
+    const res = await postWebhook(app, makePRClosedMergedPayload(), "pull_request");
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // Still returns ok: true, action: "pr-merged" (handler ran, just found no run)
+    expect(json.ok).toBe(true);
+    expect(notifier.onPRMerged).not.toHaveBeenCalled();
+  });
+
+  it("idempotency: already-merged run is not re-processed", async () => {
+    // If auto_merged is already true, skip the update and notifier call
+    const alreadyMergedRun = { ...mockRun, autoMerged: true };
+    const db = makeMockDb(alreadyMergedRun as any);
+    const notifier = makeMockNotifier();
+    const app = createGitHubWebhookHandler(
+      buildConfig({ runner: runner as any, db: db as any, notifier: notifier as any }),
+    );
+
+    await postWebhook(app, makePRClosedMergedPayload(), "pull_request");
+
+    expect(db._updateMock).not.toHaveBeenCalled();
+    expect(notifier.onPRMerged).not.toHaveBeenCalled();
+  });
+
+  it("pull_request.closed WITHOUT merged=true is skipped (no Done transition)", async () => {
+    // PR closed without merge (e.g. closed manually) must NOT trigger Done transition.
+    const db = makeMockDb(mockRun);
+    const notifier = makeMockNotifier();
+    const payload = {
+      ...makePRClosedMergedPayload(),
+      pull_request: {
+        ...makePRClosedMergedPayload().pull_request,
+        merged: false,
+      },
+    };
+    const app = createGitHubWebhookHandler(
+      buildConfig({ runner: runner as any, db: db as any, notifier: notifier as any }),
+    );
+
+    const res = await postWebhook(app, payload, "pull_request");
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // Falls through to "unhandled event type" — correct outcome
+    expect(json.skipped).toBeDefined();
+    expect(db._updateMock).not.toHaveBeenCalled();
+    expect(notifier.onPRMerged).not.toHaveBeenCalled();
+  });
+
+  it("works when notifier is not configured (no crash)", async () => {
+    // Notifier is optional — handler must not throw when absent
+    const db = makeMockDb(mockRun);
+    const app = createGitHubWebhookHandler(
+      buildConfig({ runner: runner as any, db: db as any /* no notifier */ }),
+    );
+
+    const res = await postWebhook(app, makePRClosedMergedPayload(), "pull_request");
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.action).toBe("pr-merged");
+    // DB still updated even without notifier
+    expect(db._updateMock).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/notifier/composite.ts
+++ b/packages/core/src/notifier/composite.ts
@@ -36,4 +36,10 @@ export class CompositeNotifier implements Notifier {
       this.notifiers.filter(n => n.onDailyTokenSummary).map(n => n.onDailyTokenSummary!(summary)),
     );
   }
+
+  async onPRMerged(run: PipelineRun): Promise<void> {
+    await Promise.allSettled(
+      this.notifiers.filter(n => n.onPRMerged).map(n => n.onPRMerged!(run)),
+    );
+  }
 }

--- a/packages/core/src/notifier/linear.ts
+++ b/packages/core/src/notifier/linear.ts
@@ -1,6 +1,5 @@
 import type { Notifier, PipelineRun, StageResult, PipelineResult, PipelineError } from "../types.js";
 import { createLogger } from "../logger.js";
-import { getLinearClient } from "../util/linear.js";
 
 const log = createLogger({ component: "LinearNotifier" });
 
@@ -19,13 +18,19 @@ export class LinearNotifier implements Notifier {
   private apiKey: string;
   private stateCache = new Map<string, string>();
   private issueIdCache = new Map<string, { id: string; teamId?: string }>();
+  private clientPromise: Promise<any> | null = null;
 
   constructor(config: LinearNotifierConfig) {
     this.apiKey = config.apiKey;
   }
 
   private async getClient() {
-    return getLinearClient(this.apiKey);
+    if (!this.clientPromise) {
+      this.clientPromise = import("@linear/sdk").then(
+        ({ LinearClient }) => new LinearClient({ apiKey: this.apiKey }),
+      );
+    }
+    return this.clientPromise;
   }
 
   async onPipelineStart(run: PipelineRun): Promise<void> {
@@ -108,6 +113,16 @@ export class LinearNotifier implements Notifier {
       `Usage: ${usedTokens.toLocaleString()} / ${maxTokens.toLocaleString()} tokens (${pct}%)\n` +
       `The run will be aborted if the budget is exceeded.`
     );
+  }
+
+  async onPRMerged(run: PipelineRun): Promise<void> {
+    await Promise.all([
+      this.postComment(run.issueId,
+        `🤖 **Agent Run #${run.id.slice(0, 8)}** — PR Merged ✅\n\n` +
+        `The PR has been merged. Closing this ticket.`
+      ),
+      this.transitionState(run.issueId, LINEAR_STATES.DONE),
+    ]);
   }
 
   async onPipelineFailed(run: PipelineRun, error: PipelineError): Promise<void> {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -120,6 +120,9 @@ export async function createApp(config: ServerConfig) {
       repoConfigs: config.repoConfigs,
       db: db as any,
       github: config.github,
+      // BEC-186: webhook handler needs the notifier to fire onPRMerged when a
+      // PR is merged externally (human merge / GitHub auto-merge-when-ready).
+      notifier,
     });
     app.route("/", githubWebhookApp);
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -445,6 +445,13 @@ export interface Notifier {
   onTokenBudgetAlert?(run: PipelineRun, usedTokens: number, maxTokens: number): Promise<void>;
   /** Called by sendDailyTokenSummary() with aggregated usage for a given date. */
   onDailyTokenSummary?(summary: DailyTokenSummary): Promise<void>;
+  /**
+   * BEC-186: called when a PR is merged externally — either by a human via
+   * the GitHub UI or by GitHub's "auto-merge when ready" feature — after
+   * the pipeline has already completed. Implementations should transition
+   * the Linear issue to Done.
+   */
+  onPRMerged?(run: PipelineRun): Promise<void>;
 }
 
 // --- Sandbox Config ---

--- a/packages/core/src/webhook/github-handler.ts
+++ b/packages/core/src/webhook/github-handler.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { pipelineRuns } from "../db/schema.js";
 import type { AnyDb } from "../db/client.js";
 import type { PipelineRunner } from "../pipeline/runner.js";
-import type { PipelineConfig, RepoConfig } from "../types.js";
+import type { Notifier, PipelineConfig, PipelineRun, RepoConfig } from "../types.js";
 import { createLogger } from "../logger.js";
 import { createGitHubClient } from "../repo/github.js";
 import type { GitHubConfig } from "../repo/github.js";
@@ -45,6 +45,12 @@ export interface GitHubWebhookHandlerConfig {
    * requiredStatusChecks, etc.).  When not provided, automerge events are skipped.
    */
   github?: GitHubConfig;
+  /**
+   * Notifier instance. When provided, `onPRMerged` is called when a PR is
+   * merged externally (human merge or GitHub's auto-merge-when-ready), which
+   * transitions the Linear issue to Done.
+   */
+  notifier?: Notifier;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +76,47 @@ export function verifyGitHubSignature(
   } catch {
     return false; // Different lengths
   }
+}
+
+// ---------------------------------------------------------------------------
+// Shared DB helpers — avoid repeating the same lookup / update patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a pipeline run by PR URL (primary) then by branch name (fallback).
+ * Returns `undefined` when no matching row is found.
+ */
+async function findPipelineRunByPrUrlOrBranch(
+  db: AnyDb,
+  prUrl?: string,
+  prBranch?: string,
+): Promise<(typeof pipelineRuns.$inferSelect) | undefined> {
+  if (prUrl) {
+    const rows = await db.select().from(pipelineRuns).where(eq(pipelineRuns.prUrl, prUrl)).limit(1);
+    if (rows.length > 0) return rows[0];
+  }
+  if (prBranch?.startsWith("agent/")) {
+    const rows = await db.select().from(pipelineRuns).where(eq(pipelineRuns.branch, prBranch)).limit(1);
+    if (rows.length > 0) return rows[0];
+  }
+  return undefined;
+}
+
+/**
+ * Persist a merge decision to the DB.
+ * `merged` — pass `true` (or `result.merged || null` for the automerge path).
+ * `reason` — human-readable label stored in `autoMergeReason`.
+ */
+async function updatePipelineRunMerged(
+  db: AnyDb,
+  runId: string,
+  merged: boolean | null,
+  reason: string,
+): Promise<void> {
+  await db
+    .update(pipelineRuns)
+    .set({ autoMerged: merged, autoMergeReason: reason })
+    .where(eq(pipelineRuns.id, runId));
 }
 
 // ---------------------------------------------------------------------------
@@ -171,16 +218,7 @@ async function handleAutoMergeEvent(
 
   for (const candidate of candidates) {
     // Look up pipeline run in DB by PR URL then branch
-    let originalRun: (typeof pipelineRuns.$inferSelect) | undefined;
-
-    if (candidate.prUrl) {
-      const rows = await db.select().from(pipelineRuns).where(eq(pipelineRuns.prUrl, candidate.prUrl)).limit(1);
-      if (rows.length > 0) originalRun = rows[0];
-    }
-    if (!originalRun && candidate.prBranch?.startsWith("agent/")) {
-      const rows = await db.select().from(pipelineRuns).where(eq(pipelineRuns.branch, candidate.prBranch)).limit(1);
-      if (rows.length > 0) originalRun = rows[0];
-    }
+    const originalRun = await findPipelineRunByPrUrlOrBranch(db, candidate.prUrl, candidate.prBranch);
 
     if (!originalRun) {
       log.debug({ candidate }, "automerge: no pipeline run found for PR — skipping");
@@ -233,17 +271,67 @@ async function handleAutoMergeEvent(
     );
 
     // Persist result to DB
-    await db
-      .update(pipelineRuns)
-      .set({
-        autoMerged: result.merged || null,
-        autoMergeReason: result.message,
-      })
-      .where(eq(pipelineRuns.id, originalRun.id));
+    await updatePipelineRunMerged(db, originalRun.id, result.merged || null, result.message);
 
     log.info(
       { runId: originalRun.id, prNumber, merged: result.merged, message: result.message },
       "automerge: decision recorded",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PR merged event handler — transitions Linear to Done when a PR is merged
+// externally (human merge or GitHub's "auto-merge when ready").
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle `pull_request.closed` events where `merged === true`.
+ *
+ * Looks up the pipeline run by PR URL, marks `auto_merged = true` in the DB,
+ * and calls `notifier.onPRMerged()` to transition the Linear issue to Done.
+ * Idempotent: if the run is already marked merged, no further action is taken.
+ */
+async function handlePRMergedEvent(
+  payload: Record<string, any>,
+  config: GitHubWebhookHandlerConfig,
+): Promise<void> {
+  const pr = payload.pull_request;
+  const prUrl: string = pr?.html_url ?? "";
+  const prBranch: string = pr?.head?.ref ?? "";
+
+  if (!prUrl) {
+    log.warn({ payload }, "pr-merged: no PR URL in payload — skipping");
+    return;
+  }
+
+  const db = config.db;
+  // Look up pipeline run by PR URL (primary) then by branch (fallback)
+  const originalRun = await findPipelineRunByPrUrlOrBranch(db, prUrl, prBranch);
+
+  if (!originalRun) {
+    log.debug({ prUrl }, "pr-merged: no pipeline run found for PR — skipping");
+    return;
+  }
+
+  // Idempotency: skip if already marked as merged
+  if (originalRun.autoMerged) {
+    log.debug({ runId: originalRun.id }, "pr-merged: run already marked merged — skipping");
+    return;
+  }
+
+  // Update DB to reflect the human/external merge
+  await updatePipelineRunMerged(db, originalRun.id, true, "merged via GitHub");
+
+  log.info({ runId: originalRun.id, prUrl }, "pr-merged: updated pipeline run auto_merged=true");
+
+  // Transition Linear issue to Done. The DB row's `status` field is typed as
+  // `string` (Drizzle inference) while PipelineRunStatus is a string union —
+  // cast is safe because the DB value always originates from runner code that
+  // writes one of the union members. Same pattern other notifier call sites use.
+  if (config.notifier?.onPRMerged) {
+    await config.notifier.onPRMerged(originalRun as unknown as PipelineRun).catch((err) =>
+      log.error({ err, runId: originalRun!.id }, "pr-merged: notifier.onPRMerged() failed"),
     );
   }
 }
@@ -297,7 +385,13 @@ export function createGitHubWebhookHandler(
       return c.json({ ok: true, action: "automerge-check-triggered" });
     }
 
-    // 3b. Handle PR review, inline review comment, and issue comment events
+    // 3b. PR merged externally (human merge or GitHub auto-merge-when-ready)
+    if (event === "pull_request" && action === "closed" && payload.pull_request?.merged === true) {
+      await handlePRMergedEvent(payload, config);
+      return c.json({ ok: true, action: "pr-merged" });
+    }
+
+    // 3c. Handle PR review, inline review comment, and issue comment events
     if (
       event !== "pull_request_review" &&
       event !== "pull_request_review_comment" &&
@@ -394,25 +488,7 @@ export function createGitHubWebhookHandler(
     // 6. Find the original pipeline run for this PR
     //    First try by PR URL (exact match), then by branch name (agent/ prefix).
     const db = config.db;
-    let originalRun: (typeof pipelineRuns.$inferSelect) | undefined;
-
-    if (prUrl) {
-      const byUrl = await db
-        .select()
-        .from(pipelineRuns)
-        .where(eq(pipelineRuns.prUrl, prUrl))
-        .limit(1);
-      if (byUrl.length > 0) originalRun = byUrl[0];
-    }
-
-    if (!originalRun && prBranch?.startsWith("agent/")) {
-      const byBranch = await db
-        .select()
-        .from(pipelineRuns)
-        .where(eq(pipelineRuns.branch, prBranch))
-        .limit(1);
-      if (byBranch.length > 0) originalRun = byBranch[0];
-    }
+    const originalRun = await findPipelineRunByPrUrlOrBranch(db, prUrl, prBranch);
 
     if (!originalRun) {
       return c.json({ ok: true, skipped: "not an agent-created PR" });


### PR DESCRIPTION
## Summary
Replaces #246. Closes the gap where a Linear issue stays "In Review" forever after the operator merges the PR manually (or via GitHub's auto-merge-when-ready).

Branched cleanly from current main (original #246 was based on `ed8bf4b` with significant drift).

## What lands
- New `pull_request.closed` + `merged === true` handler in `webhook/github-handler.ts`
- New `Notifier.onPRMerged?(run)` interface method
- `LinearNotifier.onPRMerged()` — posts "PR Merged ✅" comment + transitions to Done
- `CompositeNotifier.onPRMerged()` — fans out via `Promise.allSettled`
- `server.ts` threads `notifier` into `createGitHubWebhookHandler`
- Refactor: extracted `findPipelineRunByPrUrlOrBranch` + `updatePipelineRunMerged` helpers (used by both the existing automerge path and the new merged-externally path)

## Idempotency
- DB row already `autoMerged: true` → skipped
- PR from non-agent source (no DB row by `prUrl` or `branch`) → silently skipped
- `merged: false` (PR closed without merge) → falls through to "unhandled event type"

## Test plan
- [x] 7 tests in `bec-186-repro.test.ts` covering happy path, no DB row, already-merged skip, `merged: false` skip, missing notifier no-op
- [x] Typecheck + audit-immutability still green

## Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)