### PR TITLE
fix(BEC-231): lazy session creation via transcriptExists() check

### DIFF
--- a/packages/core/src/__tests__/execute-stage-session-opts.test.ts
+++ b/packages/core/src/__tests__/execute-stage-session-opts.test.ts
@@ -44,17 +44,21 @@ vi.mock("../executor/extract-handoff.js", () => ({
   }),
 }));
 
-// BEC-227 Task 7: the resume branch now checks JSONL existence on disk before
-// setting `resume`. These tests fixture a `/tmp/bec227-workdir` cwd that does
-// not actually have a transcript, so we force the existence check to return
-// true to keep the resume call shape exercised here.
+// BEC-227 Task 7 / BEC-231 update: under BEC-231 the executor derives the
+// session shape from `transcriptExists()` on every stage entry, not from an
+// in-memory `isFirstResumableStage` flag. Mock the helper so each test below
+// can set the return value to exercise either the "first/create" path
+// (false → `sessionId:`) or the "resume" path (true → `resume:`).
+const { transcriptExistsMock } = vi.hoisted(() => ({
+  transcriptExistsMock: vi.fn().mockReturnValue(true),
+}));
 vi.mock("../executor/session-store.js", async () => {
   const real = await vi.importActual<typeof import("../executor/session-store.js")>(
     "../executor/session-store.js",
   );
   return {
     ...real,
-    transcriptExists: vi.fn().mockReturnValue(true),
+    transcriptExists: transcriptExistsMock,
   };
 });
 
@@ -117,9 +121,12 @@ describe("executeStage — agent session options (BEC-227, Task 6)", () => {
     vi.clearAllMocks();
   });
 
