### PR TITLE
chore(release): v0.1.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.51] — 2026-05-12
+
+Bumps:
+- `@urateam/core`: 0.1.36 → 0.1.37
+- `@urateam/cli`: 0.1.38 → 0.1.39
+- `@urateam/dashboard`: 0.1.36 → 0.1.37
+- `create-urateam`: 0.1.39 → 0.1.40
+
+### Added (OSS+)
+- **Tier 4: triage produces a real design doc + open-questions gate** ([#290](https://github.com/JonB32/urateam/pull/290)) — the PM Agent triage prompt is extended to produce `approachSummary` (3-5 line sanity-checkable plan), `openQuestions` (must-answer-before-implement), and `antiAcceptanceCriteria` (anti-scope). When `openQuestions.length > 0`, the ticket is forced to the `needs-design` pipeline label regardless of complexity — same routing mechanism as the observer-marker gate. Linear comment includes all three new sections when non-empty. `TriageResult` gains optional fields.
+- **Tier 5: escalation on consecutive failures** ([#291](https://github.com/JonB32/urateam/pull/291)) — when `promoteReadyIssues` trips the circuit breaker for an issue that does NOT already carry `needs-design`, escalate: add the label (preserving existing), post a Linear comment summarizing the last failed run's `errorMessage` (truncated 500 chars), invoke the operator-supplied `slackPostAlert` callback, and emit a `pm.escalated_to_needs_design` audit event. Idempotent — subsequent ticks find the label already in place and skip re-escalation. The existing `pm.skipped_circuit_breaker` event still fires for observability. New `getLastFailureError(db, issueId)` helper in `pm/actions/db-queries.ts`.
+
+### Audit log
+- New event type `pm.escalated_to_needs_design` (Tier 5). Total audit event count: 44 → 45.
+
 ## [0.1.50] — 2026-05-12
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.36
-ARG URATEAM_CLI_VERSION=0.1.38
-ARG URATEAM_DASHBOARD_VERSION=0.1.36
+ARG URATEAM_CORE_VERSION=0.1.37
+ARG URATEAM_CLI_VERSION=0.1.39
+ARG URATEAM_DASHBOARD_VERSION=0.1.37
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.36
-        URATEAM_CLI_VERSION: 0.1.38
-        URATEAM_DASHBOARD_VERSION: 0.1.36
+        URATEAM_CORE_VERSION: 0.1.37
+        URATEAM_CLI_VERSION: 0.1.39
+        URATEAM_DASHBOARD_VERSION: 0.1.37
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Final release of the autonomous-pipeline reliability tiers — Tier 4 (design-doc triage with open-questions gate, #290) and Tier 5 (escalation on consecutive failures, #291).

## Bumps
- \`@urateam/core\`: 0.1.36 → 0.1.37
- \`@urateam/cli\`: 0.1.38 → 0.1.39
- \`@urateam/dashboard\`: 0.1.36 → 0.1.37
- \`create-urateam\`: 0.1.39 → 0.1.40

## Test plan
- [x] \`pnpm test\` (1801 core unit tests pass on f72b229)
- [x] \`pnpm -w typecheck\` clean
- [x] CI green on #290 and #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)