### PR TITLE
chore(release): v0.1.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.49] — 2026-05-12
+
+Bumps:
+- `@urateam/core`: 0.1.34 → 0.1.35
+- `@urateam/cli`: 0.1.36 → 0.1.37
+- `@urateam/dashboard`: 0.1.34 → 0.1.35
+- `create-urateam`: 0.1.37 → 0.1.38
+
+### Added (OSS+)
+- **Tier 2: convention-checklist review prompt** ([#285](https://github.com/JonB32/urateam/pull/285)) — new `PROJECT_CONVENTION_CHECKLIST` in `packages/core/src/security/review-checklist.ts` injected into both the main review-stage prompt (`reviewTemplate`) and the OpenRouter fanout system prompt (`buildReviewPrompt`). The 9 categories (`scratch-files`, `db-ddl-drift`, `audit-bypass-undocumented`, `credential-in-interface`, `spec-vs-impl`, `convention-execfile`, `convention-console`, `convention-throw`, `convention-as-any`) mirror the deterministic-gate vocabulary from Tier 1, so operators see one consistent set of `category` strings whether the finding came from a deterministic gate or from the AI review. Review stage runs on Sonnet (not Haiku) per the existing `DEFAULT_AGENT_PROFILES.review.model`. Adds defense in depth against the Tier 1 failure modes the static checks can't catch (e.g., bare `throw` outside the runner, schema-change drift across all three required sites, credential-shaped fields in newly exported interfaces).
+
 ## [0.1.48] — 2026-05-12
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.34
-ARG URATEAM_CLI_VERSION=0.1.36
-ARG URATEAM_DASHBOARD_VERSION=0.1.34
+ARG URATEAM_CORE_VERSION=0.1.35
+ARG URATEAM_CLI_VERSION=0.1.37
+ARG URATEAM_DASHBOARD_VERSION=0.1.35
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.34
-        URATEAM_CLI_VERSION: 0.1.36
-        URATEAM_DASHBOARD_VERSION: 0.1.34
+        URATEAM_CORE_VERSION: 0.1.35
+        URATEAM_CLI_VERSION: 0.1.37
+        URATEAM_DASHBOARD_VERSION: 0.1.35
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Patch release shipping Tier 2 of the autonomous-pipeline reliability tiers — the convention-checklist review prompt (#285). Adds defense in depth against the Tier 1 failure modes the static gates can't catch.

## Bumps
- `@urateam/core`: 0.1.34 → 0.1.35
- `@urateam/cli`: 0.1.36 → 0.1.37
- `@urateam/dashboard`: 0.1.34 → 0.1.35
- `create-urateam`: 0.1.37 → 0.1.38

## Test plan
- [x] `pnpm test` (1773 core unit tests pass on 15381dc)
- [x] `pnpm -w typecheck` clean
- [x] CI green on #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)