### PR TITLE
chore(release): v0.1.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.63] — 2026-05-18
+
+Bumps:
+- `@urateam/core`: 0.1.48 → 0.1.49
+- `@urateam/cli`: 0.1.50 → 0.1.51
+- `@urateam/dashboard`: 0.1.48 → 0.1.49
+- `create-urateam`: 0.1.51 → 0.1.52
+
+### Fixed
+- **Slack PM digest no longer fails with `invalid_blocks`** (#327, BEC-225): the BEC-223 Circuit-Broken Issues section, when populated with ~10 issues × ~300 chars each (URL + 80-char title + 200-char error + timestamp), pushed the digest's single mrkdwn `section` block past Slack's 3000-char `text.text` limit. `postDigest` now uses the new `chunkLinesToSlackSectionBlocks(lines, maxChars=2900)` helper to emit one or more section blocks, each under the cap. Single lines longer than the cap pass through as-is — callers already truncate values via `truncateWithEllipsis`. Discovered during v0.1.62 production deploy on the dogfood instance.
 ## [0.1.62] — 2026-05-18
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.48
-ARG URATEAM_CLI_VERSION=0.1.50
-ARG URATEAM_DASHBOARD_VERSION=0.1.48
+ARG URATEAM_CORE_VERSION=0.1.49
+ARG URATEAM_CLI_VERSION=0.1.51
+ARG URATEAM_DASHBOARD_VERSION=0.1.49
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.48
-        URATEAM_CLI_VERSION: 0.1.50
-        URATEAM_DASHBOARD_VERSION: 0.1.48
+        URATEAM_CORE_VERSION: 0.1.49
+        URATEAM_CLI_VERSION: 0.1.51
+        URATEAM_DASHBOARD_VERSION: 0.1.49
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
Patch release containing the hotfix for the v0.1.62 production Slack `invalid_blocks` regression:
- #327 (BEC-225) Chunk Slack PM digest into multiple section blocks (≤2900 chars each)

## Test plan
- [x] Unit + regression tests green on #327
- [ ] Publish workflow green
- [ ] After deploy: next PM tick on dogfood instance posts digest successfully (no `invalid_blocks`)