### PR TITLE
chore(pm): triage-v2 review follow-ups + parseJsonObject nested-JSON fix

### DIFF
--- a/packages/core/src/__tests__/agent-stream.test.ts
+++ b/packages/core/src/__tests__/agent-stream.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { parseJsonObject } from "../executor/agent-stream.js";
 import {
   consumeAgentStream,
   StageStalledError,
@@ -142,5 +143,52 @@ describe("consumeAgentStream — operator abort", () => {
     const result = await consumeAgentStream(fast(), { abortSignal: controller.signal });
     controller.abort(); // post-hoc, should not throw or matter
     expect(result.lastText).toBe("done");
+  });
+});
+
+describe("parseJsonObject — nested-JSON handling (triage v2 regression)", () => {
+  it("parses a flat object", () => {
+    expect(parseJsonObject('{"a":1,"b":"x"}')).toEqual({ a: 1, b: "x" });
+  });
+
+  it("parses a nested object (riskAssessment shape)", () => {
+    const text = '{"priority":2,"riskAssessment":{"severity":"low","areas":["api"]}}';
+    expect(parseJsonObject(text)).toEqual({
+      priority: 2,
+      riskAssessment: { severity: "low", areas: ["api"] },
+    });
+  });
+
+  it("parses an object with array-of-objects (examples shape)", () => {
+    const text = '{"examples":[{"scenario":"a","expected":"b"},{"scenario":"c","expected":"d"}]}';
+    expect(parseJsonObject(text)).toEqual({
+      examples: [
+        { scenario: "a", expected: "b" },
+        { scenario: "c", expected: "d" },
+      ],
+    });
+  });
+
+  it("extracts a JSON object surrounded by prose", () => {
+    const text = 'Here is the result: {"a":1,"nested":{"b":2}} done.';
+    expect(parseJsonObject(text)).toEqual({ a: 1, nested: { b: 2 } });
+  });
+
+  it("handles strings containing braces (string-aware brace counting)", () => {
+    const text = '{"msg":"this has } a brace","ok":true}';
+    expect(parseJsonObject(text)).toEqual({ msg: "this has } a brace", ok: true });
+  });
+
+  it("handles escaped quotes inside strings", () => {
+    const text = '{"msg":"she said \\"hi\\"","ok":true}';
+    expect(parseJsonObject(text)).toEqual({ msg: 'she said "hi"', ok: true });
+  });
+
+  it("returns null when no object is present", () => {
+    expect(parseJsonObject("just prose, no json")).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(parseJsonObject('{"a":1,"b":')).toBeNull();
   });
 });

--- a/packages/core/src/__tests__/pm-triage.test.ts
+++ b/packages/core/src/__tests__/pm-triage.test.ts
@@ -341,4 +341,53 @@ describe("triageNewIssues", () => {
       expect(results[0].labels).toEqual(["needs-design"]);
     });
   });
