### PR TITLE
chore(release): v0.1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ Bumps:
 - `@urateam/dashboard`: 0.1.46 → 0.1.47
 - `create-urateam`: 0.1.49 → 0.1.50
 
-<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
+### Fixed
+- **Tier 6e triage prediction now reads from DB instead of description text** (#322): triage v2 appends `**Affected Files:**` (and other v2 sections) to the END of the Linear description, but `mapIssueToSchema` truncates descriptions at 4000 chars before they reach the runner. For any realistic issue the v2 section was getting sliced off and `pm.triage_quality_score` events reported `hasV2Prediction: false` every time (confirmed in the v0.1.60 soak: BEC-218 / BEC-219 / BEC-221 all produced 0-intersection events). The fix introduces a new `triage_results` table; triage v2 calls `upsertTriageResult` to persist the v2 prediction at classification time, and the runner Tier 6e hook calls `getTriageResult` to read it. `parseAffectedFilesFromDescription` is removed (3 days old, no external callers). DB-backed path is now the single source of truth; the description appender remains for human readability only.
+
 ## [0.1.60] — 2026-05-14
 
 Bumps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.61] — 2026-05-17
+
+Bumps:
+- `@urateam/core`: 0.1.46 → 0.1.47
+- `@urateam/cli`: 0.1.48 → 0.1.49
+- `@urateam/dashboard`: 0.1.46 → 0.1.47
+- `create-urateam`: 0.1.49 → 0.1.50
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.60] — 2026-05-14
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.46
-ARG URATEAM_CLI_VERSION=0.1.48
-ARG URATEAM_DASHBOARD_VERSION=0.1.46
+ARG URATEAM_CORE_VERSION=0.1.47
+ARG URATEAM_CLI_VERSION=0.1.49
+ARG URATEAM_DASHBOARD_VERSION=0.1.47
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.46
-        URATEAM_CLI_VERSION: 0.1.48
-        URATEAM_DASHBOARD_VERSION: 0.1.46
+        URATEAM_CORE_VERSION: 0.1.47
+        URATEAM_CLI_VERSION: 0.1.49
+        URATEAM_DASHBOARD_VERSION: 0.1.47
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.