### PR TITLE
chore(release): v0.1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.58] — 2026-05-14
+
+Bumps:
+- `@urateam/core`: 0.1.43 → 0.1.44
+- `@urateam/cli`: 0.1.45 → 0.1.46
+- `@urateam/dashboard`: 0.1.43 → 0.1.44
+- `create-urateam`: 0.1.46 → 0.1.47
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.57] — 2026-05-14
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,20 @@ Bumps:
 - `@urateam/dashboard`: 0.1.43 → 0.1.44
 - `create-urateam`: 0.1.46 → 0.1.47
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Fixed (PR #312)
+
+- **Critical**: `parseJsonObject` (`executor/agent-stream.ts`) used non-greedy regex `\{[\s\S]*?\}` which truncates at the first inner `}`. The v2 triage prompt (shipped in v0.1.57) asks Haiku for nested objects (`riskAssessment`, `examples`, `testStrategy`), so production triage-v2 was silently skipping every issue with nested fields. Replaced with a string-aware bracket-counting extractor that handles nested objects/arrays correctly. Affects all 3 callers: `triage.ts`, `conflict.ts`, `slack-interface.ts`.
+
+### Chore (PR #312)
+
+- Tightened `issue: any` callback cascade in `pm/actions/triage.ts:103` to `Issue` from `@linear/sdk` (now possible after the `linearClient: LinearClient` fix in v0.1.57).
+- Added a code comment explaining why `parsed.pipelineLabel` from the Haiku response is intentionally discarded (routing is authoritative from `forceNeedsDesign` / `hasBug` / `complexity`).
+
+### Tests
+
+- 8 new `parseJsonObject` regression tests (flat, nested, array-of-objects, surrounded-by-prose, brace-in-string, escaped-quote, no-match, malformed).
+- 1 new `triageNewIssues` integration test asserting `URATEAM_DISABLE_TRIAGE_V2=true` produces a description with only `**Acceptance Criteria:**` (no v2 sections leak through).
+- Full sweep: 1957 core tests pass.
 ## [0.1.57] — 2026-05-14
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.43
-ARG URATEAM_CLI_VERSION=0.1.45
-ARG URATEAM_DASHBOARD_VERSION=0.1.43
+ARG URATEAM_CORE_VERSION=0.1.44
+ARG URATEAM_CLI_VERSION=0.1.46
+ARG URATEAM_DASHBOARD_VERSION=0.1.44
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.43
-        URATEAM_CLI_VERSION: 0.1.45
-        URATEAM_DASHBOARD_VERSION: 0.1.43
+        URATEAM_CORE_VERSION: 0.1.44
+        URATEAM_CLI_VERSION: 0.1.46
+        URATEAM_DASHBOARD_VERSION: 0.1.44
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.