+
+  describe("URATEAM_DISABLE_TRIAGE_V2 escape hatch", () => {
+    it("only appends **Acceptance Criteria:** to description (no v2 sections) when v2 is disabled", async () => {
+      vi.stubEnv("URATEAM_DISABLE_TRIAGE_V2", "true");
+      try {
+        const client = mockLinearClient([
+          {
+            id: "issue-v1d",
+            identifier: "BEC-V1D",
+            title: "Disable v2 path",
+            description: "",
+            labels: { nodes: [] },
+            team: { id: "team-1" },
+          },
+        ]);
+        // Even if Claude returns v2 fields, the disable path must drop them.
+        const callClaude = mockClaude(JSON.stringify({
+          priority: 2,
+          labels: ["feature"],
+          complexity: "small",
+          rationale: "Adds a thing",
+          acceptanceCriteria: ["Thing is added", "Thing has a test"],
+          assumptions: ["Should not appear in description"],
+          examples: [{ scenario: "X", expected: "Y" }],
+          affectedFiles: ["src/x.ts"],
+          testStrategy: { unit: "vitest" },
+          riskAssessment: { severity: "low", areas: ["api"] },
+        }));
+
+        await triageNewIssues({
+          linearClient: client as any,
+          teamIds: ["team-1"],
+          callClaude,
+          sanitize: (s: string) => s,
+          stateMap: defaultStateMap,
+        });
+
+        const updateCall = client.updateIssue.mock.calls[0]!;
+        const desc = (updateCall[1] as { description?: string }).description ?? "";
+        expect(desc).toContain("**Acceptance Criteria:**");
+        expect(desc).not.toContain("**Examples:**");
+        expect(desc).not.toContain("**Affected Files:**");
+        expect(desc).not.toContain("**Test Strategy:**");
+        expect(desc).not.toContain("**Risk Assessment:**");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
 });

--- a/packages/core/src/executor/agent-stream.ts
+++ b/packages/core/src/executor/agent-stream.ts
@@ -317,18 +317,55 @@ function parseJsonWithRegex(text: string, regex: RegExp, groupIndex: number = 0)
 }
 
 /**
- * Extract and parse a bare JSON object from text (finds first `{...}` match).
- * Returns null if no object is found or if parsing fails.
+ * Extract and parse a bare JSON object from text. Returns null if no object
+ * is found or if parsing fails.
  *
- * Uses non-greedy matching so that if the text contains multiple top-level
- * JSON-like blocks separated by non-JSON content (e.g. log lines), the first
- * parseable object is returned rather than a greedy span that crosses all of
- * them and fails to parse. Trade-off: non-greedy does not correctly handle
- * deeply nested objects — for those, prefer `parseJsonBlock` (fenced block).
- * In practice, PM-agent Haiku responses are flat JSON, so non-greedy is safe.
+ * Strategy:
+ * 1. Try `JSON.parse(text.trim())` first — covers clean JSON-only responses
+ *    (the prefill-anchored v2 triage prompt elicits this shape).
+ * 2. Fall back to bracket-counted extraction: find the first `{`, then walk
+ *    forward tracking nesting depth (string-aware, escape-aware) until the
+ *    matching closing `}`. Handles nested objects/arrays correctly — the
+ *    previous non-greedy regex (`\{[\s\S]*?\}`) truncated at the first inner
+ *    `}` and silently failed to parse v2 Haiku responses with `riskAssessment`
+ *    / `examples` / `testStrategy` objects.
  */
 export function parseJsonObject(text: string): any | null {
-  return parseJsonWithRegex(text, /\{[\s\S]*?\}/, 0) as any | null;
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // fall through to extraction
+    }
+  }
+  const start = text.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(text.slice(start, i + 1));
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/core/src/pm/actions/triage.ts
+++ b/packages/core/src/pm/actions/triage.ts
@@ -1,4 +1,4 @@
-import type { LinearClient } from "@linear/sdk";
+import type { Issue, LinearClient } from "@linear/sdk";
 import type { TriageResult } from "../types.js";
 import { parseTriageV2Extensions } from "../types.js";
 import { parseJsonObject } from "../../executor/agent-stream.js";
@@ -100,7 +100,7 @@ export async function triageNewIssues(input: TriageInput): Promise<TriageResult[
   const results = (await runInBatches(
     issues.slice(0, MAX_ISSUES_PER_TICK),
     batchSize,
-    async (issue: any) => {
+    async (issue: Issue) => {
       try {
         if (isObserverOriginIssue(issue.description)) {
           const team = await issue.team;
@@ -205,6 +205,14 @@ export async function triageNewIssues(input: TriageInput): Promise<TriageResult[
             ? parsed.approachSummary.trim()
             : "";
 
+        // `parsed.pipelineLabel` from the v2 prompt is INTENTIONALLY
+        // discarded here — Haiku's classification informs the response
+        // schema, but the authoritative pipeline routing happens below
+        // from `forceNeedsDesign` / `hasBug` / `complexity`. Wiring the
+        // model's self-classification directly into routing would let a
+        // prompt-injected issue self-route to `quick-fix` (escaping the
+        // bug-severity gate). Treat the model's `pipelineLabel` as
+        // telemetry only.
         const forceNeedsDesign = openQuestions.length > 0;
         const hasBug = labels.some((l: string) => l.toLowerCase() === "bug");
         const pipelineLabel = forceNeedsDesign


### PR DESCRIPTION
## Summary

Three follow-ups from PR #310's Sonnet code review, plus one production bug uncovered in the process.

### Review follow-ups

1. **Tighten the `issue: any` callback cascade** in `triage.ts:103` — `Issue` from `@linear/sdk` flows naturally now that `linearClient` is properly typed.
2. **Comment the `pipelineLabel` discard** — Haiku's classification informs the schema, but routing is authoritative from `forceNeedsDesign` / `hasBug` / `complexity`. Wiring the model's self-classification into routing would let a prompt-injected issue self-route past the bug-severity gate. The comment captures the rationale so a future contributor doesn't "fix" it.
3. **Integration test for the v1-disable path** — `URATEAM_DISABLE_TRIAGE_V2=true` is asserted to drop v2 fields even when Haiku returns them.

### Bonus — production bug found while writing #3

`parseJsonObject` used non-greedy regex `\{[\s\S]*?\}` which truncates at the first inner `}`. The v2 triage prompt asks Haiku for **nested objects** (`riskAssessment`, `examples`, `testStrategy`), so production triage-v2 was silently skipping every issue with nested fields.

The fix replaces the regex with a string-aware bracket-counting extractor. Three callers benefit: `triage.ts`, `conflict.ts`, `slack-interface.ts`.

8 new regression tests in `agent-stream.test.ts` cover: flat, nested, array-of-objects, surrounded-by-prose, brace-in-string, escaped-quote, no-match, malformed.

## Tests

- Full sweep: **1957 core tests pass** (up from 1948 — 9 new). `pnpm -w typecheck` clean.
- New tests target: `parseJsonObject` nested handling (8); v1-disable description integrity (1).

## Constitution Self-Review

- [x] **scratch-files** — clean
- [x] **db-ddl-drift** — N/A
- [x] **audit-bypass-undocumented** — N/A
- [x] **credential-in-interface** — N/A
- [x] **spec-vs-impl** — `Issue` type was claimed to cascade in #310's review reply but deferred; now actually addressed
- [x] **convention-execfile** — N/A
- [x] **convention-console** — clean
- [x] **convention-throw** — clean
- [x] **convention-as-any** — net -1 `: any` (removed in triage.ts:103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)