### PR TITLE
fix(BEC-236): ura circuit reset cascade missed two FK-child tables

### DIFF
--- a/packages/cli/src/__tests__/circuit.test.ts
+++ b/packages/cli/src/__tests__/circuit.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { createDb, pipelineRuns, stageRuns, agentLogs, circuitBreakerState, type AnyDb } from "@urateam/core";
+import {
+  agentLogs,
+  circuitBreakerState,
+  createDb,
+  pipelineRunDecisions,
+  pipelineRuns,
+  reviewModelRuns,
+  stageRuns,
+  type AnyDb,
+} from "@urateam/core";
 import { runCircuitList, runCircuitReset, runCircuitResetAll } from "../commands/circuit.js";
 
 describe("ura circuit list", () => {
@@ -82,7 +91,11 @@ describe("ura circuit reset <issueId>", () => {
   });
 
   it("deletes the failed pipeline_runs cascade + state row, strips needs-design label", async () => {
-    // 3 failed runs, each with 1 stage_run, each with 1 agent_log
+    // 3 failed runs, each with 1 stage_run, each with 1 agent_log, 1
+    // review_model_run (child of stage_run), and 1 pipeline_run_decision
+    // (child of pipeline_run). Real dogfood data has all of these — the
+    // initial implementation missed the latter two and tripped a SQLite
+    // FOREIGN KEY constraint on `ura circuit reset` in production.
     for (let i = 0; i < 3; i++) {
       const runId = `BEC-1-r${i}`;
       const stageRunId = `BEC-1-r${i}-stage`;
@@ -109,6 +122,21 @@ describe("ura circuit reset <issueId>", () => {
         content: "test log",
         timestamp: new Date(1_000_000_000 + i * 1000),
       });
+      await db.insert(reviewModelRuns).values({
+        id: `${stageRunId}-rmr`,
+        stageRunId,
+        providerId: "openrouter",
+        modelId: "test",
+        status: "completed",
+      });
+      await db.insert(pipelineRunDecisions).values({
+        id: `${runId}-dec`,
+        pipelineRunId: runId,
+        iteration: 0,
+        stage: "implement",
+        payload: "{}",
+        createdAt: new Date(1_000_000_000 + i * 1000),
+      });
     }
     await db.insert(circuitBreakerState).values({
       issueId: "BEC-1",
@@ -131,6 +159,8 @@ describe("ura circuit reset <issueId>", () => {
     expect((await db.select().from(pipelineRuns)).length).toBe(0);
     expect((await db.select().from(stageRuns)).length).toBe(0);
     expect((await db.select().from(agentLogs)).length).toBe(0);
+    expect((await db.select().from(reviewModelRuns)).length).toBe(0);
+    expect((await db.select().from(pipelineRunDecisions)).length).toBe(0);
     expect((await db.select().from(circuitBreakerState)).length).toBe(0);
     expect(linearClient.updateIssue).toHaveBeenCalledOnce();
     const [, payload] = linearClient.updateIssue.mock.calls[0];

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -1,5 +1,5 @@
 export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, getCreateTablesDDL, getMigratePostgres, getMigrateSqlite, type Db, type AnyDb, type CreateDbOptions } from "./client.js";
-export { pipelineRuns, stageRuns, agentLogs, activeWork, webhookDedup, pmApprovals, circuitBreakerState } from "./schema.js";
+export { pipelineRuns, stageRuns, agentLogs, activeWork, webhookDedup, pmApprovals, circuitBreakerState, pipelineRunDecisions, reviewModelRuns } from "./schema.js";
 export {
   loadMigrationFiles,
   loadActiveMigrationFiles,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ export * from "./rbac/index.js";
 export { computeConfigFingerprint } from "./audit/config-fingerprint.js";
 export { rootLogger, createLogger, addLogStream } from "./logger.js";
 export { createDb, isPostgres, sqlDateGroup, sqlDaysAgoFilter, type Db, type AnyDb } from "./db/index.js";
-export { pipelineRuns, stageRuns, agentLogs, activeWork, pmApprovals, circuitBreakerState } from "./db/index.js";
+export { pipelineRuns, stageRuns, agentLogs, activeWork, pmApprovals, circuitBreakerState, pipelineRunDecisions, reviewModelRuns } from "./db/index.js";
 export { batchCountConsecutiveFailures, deleteFailedRunsForIssue } from "./pm/actions/db-queries.js";
 export { createApp, type ServerConfig } from "./server.js";
 export { PipelineRunner, type PipelineRunnerConfig, type LinearIssue } from "./pipeline/index.js";

--- a/packages/core/src/pm/actions/db-queries.ts
+++ b/packages/core/src/pm/actions/db-queries.ts
@@ -1,6 +1,13 @@
 import type { AnyDb } from "../../db/client.js";
 import type { CircuitBrokenIssue } from "../types.js";
-import { agentLogs, circuitBreakerState, pipelineRuns, stageRuns } from "../../db/schema.js";
+import {
+  agentLogs,
+  circuitBreakerState,
+  pipelineRunDecisions,
+  pipelineRuns,
+  reviewModelRuns,
+  stageRuns,
+} from "../../db/schema.js";
 import { and, desc, eq, gte, inArray, or, sql } from "drizzle-orm";
 import { isPostgres } from "../../db/client.js";
 
@@ -294,7 +301,10 @@ export async function fetchCircuitBrokenIssues(
  *
  * Inside a single transaction:
  *   1. Identify all `status = 'failed'` pipeline_runs for the issue.
- *   2. Cascade-delete: agent_logs → stage_runs → pipeline_runs (failed only).
+ *   2. Cascade-delete in FK-respecting order:
+ *      review_model_runs + agent_logs (children of stage_runs)
+ *      → stage_runs + pipeline_run_decisions (children of pipeline_runs)
+ *      → pipeline_runs (failed only).
  *   3. Delete the circuit_breaker_state row (if present).
  *
  * Returns `{ hadStateRow, failedRunIds }` so the CLI layer can decide
@@ -337,9 +347,15 @@ export async function deleteFailedRunsForIssue(
         .where(inArray(stageRuns.pipelineRunId, failedRunIds))) as Array<{ id: string }>;
       const stageRunIds = stageRunRows.map((r) => r.id);
       if (stageRunIds.length > 0) {
+        // Children of stage_runs (review_model_runs + agent_logs) must go first.
+        await handle.delete(reviewModelRuns).where(inArray(reviewModelRuns.stageRunId, stageRunIds));
         await handle.delete(agentLogs).where(inArray(agentLogs.stageRunId, stageRunIds));
         await handle.delete(stageRuns).where(inArray(stageRuns.id, stageRunIds));
       }
+      // pipeline_run_decisions is a child of pipeline_runs (BEC-227 Phase 4).
+      await handle
+        .delete(pipelineRunDecisions)
+        .where(inArray(pipelineRunDecisions.pipelineRunId, failedRunIds));
       await handle.delete(pipelineRuns).where(inArray(pipelineRuns.id, failedRunIds));
     }
     await handle.delete(circuitBreakerState).where(eq(circuitBreakerState.issueId, issueId));


### PR DESCRIPTION
## Summary

`ura circuit reset` (single-issue and `--all`) tripped `SQLITE_CONSTRAINT_FOREIGNKEY` on dogfood because the cascade-delete in `deleteFailedRunsForIssue` only knew about `agent_logs` and `stage_runs`. It missed:

- `pipeline_run_decisions` (BEC-227 Phase 4 — `pipeline_run_id` FK)
- `review_model_runs` (BEC-134 OpenRouter fanout — `stage_run_id` FK)

The `ura circuit reset --all --yes` run on dogfood cleared 13/22 issues and silently failed for the other 9 — the CLI only reports counts, not individual error messages, so the failure was invisible until the single-issue path surfaced the stack trace. The 9 issues that failed all had `pipeline_run_decisions` rows from Phase 4 work; the 13 that succeeded had none.

## Fix

Extended `deleteFailedRunsForIssue` to delete both tables in FK-respecting order:
1. `review_model_runs` + `agent_logs` (children of `stage_runs`)
2. `stage_runs` + `pipeline_run_decisions` (children of `pipeline_runs`)
3. `pipeline_runs`
4. `circuit_breaker_state`

Existing cascade test extended to seed both newly-included tables — would have caught this if the test fixtures had matched the real dogfood schema.

## Test plan

- [x] Unit test `ura circuit reset <id> > deletes the failed pipeline_runs cascade + state row` now seeds all 5 child tables and asserts all 5 empty after reset (9/9 pass)
- [x] `pnpm -w typecheck` clean
- [ ] After merge + deploy: re-run `ura circuit reset --all --yes` on dogfood; expect cleared count to match `ura circuit list` count, no FK errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)