### PR TITLE
chore(release): v0.1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ notes call out when a change affects only a single package.
 - **`ServerConfig` additions**: `bitbucket?: BitbucketConfig`, `gitlabWebhookToken?: string`, `bitbucketWebhookSecret?: string`. Both new handlers are mounted automatically when their respective config fields are set.
 - **Provider enum expanded**: `RepoConfig.provider` now accepts `"github" | "gitlab" | "bitbucket"`.
 
+## [0.1.85] — 2026-05-27
+
+Bumps:
+- `@urateam/core`: 0.1.70 → 0.1.71
+- `@urateam/cli`: 0.1.72 → 0.1.73
+- `@urateam/dashboard`: 0.1.70 → 0.1.71
+- `create-urateam`: 0.1.73 → 0.1.74
+
+<!-- TODO: replace with ### Added / ### Fixed / ### Chore sections describing this release. -->
 ## [0.1.84] — 2026-05-27
 
 Bumps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN apk add --no-cache git openssh-client github-cli sqlite tini python3 make g+
 ENV SHELL=/bin/bash
 
 # Pinned versions — image is reproducible per build.
-ARG URATEAM_CORE_VERSION=0.1.70
-ARG URATEAM_CLI_VERSION=0.1.72
-ARG URATEAM_DASHBOARD_VERSION=0.1.70
+ARG URATEAM_CORE_VERSION=0.1.71
+ARG URATEAM_CLI_VERSION=0.1.73
+ARG URATEAM_DASHBOARD_VERSION=0.1.71
 ARG CLAUDE_CODE_VERSION=2.1.128
 RUN npm install -g \
       @urateam/cli@${URATEAM_CLI_VERSION} \

--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        URATEAM_CORE_VERSION: 0.1.70
-        URATEAM_CLI_VERSION: 0.1.72
-        URATEAM_DASHBOARD_VERSION: 0.1.70
+        URATEAM_CORE_VERSION: 0.1.71
+        URATEAM_CLI_VERSION: 0.1.73
+        URATEAM_DASHBOARD_VERSION: 0.1.71
         CLAUDE_CODE_VERSION: 2.1.128
     container_name: urateam-dogfood
     restart: unless-stopped

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/cli",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/core",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/create-urateam/package.json
+++ b/packages/create-urateam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-urateam",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "license": "BUSL-1.1",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urateam/dashboard",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "license": "BUSL-1.1",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Automated bump via `pnpm cut-release patch`. Edit the CHANGELOG TODO before merging.