### PR TITLE
fix(dashboard): retry handler crashed for non-resumable runs (BEC-226)

### DIFF
--- a/packages/dashboard/src/__tests__/retry-route.test.ts
+++ b/packages/dashboard/src/__tests__/retry-route.test.ts
@@ -95,7 +95,7 @@ describe("POST /runs/:id/retry", () => {
       expect(retry).toBeDefined();
     });
 
-    it("operator retrying a failed run with no resumePayload → runner.start called with parentRunId", async () => {
+    it("operator retrying a failed run with no resumePayload → 422 (BEC-226: cannot reconstruct Linear/repo/pipeline context from a bare DB row)", async () => {
       // run_1 has no resumePayload (default fixture in beforeEach)
       const runner = {
         resume: vi.fn(),
@@ -103,15 +103,10 @@ describe("POST /runs/:id/retry", () => {
       };
       const app = appWith("operator", runner);
       const res = await app.request("/runs/run_1/retry", { method: "POST" });
-      expect(res.status).toBe(302);
-      expect(runner.start).toHaveBeenCalledWith(
-        expect.objectContaining({
-          issueId: "BEC-42",
-          issueTitle: "fix bug",
-          repoUrl: "https://github.com/acme/api",
-          parentRunId: "run_1",
-        }),
-      );
+      expect(res.status).toBe(422);
+      const body = await res.text();
+      expect(body).toContain("no resumePayload");
+      expect(runner.start).not.toHaveBeenCalled();
       expect(runner.resume).not.toHaveBeenCalled();
     });
 

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -33,6 +33,17 @@ function isRetryableStatus(status: string): boolean {
   return status === "failed" || status === "retriable";
 }
 
+/**
+ * Thrown by `retryRun` when a run is in a retryable status but lacks the
+ * `resumePayload` needed to actually resume. Handler maps to HTTP 422.
+ */
+class RetryNotSupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RetryNotSupportedError";
+  }
+}
+
 export interface RunsRouterDeps {
   db: Db;
   runner?: {
@@ -100,20 +111,20 @@ export function createRunsRouter(
   }
 
   /**
-   * Resume or start a pipeline run (the "retry" logic shared between the
-   * dashboard and CLI retry handlers).
+   * Resume a pipeline run from its `resumePayload`. Throws `RetryNotSupportedError`
+   * if the run lacks one — `runner.start()` requires the full Linear/repo/pipeline
+   * context that isn't reconstructible from a bare DB row (BEC-226). Operators
+   * needing to re-run a failed-without-resume issue should re-open it in Linear.
    */
   async function retryRun(id: string, run: any): Promise<void> {
-    if (run.resumePayload) {
-      await runner!.resume(id);
-    } else {
-      await runner!.start({
-        issueId: run.issueId,
-        issueTitle: run.issueTitle,
-        repoUrl: run.repoUrl,
-        parentRunId: id,
-      });
+    if (!run.resumePayload) {
+      throw new RetryNotSupportedError(
+        "Cannot retry: run has no resumePayload. The original Linear/repo/pipeline " +
+          "context is not reconstructible from a bare run row. Re-open the issue in " +
+          "Linear or trigger a fresh pipeline run from the webhook.",
+      );
     }
+    await runner!.resume(id);
   }
 
   /**
@@ -264,6 +275,9 @@ export function createRunsRouter(
       try {
         await retryRun(id, run);
       } catch (err) {
+        if (err instanceof RetryNotSupportedError) {
+          return c.text(err.message, 422);
+        }
         return c.text(`Retry failed: ${(err as Error).message}`, 500);
       }
 
@@ -446,6 +460,9 @@ export function createRunsRouter(
     try {
       await retryRun(id, run);
     } catch (err) {
+      if (err instanceof RetryNotSupportedError) {
+        return c.json({ error: err.message }, 422);
+      }
       return c.text(`Retry failed: ${(err as Error).message}`, 500);
     }
     const actor = cliActor(c);


### PR DESCRIPTION
## Summary
`ura retry` (BEC-221) and the dashboard retry button were both crashing with HTTP 500 (`Cannot read properties of undefined (reading 'url')`) for any failed run without a `resumePayload`. Root cause: `retryRun` called `runner.start(opts)` with a single object, but `PipelineRunner.start()` takes 6 positional args — `repoConfig` ended up undefined, then `checkDuplicateBranch(repoConfig.url, …)` exploded.

Quick fix: error out cleanly when there's no resumePayload (HTTP 422). Properly reconstructing positional args (re-fetch Linear issue, resolve pipeline label, load repo config, re-sanitize) is follow-up work.

## Test plan
- [x] `retry-route.test.ts` updated (was permissively mocking `runner.start` shape; now asserts 422 + neither runner method called)
- [x] CLI `retry.test.ts` still passes (it already surfaces non-OK responses as `HTTP {code}: …`)
- [x] `pnpm -w typecheck` green
- [ ] After merge: cut v0.1.64, redeploy, retest `ura retry <runId>` against real BEC-192 → expect clean 422 message