### PR TITLE
chore(release): v0.1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ notes call out when a change affects only a single package.
 
 ## [Unreleased]
 
+## [0.1.56] — 2026-05-13
+
+Bumps:
+- `@urateam/core`: 0.1.41 → 0.1.42
+- `@urateam/cli`: 0.1.43 → 0.1.44
+- `@urateam/dashboard`: 0.1.41 → 0.1.42
+- `create-urateam`: 0.1.44 → 0.1.45
+
+### Added (OSS+)
+- **`~/.urateam/config.json` hot-reload** ([#306](https://github.com/JonB32/urateam/pull/306)) — `ura start` now watches the user-level config file and applies changes from `ura repo add` / `ura repo remove` / hand-edits without a restart. Debounced (1s default). Safe fields (`labelPattern`, `testCommand`, `buildCommand`, `teamId`) apply in-place; unsafe fields (`url`, `path`, `defaultBranch`) log `restart required`. Removals delete the entry from the live `repoConfigs` immediately — in-flight pipeline runs hold their own snapshot of state and continue uninterrupted; only NEW work is blocked. Schema-validation failures keep the previous in-memory config and log a warning. `teamId` changes correctly re-key the entry under the new key (so webhook routing keeps working). New library: `packages/cli/src/lib/config-watcher.ts` (`ConfigWatcher`, `diffRepos`, `hashConfig`). Project-level (sidecar) installs are env-var driven and don't use hot-reload.
+
+### Audit log
+- One new event type: `config.reloaded`. Payload: `{ added, removed, modifiedSafe, modifiedUnsafe, sha256 }`. License-gated via `logAuditEvent`. CLAUDE.md count: 50 → 51.
+
+### Closed
+- This release completes the full deferred-list from the original user-level install PR (#296). All four follow-ups — `ura service install`, `ura self-auth-linear`, built-in tunnel manager, config.json hot-reload — are now shipped.
+
 ## [0.1.55] — 2026-05-13
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.41
-ARG URATEAM_CLI_VERSION=0.1.43
-ARG URATEAM_DASHBOARD_VERSION=0.1.41
+ARG URATEAM_CORE_VERSION=0.1.42
+ARG URATEAM_CLI_VERSION=0.1.44
+ARG URATEAM_DASHBOARD_VERSION=0.1.42
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.41
-        URATEAM_CLI_VERSION: 0.1.43
-        URATEAM_DASHBOARD_VERSION: 0.1.41
+        URATEAM_CORE_VERSION: 0.1.42
+        URATEAM_CLI_VERSION: 0.1.44
+        URATEAM_DASHBOARD_VERSION: 0.1.42
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Release v0.1.56 — `~/.urateam/config.json` hot-reload (PR #306). Closes the deferred list from PR #296. See CHANGELOG.md.