### PR TITLE
fix(pm): normalize affectedFiles bullet/backtick prefixes

### DIFF
--- a/packages/core/src/__tests__/triage-v2-prediction-emission.test.ts
+++ b/packages/core/src/__tests__/triage-v2-prediction-emission.test.ts
@@ -52,6 +52,30 @@ describe("parseAffectedFilesFromDescription", () => {
       "src/beta.ts",
     ]);
   });
+
+  it("handles * bullets in addition to - (forward-compat for v0.1.59 dirty descriptions)", () => {
+    const description = `**Affected Files:**\n* src/x.ts\n* src/y.ts`;
+    expect(parseAffectedFilesFromDescription(description)).toEqual([
+      "src/x.ts",
+      "src/y.ts",
+    ]);
+  });
+
+  it("strips surrounding backticks from path entries", () => {
+    const description = `**Affected Files:**\n- \`src/a.ts\`\n* \`src/b.ts\``;
+    expect(parseAffectedFilesFromDescription(description)).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+  });
+
+  it("handles numbered-list bullets", () => {
+    const description = `**Affected Files:**\n1. src/foo.ts\n2) src/bar.ts`;
+    expect(parseAffectedFilesFromDescription(description)).toEqual([
+      "src/foo.ts",
+      "src/bar.ts",
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/__tests__/triage-v2-schema.test.ts
+++ b/packages/core/src/__tests__/triage-v2-schema.test.ts
@@ -129,4 +129,39 @@ describe("parseTriageV2Extensions — pre-zod truncation + filter", () => {
   it("returns an empty object when none of the v2 fields are present", () => {
     expect(parseTriageV2Extensions({ priority: 1, labels: [] })).toEqual({});
   });
+
+  it("strips leading markdown bullets from affectedFiles entries (Haiku echo bug)", () => {
+    const parsed = parseTriageV2Extensions({
+      affectedFiles: [
+        "* CLAUDE.md",
+        "- src/foo.ts",
+        "+ src/bar.ts",
+        "1. src/baz.ts",
+        "2) src/qux.ts",
+        "src/already-clean.ts",
+      ],
+    });
+    expect(parsed.affectedFiles).toEqual([
+      "CLAUDE.md",
+      "src/foo.ts",
+      "src/bar.ts",
+      "src/baz.ts",
+      "src/qux.ts",
+      "src/already-clean.ts",
+    ]);
+  });
+
+  it("strips surrounding backticks from affectedFiles entries", () => {
+    const parsed = parseTriageV2Extensions({
+      affectedFiles: ["`src/foo.ts`", "``src/bar.ts``", "* `src/baz.ts`"],
+    });
+    expect(parsed.affectedFiles).toEqual(["src/foo.ts", "src/bar.ts", "src/baz.ts"]);
+  });
+
+  it("drops affectedFiles entries that become empty after normalization", () => {
+    const parsed = parseTriageV2Extensions({
+      affectedFiles: ["- ", "src/keep.ts", "`"],
+    });
+    expect(parsed.affectedFiles).toEqual(["src/keep.ts"]);
+  });
 });

--- a/packages/core/src/pm/triage-prediction-quality.ts
+++ b/packages/core/src/pm/triage-prediction-quality.ts
@@ -78,9 +78,18 @@ export function parseAffectedFilesFromDescription(description: string): string[]
   if (!match) return undefined;
 
   const block = match[1] ?? "";
+  // Strip any leading bullet (-, *, +, 1., 1)) and surrounding backticks. Triage v2
+  // normalizes these at parse time (`parseTriageV2Extensions`), but descriptions
+  // already on disk from runs prior to that fix may still contain bullet-prefixed
+  // paths — handle both shapes for forward compatibility.
   const paths = block
     .split("\n")
-    .map((line) => line.replace(/^-\s*/, "").trim())
+    .map((line) =>
+      line
+        .replace(/^\s*(?:[-*+]|\d+[.)])\s*/, "")
+        .replace(/^`+|`+$/g, "")
+        .trim(),
+    )
     .filter((line) => line.length > 0);
 
   return paths;

--- a/packages/core/src/pm/types.ts
+++ b/packages/core/src/pm/types.ts
@@ -199,7 +199,22 @@ export function parseTriageV2Extensions(raw: unknown): TriageV2Extensions {
   const assumptions = collectStringArray("assumptions", TRIAGE_V2_CAPS.assumptions);
   if (assumptions) out.assumptions = assumptions;
   const affectedFiles = collectStringArray("affectedFiles", TRIAGE_V2_CAPS.affectedFiles);
-  if (affectedFiles) out.affectedFiles = affectedFiles;
+  if (affectedFiles) {
+    // Haiku sometimes echoes markdown-bullet syntax from the issue description
+    // into the affectedFiles array as a string prefix (`"* CLAUDE.md"`,
+    // `"- src/foo.ts"`, `"1. src/bar.ts"`). Strip those + surrounding backticks
+    // so downstream consumers (Linear comment render, description appender,
+    // Tier 6e prediction-quality comparison) see raw paths.
+    const normalized = affectedFiles
+      .map((p) =>
+        p
+          .replace(/^\s*(?:[-*+]|\d+[.)])\s*/, "") // leading bullet (-, *, +, 1., 1)) — \s* not \s+ so a lone bullet char also gets stripped
+          .replace(/^`+|`+$/g, "")                  // surrounding backticks
+          .trim(),
+      )
+      .filter((p) => p.length > 0);
+    if (normalized.length > 0) out.affectedFiles = normalized;
+  }
 
   // examples — drop entries missing either field.
   if (Array.isArray(r.examples)) {


### PR DESCRIPTION
## Summary

- The first real `pm.triage_quality_score` audit event (from BEC-218 soak) reported `intersection=0` because Haiku echoed `* `-prefixed markdown bullets from the operator's issue description verbatim into the `affectedFiles` JSON array. Downstream string-equality compare in `computeAffectedFilesPredictionQuality` then matched zero paths against the real diff.
- Fix normalizes bullet/backtick prefixes at the parse boundary (`parseTriageV2Extensions`) so the JSON-bound `affectedFiles` array never contains markdown artifacts.
- Defense-in-depth: `parseAffectedFilesFromDescription` applies the same normalization when re-reading descriptions written by pre-fix triage runs, so historical issues still produce clean prediction sets.

## Root cause

Triage v2's Haiku prompt instructs the model to emit a JSON array of paths. In practice — confirmed from the BEC-218 prompt rendering — the model occasionally copies the visual list style from the surrounding markdown rather than emitting bare strings. Inputs like `"* CLAUDE.md"` then fall through Zod (`.min(1)` only checks length) and reach the comparator.

## Changes

- `packages/core/src/pm/types.ts` — `parseTriageV2Extensions` strips leading `-`, `*`, `+`, `1.`, `1)` and surrounding backticks; drops entries that normalize to empty.
- `packages/core/src/pm/triage-prediction-quality.ts` — `parseAffectedFilesFromDescription` applies the same normalization per-line for forward-compat with descriptions on disk.
- Tests:
  - `__tests__/triage-v2-schema.test.ts` — 3 new (bullet stripping, backtick stripping, empty-after-normalization filter).
  - `__tests__/triage-v2-prediction-emission.test.ts` — 3 new (`*` bullets, surrounding backticks, numbered-list bullets).

## Test plan

- [x] `pnpm --filter @urateam/core test` — 1976 passed | 11 skipped (1987)
- [x] Targeted `triage-v2-schema` + `triage-v2-prediction-emission` — 34/34
- [ ] Soak: next `pm.triage_quality_score` event from BEC-219 (or a re-triaged BEC-218 run) should show `intersection > 0` when the diff actually overlaps the prediction

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)