### PR TITLE
fix(BEC-228): pre-create agent sessions volume mount as ura-owned

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,21 @@ RUN git config --global user.name  "Urateam Agent" \
  && git config --global --replace-all "credential.https://gist.github.com.helper" "" \
  && git config --global --add         "credential.https://gist.github.com.helper" '!/usr/bin/gh auth git-credential'
 
+# BEC-228 — pre-create the agent-sessions volume mount point owned by ura so
+# Docker's first-mount behavior preserves ura ownership. Without this, a fresh
+# named volume mounts as root-owned and the SDK (running as ura) cannot write
+# JSONL transcripts, silently breaking BEC-227 session resume.
+RUN mkdir -p /home/ura/.claude/projects
+
 # Persistent volumes:
 # - /home/ura/data: SQLite database
 # - /home/ura/work: cloned repos + worktrees (PM agent clones REPO_URL here)
 # - /home/ura/.claude: OAuth credentials so executor's auth-check passes without
 #   ANTHROPIC_API_KEY (`docker compose exec urateam-dogfood claude login` once)
+# - /home/ura/.claude/projects: BEC-227 session transcripts (Phase 1 — must be
+#   pre-created above so the named volume initializes ura-owned)
 # - /home/ura/.config: gh CLI auth (`gh auth login --with-token` once)
-VOLUME ["/home/ura/data", "/home/ura/work", "/home/ura/.claude", "/home/ura/.config"]
+VOLUME ["/home/ura/data", "/home/ura/work", "/home/ura/.claude", "/home/ura/.claude/projects", "/home/ura/.config"]
 EXPOSE 3001
 
 # `ura start` runs the full daemon: webhook + dashboard + PM agent + Release


### PR DESCRIPTION
Follow-up to BEC-227 #339. Without this fix, fresh deployments of the agent-sessions named volume mount as root-owned and the SDK (running as `ura`) can't write JSONL transcripts. The boot-time `system.session_volume_warning` check passes because it runs as root.

The active dogfood already has a manual chown applied; this PR fixes the issue for fresh deployments.

## Test plan
- [x] Dockerfile builds clean (verified via current dogfood build)
- [ ] After merge + release + redeploy, verify `/home/ura/.claude/projects` is ura-owned without manual intervention