### PR TITLE
chore(release): v0.1.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.55] — 2026-05-13
+
+Bumps:
+- `@urateam/core`: 0.1.40 → 0.1.41
+- `@urateam/cli`: 0.1.42 → 0.1.43
+- `@urateam/dashboard`: 0.1.40 → 0.1.41
+- `create-urateam`: 0.1.43 → 0.1.44
+
+### Added (OSS+)
+- **`ura start --tunnel <mode>`** ([#304](https://github.com/JonB32/urateam/pull/304)) — built-in Cloudflare tunnel manager. Three modes: `none` (default — daemon stays on local ports), `cloudflare-quick` (spawns `cloudflared tunnel --url http://localhost:<port>`, parses the `*.trycloudflare.com` URL from cloudflared's stderr — free, ephemeral), `cloudflare-token` (spawns `cloudflared tunnel --token <token> run` — requires `CLOUDFLARE_TUNNEL_TOKEN` + `URATEAM_PUBLIC_URL` env vars for a persistent named tunnel). New `TunnelManager` class in `packages/cli/src/lib/tunnel.ts` supervises cloudflared with exponential-backoff restart (1s → 30s capped, 10 attempts max) and graceful SIGTERM shutdown. On startup, the detected public URL is exported as `URATEAM_PUBLIC_URL` so OAuth callbacks and webhook handlers see it. When `cloudflared` isn't on `$PATH`, `CloudflaredMissingError` surfaces brew/apt/release-page install hints; tunnel failures never crash the daemon — it stays on local ports. Audit-event observability via `tunnel.started` and `tunnel.stopped`.
+
+### Audit log
+- Two new event types: `tunnel.started` (provider, publicUrl, restartCount), `tunnel.stopped` (provider, restartCount, exitCode, signal). CLAUDE.md count: 48 → 50.
+
 ## [0.1.54] — 2026-05-13
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.40
-ARG URATEAM_CLI_VERSION=0.1.42
-ARG URATEAM_DASHBOARD_VERSION=0.1.40
+ARG URATEAM_CORE_VERSION=0.1.41
+ARG URATEAM_CLI_VERSION=0.1.43
+ARG URATEAM_DASHBOARD_VERSION=0.1.41
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.40
-        URATEAM_CLI_VERSION: 0.1.42
-        URATEAM_DASHBOARD_VERSION: 0.1.40
+        URATEAM_CORE_VERSION: 0.1.41
+        URATEAM_CLI_VERSION: 0.1.43
+        URATEAM_DASHBOARD_VERSION: 0.1.41
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Release v0.1.55 — `ura start --tunnel <mode>` (built-in Cloudflare tunnel manager, PR #304). See CHANGELOG.md.