### PR TITLE
chore(release): v0.1.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.53] — 2026-05-13
+
+Bumps:
+- `@urateam/core`: 0.1.38 → 0.1.39
+- `@urateam/cli`: 0.1.40 → 0.1.41
+- `@urateam/dashboard`: 0.1.38 → 0.1.39
+- `create-urateam`: 0.1.41 → 0.1.42
+
+### Added (OSS+)
+- **`ura service install` / `ura service uninstall`** ([#300](https://github.com/JonB32/urateam/pull/300)) — auto-generate and install a platform service unit so the user-level daemon auto-starts on login. Auto-detects platform: macOS → launchd plist at `~/Library/LaunchAgents/com.urateam.daemon.plist` + `launchctl load -w`; Linux → systemd-user unit at `~/.config/systemd/user/urateam.service` + `systemctl --user daemon-reload + enable --now`. Idempotent — refuses to overwrite an existing unit, prints "already exists" instead. `--dry-run` prints the unit content without writing. Other platforms fail with a clear pointer to the manual snippets in `deploy/USER_LEVEL_INSTALL.md`. Pure I/O-free unit-file generators live in `packages/cli/src/lib/service-unit.ts` (`renderLaunchdPlist`, `renderSystemdUserUnit`) and are snapshot-tested.
+
+### Audit log
+- Two new event types: `service.installed`, `service.uninstalled`. Emitted opportunistically from the CLI when the daemon SQLite DB exists. Routed through the license-gated `logAuditEvent` — Enterprise-tier `audit-log` deployments record them; OSS / Pro drop them silently. CLAUDE.md count: 45 → 47.
+
 ## [0.1.52] — 2026-05-13
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.38
-ARG URATEAM_CLI_VERSION=0.1.40
-ARG URATEAM_DASHBOARD_VERSION=0.1.38
+ARG URATEAM_CORE_VERSION=0.1.39
+ARG URATEAM_CLI_VERSION=0.1.41
+ARG URATEAM_DASHBOARD_VERSION=0.1.39
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.38
-        URATEAM_CLI_VERSION: 0.1.40
-        URATEAM_DASHBOARD_VERSION: 0.1.38
+        URATEAM_CORE_VERSION: 0.1.39
+        URATEAM_CLI_VERSION: 0.1.41
+        URATEAM_DASHBOARD_VERSION: 0.1.39
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Release v0.1.53.

### Highlights
- `ura service install` / `ura service uninstall` (#300) — auto-generate launchd plist (macOS) or systemd-user unit (Linux) so the user-level daemon auto-starts on login.

See CHANGELOG.md for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)