### PR TITLE
fix(bootstrap): add checks + statuses permissions to GitHub App manifest

### DIFF
--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -571,6 +571,10 @@ export async function createGitHubApp(
       pull_requests: "write",
       contents: "write",
       metadata: "read",
+      // Required by GitHub when default_events includes check_suite / check_run.
+      checks: "read",
+      // Required by GitHub when default_events includes status.
+      statuses: "read",
     },
     default_events: [
       "push",


### PR DESCRIPTION
## Summary
- GitHub rejects the manifest submission with: *"Default events are not supported by permissions: check_suite, check_run, and status"*
- Adds `checks: "read"` (required for `check_suite` + `check_run` events) and `statuses: "read"` (required for `status` event) to `default_permissions`
- One-line fix; no behavior change beyond unblocking the existing manifest POST flow (#425)

## Test plan
- [ ] Re-run `ura bootstrap` and observe the manifest form now POSTs successfully to GitHub instead of returning the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)