### PR TITLE
chore(release): v0.1.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.52] — 2026-05-13
+
+Bumps:
+- `@urateam/core`: 0.1.37 → 0.1.38
+- `@urateam/cli`: 0.1.39 → 0.1.40
+- `@urateam/dashboard`: 0.1.37 → 0.1.38
+- `create-urateam`: 0.1.40 → 0.1.41
+
+### Added (OSS+)
+- **User-level install path (Cyrus-style)** ([#296](https://github.com/JonB32/urateam/pull/296)) — new minimum-effort onboarding for operators evaluating urateam on a single machine. Five new CLI commands: `ura init` (bootstraps `~/.urateam/{config.json,data/,repos/}`), `ura repo add <url>` (clones into `~/.urateam/repos/<slug>` and registers in `config.json` — options: `--branch`, `--test-command`, `--build-command`, `--team`, `--label-pattern`), `ura repo list`, `ura repo remove <slug> [--purge]` (with path-safety guard refusing to delete outside `URATEAM_HOME`), `ura uninstall --yes`. `ura start` now reads `~/.urateam/config.json` (or `$URATEAM_HOME/config.json`) as a fallback when no `REPO_*` env vars are set, and explicitly loads `~/.urateam/.env` regardless of cwd so secrets work without `cd ~/.urateam`. Project-level (sidecar / docker-compose) install is unchanged — env vars win when both are present. New schema lives in `packages/cli/src/lib/user-level-config.ts` (Zod, JSON file). Public API: `cloneRepo` is now re-exported from `@urateam/core`. Full operator doc: `deploy/USER_LEVEL_INSTALL.md`.
+
 ## [0.1.51] — 2026-05-12
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.37
-ARG URATEAM_CLI_VERSION=0.1.39
-ARG URATEAM_DASHBOARD_VERSION=0.1.37
+ARG URATEAM_CORE_VERSION=0.1.38
+ARG URATEAM_CLI_VERSION=0.1.40
+ARG URATEAM_DASHBOARD_VERSION=0.1.38
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.37
-        URATEAM_CLI_VERSION: 0.1.39
-        URATEAM_DASHBOARD_VERSION: 0.1.37
+        URATEAM_CORE_VERSION: 0.1.38
+        URATEAM_CLI_VERSION: 0.1.40
+        URATEAM_DASHBOARD_VERSION: 0.1.38
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Patch release shipping the Cyrus-style user-level install path (#296).

## Bumps
- \`@urateam/core\`: 0.1.37 → 0.1.38
- \`@urateam/cli\`: 0.1.39 → 0.1.40
- \`@urateam/dashboard\`: 0.1.37 → 0.1.38
- \`create-urateam\`: 0.1.40 → 0.1.41

## Test plan
- [x] \`pnpm test\` (full CLI + core suites pass on 427f446)
- [x] \`pnpm -w typecheck\` clean
- [x] CI green on #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)