### PR TITLE
chore(release): v0.1.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.60] — 2026-05-14
+
+Bumps:
+- `@urateam/core`: 0.1.45 → 0.1.46
+- `@urateam/cli`: 0.1.47 → 0.1.48
+- `@urateam/dashboard`: 0.1.45 → 0.1.46
+- `create-urateam`: 0.1.48 → 0.1.49
+
+### Fixed
+- **Triage v2 affectedFiles bullet/backtick contamination** (#318): When Haiku occasionally echoed the surrounding markdown list style into the `affectedFiles` JSON array (e.g. `"* CLAUDE.md"`), the downstream `computeAffectedFilesPredictionQuality` string-equality compare produced `intersection=0` even when the prediction was accurate. The first real `pm.triage_quality_score` event from the v0.1.59 soak (BEC-218: predicted=5, actual=4, intersection=0) surfaced this. `parseTriageV2Extensions` (`pm/types.ts`) now strips leading `-`/`*`/`+`/`N.`/`N)` bullets and surrounding backticks from each entry before Zod validation, dropping entries that normalize to empty. `parseAffectedFilesFromDescription` (`pm/triage-prediction-quality.ts`) applies the same normalization as defense-in-depth so descriptions on disk from pre-fix runs still parse cleanly.
+
 ## [0.1.59] — 2026-05-14
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.45
-ARG URATEAM_CLI_VERSION=0.1.47
-ARG URATEAM_DASHBOARD_VERSION=0.1.45
+ARG URATEAM_CORE_VERSION=0.1.46
+ARG URATEAM_CLI_VERSION=0.1.48
+ARG URATEAM_DASHBOARD_VERSION=0.1.46
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.45
-        URATEAM_CLI_VERSION: 0.1.47
-        URATEAM_DASHBOARD_VERSION: 0.1.45
+        URATEAM_CORE_VERSION: 0.1.46
+        URATEAM_CLI_VERSION: 0.1.48
+        URATEAM_DASHBOARD_VERSION: 0.1.46
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.