### PR TITLE
chore(release): v0.1.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.59] — 2026-05-14
+
+Bumps:
+- `@urateam/core`: 0.1.44 → 0.1.45
+- `@urateam/cli`: 0.1.46 → 0.1.47
+- `@urateam/dashboard`: 0.1.44 → 0.1.45
+- `create-urateam`: 0.1.47 → 0.1.48
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.58] — 2026-05-14
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,16 @@ Bumps:
 - `@urateam/dashboard`: 0.1.44 → 0.1.45
 - `create-urateam`: 0.1.47 → 0.1.48
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Added (Tier 6e, PR #314)
+
+- **New audit event `pm.triage_quality_score`** — emitted by `pipeline/runner.ts` after each successful push. Records how closely triage v2's `affectedFiles` prediction matched the actual changed files. Audit-event count: 51 → **52**.
+- **`pmTriageQualityScoreEvent(args)`** helper in `audit/events.ts`. Payload includes `runId`, `issueId`, `hasV2Prediction`, `predicted`, `actual`, `intersection`, plus `missed` and `unexpected` path lists (each capped at 50 entries to keep the audit row ≤ ~2 KB).
+- **`parseAffectedFilesFromDescription(description)`** in `pm/triage-prediction-quality.ts` — reads the `**Affected Files:**` section that `appendTriageSectionsToDescription` wrote, returns `undefined` when no section is present (v1 triage path).
+- Runner emission is **fail-open**: any error in parse, `getChangedFiles`, or audit write is logged at warn and swallowed. Telemetry can never block pipeline completion.
+
+### Notes
+
+- This release was **dogfooded end-to-end**: BEC-217 was filed in Linear and the dogfood agent itself classified, planned, implemented, tested, and opened the draft PR via the v2 triage pipeline. One regex edge case (`parseAffectedFilesFromDescription` empty-section path) was caught by the agent's own test, fixed by the operator, and merged. The full soak validates v0.1.58's `parseJsonObject` nested-JSON fix in production.
 ## [0.1.58] — 2026-05-14
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.44
-ARG URATEAM_CLI_VERSION=0.1.46
-ARG URATEAM_DASHBOARD_VERSION=0.1.44
+ARG URATEAM_CORE_VERSION=0.1.45
+ARG URATEAM_CLI_VERSION=0.1.47
+ARG URATEAM_DASHBOARD_VERSION=0.1.45
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.44
-        URATEAM_CLI_VERSION: 0.1.46
-        URATEAM_DASHBOARD_VERSION: 0.1.44
+        URATEAM_CORE_VERSION: 0.1.45
+        URATEAM_CLI_VERSION: 0.1.47
+        URATEAM_DASHBOARD_VERSION: 0.1.45
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.