-  it("first resumable stage: passes options.sessionId, NOT options.resume", async () => {
+  it("first resumable stage (JSONL absent): passes options.sessionId, NOT options.resume", async () => {
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
     (query as any).mockReturnValue(makeMinimalStream());
+    // BEC-231: "first resumable stage" semantically means "JSONL doesn't
+    // exist yet" — the create path. Force the existence check to false.
+    transcriptExistsMock.mockReturnValue(false);
 
     await seedPipelineRun(db, "run-first-resumable");
 
@@ -132,7 +139,7 @@ describe("executeStage — agent session options (BEC-227, Task 6)", () => {
       workdir: "/tmp/bec227-workdir",
       db,
       agentSessionId: "uuid-1",
-      isFirstResumableStage: true,
+      isFirstResumableStage: true, // BEC-231: ignored; transcriptExists drives the shape
     });
 
     expect(query).toHaveBeenCalledOnce();
@@ -147,9 +154,11 @@ describe("executeStage — agent session options (BEC-227, Task 6)", () => {
     });
   });
 
-  it("non-first resumable stage: passes options.resume, NOT options.sessionId", async () => {
+  it("non-first resumable stage (JSONL present): passes options.resume, NOT options.sessionId", async () => {
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
     (query as any).mockReturnValue(makeMinimalStream());
+    // BEC-231: JSONL is present on disk → resume path
+    transcriptExistsMock.mockReturnValue(true);
 
     await seedPipelineRun(db, "run-non-first-resumable");
 

--- a/packages/core/src/__tests__/session-lazy-creation.test.ts
+++ b/packages/core/src/__tests__/session-lazy-creation.test.ts
@@ -1,0 +1,172 @@
+/**
+ * BEC-231 — Lazy / retry SDK session creation.
+ *
+ * Reproduces the production bug surfaced during the BEC-227 Phase 2 dogfood
+ * soak: when the first resumable stage's SDK call fails before any JSONL
+ * message is written (auth 401, pre-stream stall, etc.), subsequent stages
+ * MUST retry the create path (`sessionId:`) rather than blindly using
+ * `resume:` against a transcript that never materialized.
+ *
+ * The pre-BEC-231 implementation used an in-memory `hasInitiatedSession` flag
+ * (flipped after the first resumable stage's CALL, not after the SDK actually
+ * wrote a message). The new implementation derives the shape from
+ * `transcriptExists()` on every stage entry, so a stage 2 invocation against
+ * a non-existent JSONL re-attempts creation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Module mocks (declared before imports) ────────────────────────────────────
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../executor/auth-check.js", () => ({
+  isClaudeAuthValid: vi.fn().mockResolvedValue(true),
+  resolveClaudeAuth: vi.fn().mockReturnValue({ method: "session" }),
+}));
+
+vi.mock("../executor/extract-handoff.js", () => ({
+  extractHandoff: vi.fn().mockResolvedValue({
+    artifact: {
+      runId: "run-bec231",
+      issueId: "BEC-231",
+      stage: "implement",
+      timestamp: new Date().toISOString(),
+      summary: "Stub handoff",
+      filesChanged: [],
+      approach: "Stub",
+      context: { issueIntent: "x", constraints: [], assumptions: [] },
+      tokenBudget: { contextTokensUsed: 0, recommendedMaxTurns: 1 },
+    },
+    structured: true,
+  }),
+}));
+
+const { transcriptExistsMock } = vi.hoisted(() => ({
+  transcriptExistsMock: vi.fn(),
+}));
+vi.mock("../executor/session-store.js", async () => {
+  const real = await vi.importActual<typeof import("../executor/session-store.js")>(
+    "../executor/session-store.js",
+  );
+  return {
+    ...real,
+    transcriptExists: transcriptExistsMock,
+  };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { executeStage } from "../executor/executor.js";
+import { createDb, type Db } from "../db/client.js";
+import { pipelineRuns } from "../db/schema.js";
+import type { SanitizedIssue, RepoConfig } from "../types.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const testIssue: SanitizedIssue = {
+  id: "BEC-231",
+  slug: "lazy-session-creation",
+  title: "BEC-231 lazy session creation",
+  description: "Verify session shape is derived from on-disk state",
+  acceptanceCriteria: ["transcriptExists drives sessionId vs resume choice"],
+  labels: ["bug"],
+  priority: 2,
+};
+
+const testRepoConfig: RepoConfig = {
+  url: "https://github.com/test-org/test-repo",
+  defaultBranch: "main",
+  testCommand: "echo ok",
+  buildCommand: "echo ok",
+};
+
+async function seedPipelineRun(db: Db, runId: string): Promise<void> {
+  await (db as any).insert(pipelineRuns).values({
+    id: runId,
+    issueId: testIssue.id,
+    issueTitle: testIssue.title,
+    pipelineKey: "auto-implement",
+    repoUrl: testRepoConfig.url,
+    branch: `agent/${runId}`,
+    status: "running",
+  });
+}
+
+function makeMinimalStream() {
+  return (async function* () {
+    yield { type: "assistant", content: [{ type: "text", text: "done" }] };
+  })();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("BEC-231 — lazy session creation derives shape from transcriptExists()", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await createDb({ connectionString: ":memory:" });
+    vi.clearAllMocks();
+  });
+
+  it("isFirstResumableStage=false BUT transcript absent → retries create (sessionId:), not resume:", async () => {
+    // This is the exact bug pattern: a "second" stage gets called with
+    // isFirstResumableStage=false (because the runner's in-memory flag
+    // believed the first stage initiated the session) but the JSONL was
+    // never written (first stage failed at auth before any SDK message).
+    // Pre-BEC-231: routed to resume:, found JSONL missing, dropped to
+    // legacy fresh-session-no-opts, lost the session permanently.
+    // Post-BEC-231: routes to sessionId: → SDK creates the session now.
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    (query as any).mockReturnValue(makeMinimalStream());
+    transcriptExistsMock.mockReturnValue(false);
+
+    await seedPipelineRun(db, "run-bec231-stage2-recreate");
+
+    await executeStage({
+      runId: "run-bec231-stage2-recreate",
+      issueId: testIssue.id,
+      stage: "implement",
+      sanitizedIssue: testIssue,
+      repoConfig: testRepoConfig,
+      workdir: "/tmp/bec231-workdir",
+      db,
+      agentSessionId: "uuid-bec231",
+      isFirstResumableStage: false,
+    });
+
+    const opts = (query as any).mock.calls[0][0].options;
+    expect(opts.sessionId).toBe("uuid-bec231");
+    expect(opts.resume).toBeUndefined();
+  });
+
+  it("isFirstResumableStage=true AND transcript present → resumes (transcriptExists wins over the flag)", async () => {
+    // Symmetric case: the runner says "this is the first resumable stage"
+    // but the JSONL actually already exists (e.g. retriable resume after a
+    // restart that lost the in-memory flag). BEC-231 still routes to
+    // resume: because the transcript is on disk.
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    (query as any).mockReturnValue(makeMinimalStream());
+    transcriptExistsMock.mockReturnValue(true);
+
+    await seedPipelineRun(db, "run-bec231-restarted");
+
+    await executeStage({
+      runId: "run-bec231-restarted",
+      issueId: testIssue.id,
+      stage: "implement",
+      sanitizedIssue: testIssue,
+      repoConfig: testRepoConfig,
+      workdir: "/tmp/bec231-workdir",
+      db,
+      agentSessionId: "uuid-bec231-existing",
+      isFirstResumableStage: true,
+    });
+
+    const opts = (query as any).mock.calls[0][0].options;
+    expect(opts.resume).toBe("uuid-bec231-existing");
+    expect(opts.sessionId).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/session-resume-fallback.test.ts
+++ b/packages/core/src/__tests__/session-resume-fallback.test.ts
@@ -1,18 +1,22 @@
 /**
- * Tests for BEC-227 — Task 7:
- * JSONL-exists pre-check on the resume path of `executeStage()`.
+ * Tests for BEC-227 Task 7, AS UPDATED BY BEC-231 (lazy session creation).
  *
- * Scenario covered:
- *  - When `agentSessionId` is set and `isFirstResumableStage=false` BUT the
- *    SDK transcript JSONL file does NOT exist on disk for the (cwd, sessionId)
- *    tuple, the executor must:
- *      1. Drop the resume option (call shape is fresh: no `sessionId`, no `resume`)
- *      2. Emit the `pipeline.agent_session_missing_fallback` audit event with
- *         `reason: "jsonl-not-found"`
- *      3. Log a warning
+ * Original BEC-227 design (T7): when `isFirstResumableStage=false` AND the
+ * JSONL is missing, drop to fresh-session shape (no opts) + emit
+ * `missing_fallback` audit event. The bug: the in-memory `hasInitiatedSession`
+ * flag flipped after the first stage's CALL, not after the SDK actually wrote
+ * the JSONL. If the first stage failed (auth 401, etc.) before writing, every
+ * later stage thought "session initiated; use resume:" but the JSONL didn't
+ * exist, so they all dropped to fresh-session-with-no-opts — losing the
+ * session permanently for the run's lifetime.
  *
- * The SDK `query` and `logAuditEvent` are mocked, and `transcriptExists` is
- * forced to return `false` so this test does not depend on the host filesystem.
+ * BEC-231 fix: derive the shape from on-disk state, not from the in-memory
+ * flag. JSONL present → `resume:`. JSONL absent → `sessionId:` (retries
+ * creation). The `missing_fallback` audit event is no longer emitted from
+ * the executor — the new logic always picks the right shape.
+ *
+ * This test now verifies the new behavior: missing JSONL → SDK call shape
+ * is `{ sessionId: <uuid> }` (the create/retry path), NOT empty opts.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -118,7 +122,7 @@ function makeMinimalStream() {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe("executeStage — session resume fallback (BEC-227, Task 7)", () => {
+describe("executeStage — lazy session creation when JSONL absent (BEC-231 update of BEC-227 T7)", () => {
   let db: Db;
 
   beforeEach(async () => {
@@ -128,38 +132,45 @@ describe("executeStage — session resume fallback (BEC-227, Task 7)", () => {
     logAuditEventMock.mockResolvedValue(undefined);
   });
 
-  it("transcript missing → falls back to fresh session and emits missing_fallback audit event", async () => {
+  it("transcript missing → retries session creation (sessionId set), does NOT emit missing_fallback (BEC-231)", async () => {
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
     (query as any).mockReturnValue(makeMinimalStream());
 
-    await seedPipelineRun(db, "run-fallback-t7");
+    await seedPipelineRun(db, "run-bec231-retry-create");
 
+    // Even though the caller passes isFirstResumableStage=false (the old
+    // pre-BEC-231 callers do this for non-first stages), the new logic checks
+    // transcriptExists() and routes to sessionId: when it returns false.
     await executeStage({
-      runId: "run-fallback-t7",
+      runId: "run-bec231-retry-create",
       issueId: testIssue.id,
       stage: "implement",
       sanitizedIssue: testIssue,
       repoConfig: testRepoConfig,
-      workdir: "/nonexistent/path/bec227-t7",
+      workdir: "/nonexistent/path/bec231",
       db,
-      agentSessionId: "uuid-nonexistent",
-      isFirstResumableStage: false,
+      agentSessionId: "uuid-bec231-recreate",
+      isFirstResumableStage: false, // ← ignored under BEC-231
     });
 
-    // SDK call shape: no resume, no sessionId (fresh)
     expect(query).toHaveBeenCalledOnce();
     const opts = (query as any).mock.calls[0][0].options;
+    // BEC-231: when JSONL is absent, we (re-)create with sessionId: rather
+    // than dropping to legacy fresh-session shape.
+    expect(opts.sessionId).toBe("uuid-bec231-recreate");
     expect(opts.resume).toBeUndefined();
-    expect(opts.sessionId).toBeUndefined();
 
-    // Audit event emitted with jsonl-not-found reason
+    // BEC-231: missing_fallback audit event is no longer emitted from the
+    // executor — the new logic always picks the right shape.
     const fallbackCall = logAuditEventMock.mock.calls.find(
       (call: any[]) => call[1]?.eventType === "pipeline.agent_session_missing_fallback",
     );
-    expect(fallbackCall).toBeDefined();
-    expect(fallbackCall![1].payload.reason).toBe("jsonl-not-found");
-    expect(fallbackCall![1].payload.sessionId).toBe("uuid-nonexistent");
-    expect(fallbackCall![1].payload.runId).toBe("run-fallback-t7");
-    expect(fallbackCall![1].payload.issueId).toBe(testIssue.id);
+    expect(fallbackCall).toBeUndefined();
+
+    // resumed event is also not emitted (we're creating, not resuming).
+    const resumedCall = logAuditEventMock.mock.calls.find(
+      (call: any[]) => call[1]?.eventType === "pipeline.agent_session_resumed",
+    );
+    expect(resumedCall).toBeUndefined();
   });
 });

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -24,10 +24,13 @@ import { consumeAgentStream, StagePreStreamStalledError, type StreamMessage } fr
 import { isClaudeAuthValid, resolveClaudeAuth } from "./auth-check.js";
 import { isResumable } from "./session-policy.js";
 import { transcriptExists, defaultProjectsRoot } from "./session-store.js";
-import {
-  agentSessionMissingFallbackEvent,
-  agentSessionResumedEvent,
-} from "../audit/index.js";
+// BEC-231 — `agentSessionMissingFallbackEvent` was previously fired from this
+// module when the resume branch found the JSONL absent. The new logic always
+// picks the right shape (`sessionId:` to create, `resume:` to continue) based
+// on actual disk state, so the missing-fallback path is unreachable from here.
+// The event type itself is kept in `audit/events.ts` for callers (e.g. the
+// session-volume boot check) that may need it.
+import { agentSessionResumedEvent } from "../audit/index.js";
 import { logAuditEvent } from "../audit/writer.js";
 
 /**
@@ -244,82 +247,81 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
     // operator wiped `~/.claude/projects`), the SDK would throw on resume.
     // Drop to a fresh-session shape, emit a `missing_fallback` audit event,
     // and warn so operators can spot loss patterns.
+    // BEC-231 — derive session-shape from on-disk state, not from an in-memory
+    // flag. The previous implementation passed `isFirstResumableStage` (set by
+    // the runner via `hasInitiatedSession`) and used it to pick `sessionId:` vs.
+    // `resume:`. That flag flipped after the first resumable stage's CALL —
+    // before the SDK had actually written a single message to the JSONL. If the
+    // first stage failed (auth 401, MCP init error, pre-stream stall) before
+    // the SDK got that far, every subsequent stage saw "session initiated; use
+    // resume:" and fell back when the JSONL didn't exist. The session was lost
+    // for the run's lifetime.
+    //
+    // Fix: ignore `isFirstResumableStage`. Check `transcriptExists()` on every
+    // stage. JSONL present → `resume:`. JSONL absent → `sessionId:` (which
+    // re-attempts creation; the SDK pre-assigns the UUID and writes a fresh
+    // transcript if there's nothing on disk).
+    //
+    // The `isFirstResumableStage` field is retained on `ExecuteStageContext`
+    // for backwards compatibility with callers that still pass it; the value
+    // is now ignored. Runner cleanup is in the companion runner.ts edit.
     const resolvedModel = context.stageModels?.[stage] ?? effectiveProfile.model;
     const agentSessionId = context.agentSessionId ?? null;
-    const isFirstResumableStage = context.isFirstResumableStage ?? false;
     const wantsResume =
       agentSessionId !== null &&
       !!resolvedModel &&
       isResumable(stage, resolvedModel);
     let sessionOpts: { sessionId?: string; resume?: string } = {};
     if (wantsResume) {
-      if (isFirstResumableStage) {
-        sessionOpts = { sessionId: agentSessionId! };
-      } else {
-        const exists = transcriptExists({
-          projectsRoot: defaultProjectsRoot(),
-          cwd: workdir,
-          sessionId: agentSessionId!,
-        });
-        if (exists) {
-          sessionOpts = { resume: agentSessionId! };
-          // BEC-227 — emit resumed audit event with prior message count.
-          // Read transcript line count directly from the JSONL (the SDK's
-          // `getSessionMessages` is awaitable async; we want a synchronous
-          // best-effort count here so the event isn't blocked on an extra
-          // round-trip).
-          try {
-            const { readFileSync } = await import("node:fs");
-            const tp = (await import("./session-store.js")).transcriptPath({
-              projectsRoot: defaultProjectsRoot(),
-              cwd: workdir,
-              sessionId: agentSessionId!,
-            });
-            const priorMessageCount = readFileSync(tp, "utf8")
-              .split("\n")
-              .filter((line) => line.trim().length > 0).length;
-            void logAuditEvent(
-              db,
-              agentSessionResumedEvent({
-                runId,
-                issueId,
-                sessionId: agentSessionId!,
-                stage,
-                priorMessageCount,
-              }),
-            );
-          } catch (err) {
-            log.warn(
-              { err: (err as Error).message },
-              "failed to count prior session messages — emitting resumed event with count=0",
-            );
-            void logAuditEvent(
-              db,
-              agentSessionResumedEvent({
-                runId,
-                issueId,
-                sessionId: agentSessionId!,
-                stage,
-                priorMessageCount: 0,
-              }),
-            );
-          }
-        } else {
+      const exists = transcriptExists({
+        projectsRoot: defaultProjectsRoot(),
+        cwd: workdir,
+        sessionId: agentSessionId!,
+      });
+      if (exists) {
+        // Transcript present — resume the conversation.
+        sessionOpts = { resume: agentSessionId! };
+        try {
+          const { readFileSync } = await import("node:fs");
+          const tp = (await import("./session-store.js")).transcriptPath({
+            projectsRoot: defaultProjectsRoot(),
+            cwd: workdir,
+            sessionId: agentSessionId!,
+          });
+          const priorMessageCount = readFileSync(tp, "utf8")
+            .split("\n")
+            .filter((line) => line.trim().length > 0).length;
           void logAuditEvent(
             db,
-            agentSessionMissingFallbackEvent({
+            agentSessionResumedEvent({
               runId,
               issueId,
               sessionId: agentSessionId!,
-              reason: "jsonl-not-found",
+              stage,
+              priorMessageCount,
             }),
           );
+        } catch (err) {
           log.warn(
-            { runId, sessionId: agentSessionId, stage, cwd: workdir },
-            "agent session JSONL missing — falling back to fresh session",
+            { err: (err as Error).message },
+            "failed to count prior session messages — emitting resumed event with count=0",
           );
-          sessionOpts = {};
+          void logAuditEvent(
+            db,
+            agentSessionResumedEvent({
+              runId,
+              issueId,
+              sessionId: agentSessionId!,
+              stage,
+              priorMessageCount: 0,
+            }),
+          );
         }
+      } else {
+        // Transcript absent — (re-)create the session. The SDK pre-assigns
+        // our UUID; if a prior call started but failed before writing, this
+        // call gets a fresh shot at writing the first message.
+        sessionOpts = { sessionId: agentSessionId! };
       }
     }
 


### PR DESCRIPTION
## Summary

Production bug discovered during BEC-227 Phase 2 dogfood soak. Filed as [BEC-231](https://linear.app/beckerspace/issue/BEC-231). Fixed in this session rather than letting the agent pipeline self-host the fix (which is sketchy when the bug is in the session-resume code path itself).

### Root cause

`packages/core/src/pipeline/runner.ts:executePipeline()` tracked "have we initiated the SDK session yet?" in an in-memory `hasInitiatedSession` flag. The flag flipped to `true` on the FIRST resumable stage's CALL, regardless of whether that stage's SDK invocation actually wrote anything to the JSONL transcript.

When stage 1 failed before any SDK message (the auth 401 we hit on BEC-228 today, MCP init failure, pre-stream stall), the JSONL transcript was never written. Every subsequent stage saw "session initiated; use `resume:`" but the JSONL didn't exist, so the executor dropped to legacy fresh-session-with-no-opts. The session was lost permanently for the run's lifetime.

Observed pattern on BEC-228 today: **1** `agent_session_created`, **8** `agent_session_missing_fallback`, **0** `agent_session_resumed`. The run completed via legacy handoff — no regression from pre-BEC-227 behavior, but zero session-resume benefit delivered.

### Fix

`executeStage()` now derives the session shape from `transcriptExists()` on every entry, not from `isFirstResumableStage`:

- JSONL present → `query({ resume: sessionId })`, emit `agent_session_resumed`
- JSONL absent → `query({ sessionId })` (creates or retries creation)

The `isFirstResumableStage` field stays on `ExecuteStageContext` for runner-side backward compat — its value is now ignored. The `missing_fallback` audit event is no longer emitted from the executor; the new logic always picks the right shape.

### Tests

- **New `session-lazy-creation.test.ts`** (the bug reproducer + reverse case):
  - `isFirstResumableStage: false` but JSONL absent → `sessionId:` (retry create)
  - `isFirstResumableStage: true` but JSONL present → `resume:` (continue)
- **Updated `session-resume-fallback.test.ts`** to reflect new behavior: missing JSONL → `sessionId:` (not empty opts), no missing_fallback event fired
- **Updated `execute-stage-session-opts.test.ts`**: mock `transcriptExists` per-test via `vi.hoisted()` instead of a single global true-mock
- Full `pnpm -w typecheck` green
- Background full core suite running; will update PR if anything else needs adjusting

### Out of scope (deferred per BEC-231's anti-ACs)

- DB column for "session-truly-initiated" — `transcriptExists()` is sufficient and simpler
- 3-retry give-up + `agent_session_giveup` event — each stage now independently picks correct shape; deep failures show up as ordinary stage failures
- `agent_session_initialized` event distinguishing "minted but lost" from "actually working" — derivable from existing `agent_session_resumed` count (>0 = actually working)

Linear ticket: https://linear.app/beckerspace/issue/BEC-231