### PR TITLE
fix(BEC-234): install bash + set SHELL env in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,14 @@ WORKDIR /app
 # - sqlite: standalone sqlite3 CLI for runbook queries (e.g. docker exec urateam-dogfood sqlite3 ...)
 # - tini: PID 1 signal handling for clean shutdown
 # - python3, make, g++: better-sqlite3 native build fallback if no prebuild matches alpine-musl
-RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++
+# - bash: BEC-234 — Claude Agent SDK's Bash tool requires a POSIX shell; the
+#   alpine base ships only /bin/sh (busybox), and the SDK checks process.env.SHELL
+#   (not the filesystem) to decide whether a "suitable shell" is present.
+RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g++ bash
+
+# BEC-234 — set SHELL so the Claude Agent SDK's "no suitable shell" check passes.
+# Without this, every Bash tool call fails with "No suitable shell found ...".
+ENV SHELL=/bin/bash
 
 # Pinned versions — image is reproducible per build.
 ARG URATEAM_CORE_VERSION=0.1.54


### PR DESCRIPTION
Two-line Dockerfile fix discovered by auditing the BEC-231 JSONL transcript.

Root cause: dogfood container is Alpine-based (no /bin/bash) and SHELL env is unset. Claude Agent SDK's 'no suitable shell' check uses process.env.SHELL and refuses to run Bash tool calls when it's empty.

Effect: every Bash tool call across every pipeline run silently failed. The agent ran on Read/Edit/Grep only — couldn't run tests, builds, git inspection. Likely contributor to several historical 'max turns' failures.

Linear: https://linear.app/beckerspace/issue/BEC-234