### PR TITLE
fix(bootstrap): thread --domain into GitHub App manifest webhook URL

### DIFF
--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -125,6 +125,18 @@ export interface CreateGitHubAppOpts {
    * Auto-detected when DISPLAY and WAYLAND_DISPLAY are both unset on Linux.
    */
   headless?: boolean;
+  /**
+   * Public domain for production webhook deliveries (e.g. `hooks.example.com`).
+   * When set, `hook_attributes.url` is `https://<domain>/webhooks/github` so GitHub
+   * stores the real webhook URL at app-creation time. When unset, a placeholder is
+   * used and the operator must edit the webhook URL in the GitHub App settings later.
+   *
+   * NOTE: `redirect_url` and `callback_urls` continue to point at the local callback
+   * server (`http://localhost:<callbackPort>/callback`) because that's where the
+   * bootstrap manifest exchange captures the OAuth code. They're only used during
+   * the one-time bootstrap exchange, not in production.
+   */
+  domain?: string;
   deps?: BootstrapDeps;
 }
 
@@ -566,6 +578,7 @@ export async function createGitHubApp(
     org,
     timeoutMs = 300_000,
     headless: headlessOpt,
+    domain,
     deps,
   } = opts;
 
@@ -603,11 +616,19 @@ export async function createGitHubApp(
   const state = crypto.randomBytes(16).toString("hex");
   const callbackUrl = `http://localhost:${callbackPort}/callback`;
 
-  // Build the GitHub App manifest (same for both paths).
+  // Build the GitHub App manifest (same for both paths). The webhook URL is
+  // GitHub's permanent destination for event deliveries; we point it at the
+  // operator's public domain when supplied so they don't have to fix it up by
+  // hand after the manifest exchange. `redirect_url` / `callback_urls` continue
+  // to point at the local callback server — that's only used during the
+  // one-shot bootstrap manifest code exchange.
+  const webhookUrlForManifest = domain
+    ? `https://${domain}/webhooks/github`
+    : "https://placeholder.invalid/webhooks/github";
   const manifest = {
     name: "urateam",
     url: "https://github.com/JonB32/urateam",
-    hook_attributes: { url: "https://placeholder.invalid/webhooks/github" },
+    hook_attributes: { url: webhookUrlForManifest },
     redirect_url: callbackUrl,
     callback_urls: [callbackUrl],
     public: false,
@@ -1335,6 +1356,7 @@ export const bootstrapCommand = new Command("bootstrap")
           org: org || undefined,
           headless: useHeadless,
           timeoutMs: oauthTimeoutMs,
+          domain,
         });
         logger.info({ appId: appCredentials.appId, appName: appCredentials.appName }, "[3/7] GitHub App created.");
       } catch (err) {

--- a/packages/core/src/__tests__/force-push-agent-branches.test.ts
+++ b/packages/core/src/__tests__/force-push-agent-branches.test.ts
@@ -119,6 +119,7 @@ vi.mock("../repo/git.js", () => ({
   gitExecSafe: vi.fn().mockResolvedValue(""),
   gitExecRaw: vi.fn().mockResolvedValue(""),
   gitExec: vi.fn().mockResolvedValue(""),
+  getAgentCommits: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../repo/tech-stack.js", () => ({


### PR DESCRIPTION
## Summary
- The bootstrap command accepts `--domain hooks.example.com` for reverse-proxy config, but never threaded it into `createGitHubApp()` — the manifest hardcoded `hook_attributes.url: \"https://placeholder.invalid/webhooks/github\"`
- Result: when the operator completed the manifest flow with a domain, GitHub stored the placeholder URL as the App's permanent webhook destination, so deliveries went nowhere until the operator manually edited the webhook URL in the GitHub App settings
- Now `createGitHubApp({ domain })` is plumbed through and the manifest emits `hook_attributes.url: \"https://<domain>/webhooks/github\"` when a domain is supplied
- `redirect_url` and `callback_urls` continue to point at `http://localhost:<port>/callback` because those are only used during the one-shot bootstrap OAuth-code exchange — they don't need to match the production domain

## Test plan
- [ ] `ura bootstrap --domain hooks.example.com` → resulting GitHub App URL contains `webhook_url=https%3A%2F%2Fhooks.example.com%2Fwebhooks%2Fgithub`
- [ ] `ura bootstrap` (no domain) → manifest still uses the placeholder webhook URL so the existing fallback path works
- [ ] Existing 73 bootstrap unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)