### PR TITLE
chore(release): v0.1.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.54] — 2026-05-13
+
+Bumps:
+- `@urateam/core`: 0.1.39 → 0.1.40
+- `@urateam/cli`: 0.1.41 → 0.1.42
+- `@urateam/dashboard`: 0.1.39 → 0.1.40
+- `create-urateam`: 0.1.42 → 0.1.43
+
+### Added (OSS+)
+- **`ura self-auth-linear`** ([#302](https://github.com/JonB32/urateam/pull/302)) — browser-based Linear OAuth flow. Spins up an ephemeral `127.0.0.1:9898` HTTP server (port configurable via `--port`), opens Linear's authorize URL in the operator's browser via `open` (macOS) / `xdg-open` (Linux) / printed-URL fallback, verifies the HMAC-signed `state` parameter (per-invocation 32-byte random secret; constant-time `timingSafeEqual`), exchanges the code at `https://api.linear.app/oauth/token`, fetches workspace metadata via Linear GraphQL, and writes `LINEAR_API_KEY=<access_token>` into `~/.urateam/.env` via the new atomic `upsertEnvFile()` helper (rename-after-write; preserves comments, blank lines, and unrelated keys). Flags: `--timeout-ms` (default 5min), `--scope` (default `read,write`), `--port` (default 9898). New library helpers: `lib/oauth-state.ts`, `lib/env-file.ts`, `lib/linear-oauth.ts` (DI-able orchestrator), `lib/linear-oauth-deps.ts` (default real-world fetch + browser-open shims). Token preservation: if Linear's GraphQL metadata endpoint hiccups after a successful token exchange, the success page still renders and the token is still written; workspace metadata falls back to a placeholder. Token NEVER appears in console output, the success-page HTML, or the audit payload.
+
+### Audit log
+- One new event type: `linear.oauth_completed`. Emitted opportunistically from the CLI when the daemon SQLite DB exists. Routed through license-gated `logAuditEvent` (Enterprise tier). Payload carries `workspaceId` + `workspaceName`, never the token. CLAUDE.md count: 47 → 48.
+
 ## [0.1.53] — 2026-05-13
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.39
-ARG URATEAM_CLI_VERSION=0.1.41
-ARG URATEAM_DASHBOARD_VERSION=0.1.39
+ARG URATEAM_CORE_VERSION=0.1.40
+ARG URATEAM_CLI_VERSION=0.1.42
+ARG URATEAM_DASHBOARD_VERSION=0.1.40
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.39
-        URATEAM_CLI_VERSION: 0.1.41
-        URATEAM_DASHBOARD_VERSION: 0.1.39
+        URATEAM_CORE_VERSION: 0.1.40
+        URATEAM_CLI_VERSION: 0.1.42
+        URATEAM_DASHBOARD_VERSION: 0.1.40
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Release v0.1.54 — `ura self-auth-linear` (browser-based Linear OAuth flow, PR #302). See CHANGELOG.md.