### PR TITLE
chore(release): v0.1.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.64] — 2026-05-18
+
+Bumps:
+- `@urateam/core`: 0.1.49 → 0.1.50
+- `@urateam/cli`: 0.1.51 → 0.1.52
+- `@urateam/dashboard`: 0.1.49 → 0.1.50
+- `create-urateam`: 0.1.52 → 0.1.53
+
+### Fixed
+- **Retry handler crashed for non-resumable runs** (#329, BEC-226): both the dashboard retry button and the new `ura retry` CLI (BEC-221) crashed with HTTP 500 (`Cannot read properties of undefined (reading 'url')`) for any failed run without a `resumePayload`. `retryRun` called `runner.start(opts)` with a single bag-of-strings object, but `PipelineRunner.start()` takes 6 positional args — `repoConfig` ended up undefined, then `checkDuplicateBranch(repoConfig.url, ...)` exploded. The retry-route test mocked `runner.start` permissively (accepted any shape), so the divergence didn't surface in CI — only when called against the real implementation. Fix scope: error out cleanly with HTTP 422 when `resumePayload` is null; the resume path (with payload) is unchanged. Properly reconstructing positional args is follow-up work. Discovered when verifying the v0.1.63 deploy.
 ## [0.1.63] — 2026-05-18
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /app
 RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.49
-ARG URATEAM_CLI_VERSION=0.1.51
-ARG URATEAM_DASHBOARD_VERSION=0.1.49
+ARG URATEAM_CORE_VERSION=0.1.50
+ARG URATEAM_CLI_VERSION=0.1.52
+ARG URATEAM_DASHBOARD_VERSION=0.1.50
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.49
-        URATEAM_CLI_VERSION: 0.1.51
-        URATEAM_DASHBOARD_VERSION: 0.1.49
+        URATEAM_CORE_VERSION: 0.1.50
+        URATEAM_CLI_VERSION: 0.1.52
+        URATEAM_DASHBOARD_VERSION: 0.1.50
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
Patch release containing the hotfix for the BEC-221 retry handler bug discovered while verifying v0.1.63 deploy:
- #329 (BEC-226) Retry handler crashed for non-resumable runs — now returns HTTP 422

## Test plan
- [x] retry-route + cli retry tests green on #329
- [x] Typecheck green
- [ ] Publish workflow green
- [ ] After deploy: `ura retry <runId>` returns clean 422 message (not 500)