### PR TITLE
fix(BEC-232): encodeCwd preserves leading dash to match SDK path encoding

### DIFF
--- a/packages/core/src/__tests__/session-store.test.ts
+++ b/packages/core/src/__tests__/session-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { transcriptPath, transcriptExists } from "../executor/session-store.js";
@@ -13,25 +13,28 @@ afterEach(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-describe("session-store (BEC-227)", () => {
-  it("transcriptPath builds the expected per-cwd / per-session path", () => {
+describe("session-store (BEC-227 + BEC-232)", () => {
+  it("transcriptPath builds the SDK's leading-dash encoding for absolute cwds (BEC-232)", () => {
     const p = transcriptPath({
       projectsRoot: tmpRoot,
       cwd: "/home/ura/data/runs/abc/worktree",
       sessionId: "uuid-1",
     });
-    // Per SDK convention: projectsRoot / <encoded-cwd> / <sessionId>.jsonl
-    expect(p).toMatch(/uuid-1\.jsonl$/);
-    expect(p).toContain(tmpRoot);
+    // BEC-232: leading "/" is replaced with "-", not stripped. Matches the
+    // SDK's actual on-disk path: <projectsRoot>/-home-ura-...-worktree/<id>.jsonl
+    expect(p).toBe(
+      join(tmpRoot, "-home-ura-data-runs-abc-worktree", "uuid-1.jsonl"),
+    );
   });
 
-  it("transcriptExists returns true when the JSONL file is present", () => {
-    const dir = join(tmpRoot, "encoded-cwd");
+  it("transcriptExists returns true when the JSONL file is at the SDK-encoded path", () => {
+    // Place the file where the SDK would actually write it (leading-dash dir).
+    const dir = join(tmpRoot, "-home-ura-data-runs-abc-worktree");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "uuid-1.jsonl"), '{"message":"hi"}\n');
     const exists = transcriptExists({
       projectsRoot: tmpRoot,
-      cwd: "/encoded-cwd",
+      cwd: "/home/ura/data/runs/abc/worktree",
       sessionId: "uuid-1",
     });
     expect(exists).toBe(true);
@@ -42,6 +45,21 @@ describe("session-store (BEC-227)", () => {
       projectsRoot: tmpRoot,
       cwd: "/nonexistent",
       sessionId: "uuid-missing",
+    });
+    expect(exists).toBe(false);
+  });
+
+  it("regression (BEC-232): the OLD no-leading-dash path is NOT what we look up", () => {
+    // If anyone places a JSONL at the pre-BEC-232 (incorrect) location,
+    // transcriptExists() should NOT find it — the fix is unconditional, not
+    // a fallback-to-old-path behavior.
+    const wrongDir = join(tmpRoot, "home-ura-data-runs-abc-worktree");
+    mkdirSync(wrongDir, { recursive: true });
+    writeFileSync(join(wrongDir, "uuid-1.jsonl"), '{"message":"hi"}\n');
+    const exists = transcriptExists({
+      projectsRoot: tmpRoot,
+      cwd: "/home/ura/data/runs/abc/worktree",
+      sessionId: "uuid-1",
     });
     expect(exists).toBe(false);
   });

--- a/packages/core/src/executor/session-store.ts
+++ b/packages/core/src/executor/session-store.ts
@@ -25,10 +25,22 @@ export function defaultProjectsRoot(env: NodeJS.ProcessEnv = process.env): strin
   return env.URATEAM_CLAUDE_PROJECTS_DIR ?? join(homedir(), ".claude", "projects");
 }
 
-/** Encode a cwd into the SDK's per-project directory name. */
-function encodeCwd(cwd: string): string {
-  // SDK convention: replace path separators with hyphens, prefix removed if leading slash.
-  return cwd.replace(/^\//, "").replace(/[\/\\]/g, "-");
+/**
+ * Encode a cwd into the SDK's per-project directory name.
+ *
+ * BEC-232 — match the SDK's encoding exactly. The SDK replaces ALL path
+ * separators (including a leading `/`) with `-`, producing a directory name
+ * like `"-home-ura-data-runs-<run>-worktree"` (note the LEADING dash).
+ *
+ * The pre-BEC-232 implementation stripped the leading `/` BEFORE replacing,
+ * producing `"home-..."` (no leading dash). The mismatch caused
+ * `transcriptExists()` to always return false for absolute cwds — every
+ * BEC-227 session-resume attempt fell back to legacy handoff because
+ * urateam looked for the JSONL at the wrong path. Verified on the dogfood
+ * instance against real SDK-written transcripts (BEC-231 soak observation).
+ */
+export function encodeCwd(cwd: string): string {
+  return cwd.replace(/[\/\\]/g, "-");
 }
 
 /** Build the JSONL transcript path for a given (cwd, sessionId). */


### PR DESCRIPTION
## Summary

One-line fix to `session-store.ts:encodeCwd()`. The previous implementation stripped the leading `/` before replacing path separators, producing `"home-..."` for an absolute cwd. The Claude Agent SDK replaces ALL separators including the leading `/`, producing `"-home-..."` (leading dash). Mismatch → `transcriptExists()` returned false for every BEC-227 session resume attempt, so the lazy-creation fix (BEC-231 / v0.1.66) was effectively moot.

Verified on the dogfood host during Phase 2 soak: JSONLs are written correctly by the SDK at `-home-ura-data-runs-<run>-worktree/<sessionId>.jsonl` (268KB transcript files present), but urateam was looking at the wrong path.

## Combined effect with BEC-231

- v0.1.66 (BEC-231): correct create-vs-resume decision based on `transcriptExists()`.
- v0.1.67 (this, BEC-232): `transcriptExists()` actually finds the transcripts the SDK writes.

Together they complete the BEC-227 session-resume wiring. Post-deploy observable: the next BEC-227 pipeline run on dogfood should produce ≥1 `pipeline.agent_session_resumed` audit event.

## Test plan

- [x] 23 session-related tests pass (`session-store`, `session-resume-fallback`, `execute-stage-session-opts`, `deep-review-resume`, `session-lazy-creation`, `session-policy`)
- [x] `pnpm -w typecheck` green
- [x] New regression test asserts the OLD no-leading-dash path is NOT looked up (no silent fallback)
- [ ] After deploy: `pipeline.agent_session_resumed` events fire for non-first resumable stages of new pipeline runs

Linear ticket: https://linear.app/beckerspace/issue/BEC-232