### PR TITLE
chore(release): v0.1.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.50] — 2026-05-12
+
+Bumps:
+- `@urateam/core`: 0.1.35 → 0.1.36
+- `@urateam/cli`: 0.1.37 → 0.1.38
+- `@urateam/dashboard`: 0.1.35 → 0.1.36
+- `create-urateam`: 0.1.38 → 0.1.39
+
+### Added (OSS+)
+- **Tier 3: auto-deep-review thresholds** ([#288](https://github.com/JonB32/urateam/pull/288)) — new `packages/core/src/pipeline/auto-deep-review.ts` promotes the deep-review fanout from opt-in to default-on for non-trivial PRs. After the review-fix loop, the runner computes diff metrics (`changedFiles`, `totalLines`, `newPublicExports`). If any trips `autoDeepReviewThresholds` (defaults `{ changedFiles: 5, totalLines: 200, newPublicExports: 2 }`) AND the `deep-review` license is active, `deepReviewPasses` is bumped to ≥1 (so the agentic Claude reviewer always activates; OpenRouter fanout is the optional additional layer). New `deepReviewFindingsAreBlocking` (default `true`) upgrades deep-review finding severity to blocking so it forces draft. Escape hatches: `URATEAM_DISABLE_AUTO_DEEP_REVIEW=true` (global) or per-pipeline thresholds set high. `countNewPublicExports` parses `+export (default ?)(async ?)(function|class|const|let|interface|type|enum|{|*) ...` lines under monorepo `packages/<pkg>/src/` AND repo-root `src/`, excluding `__tests__/`. **BC note:** operators with existing `deepReviewPasses: 1` will see warnings/suggestions become blocking unless they set `deepReviewFindingsAreBlocking: false`.
+
+### Audit log
+- New event type `pipeline.auto_deep_review_bumped` (Tier 3). Total audit event count: 43 → 44.
+
 ## [0.1.49] — 2026-05-12
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.35
-ARG URATEAM_CLI_VERSION=0.1.37
-ARG URATEAM_DASHBOARD_VERSION=0.1.35
+ARG URATEAM_CORE_VERSION=0.1.36
+ARG URATEAM_CLI_VERSION=0.1.38
+ARG URATEAM_DASHBOARD_VERSION=0.1.36
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.35
-        URATEAM_CLI_VERSION: 0.1.37
-        URATEAM_DASHBOARD_VERSION: 0.1.35
+        URATEAM_CORE_VERSION: 0.1.36
+        URATEAM_CLI_VERSION: 0.1.38
+        URATEAM_DASHBOARD_VERSION: 0.1.36
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Patch release shipping Tier 3 of the autonomous-pipeline reliability tiers — auto-bump deep-review for non-trivial PRs (#288).

## Bumps
- `@urateam/core`: 0.1.35 → 0.1.36
- `@urateam/cli`: 0.1.37 → 0.1.38
- `@urateam/dashboard`: 0.1.35 → 0.1.36
- `create-urateam`: 0.1.38 → 0.1.39

## Test plan
- [x] `pnpm test` (1794 core unit tests pass on a620b36)
- [x] `pnpm -w typecheck` clean
- [x] CI green on #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)