### PR TITLE
fix(executor,runner): propagate collision-recovered session ID + capture token snapshot on stage throw

### DIFF
--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -408,6 +408,15 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
           // BEC-209: update progress timestamp for hang detection, then
           // write to DB (fire-and-forget, rate-limited by progressIntervalMs).
           lastProgressAt = new Date();
+          // BEC-268 follow-up: capture cumulative tokens into outer scope so
+          // the catch block has a non-zero snapshot when the SDK throws mid-
+          // stream (e.g., "Reached maximum number of turns"). Without this,
+          // a 5-minute / 20-turn run that errors out records 0/0 in stage_runs.
+          // Accuracy is bounded by progressIntervalMs (worst case: tokens from
+          // the last progress tick).
+          inputTokens = stats.inputTokens;
+          outputTokens = stats.outputTokens;
+          turns = stats.turns;
           db.update(stageRuns)
             .set({ lastProgressAt })
             .where(eq(stageRuns.id, stageRunId))
@@ -537,15 +546,16 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       agentSessionId !== null &&
       /session id .* is already in use/i.test(capturedStderr);
 
+    let mintedSessionId: string | undefined;
     if (isSessionCollision) {
-      const newSessionId = randomUUID();
+      mintedSessionId = randomUUID();
       log.warn(
-        { oldSessionId: agentSessionId, newSessionId, stage },
+        { oldSessionId: agentSessionId, newSessionId: mintedSessionId, stage },
         "session ID collision detected — minting fresh session ID and marking retriable",
       );
       await db
         .update(pipelineRuns)
-        .set({ agentSessionId: newSessionId })
+        .set({ agentSessionId: mintedSessionId })
         .where(eq(pipelineRuns.id, runId));
       void logAuditEvent(
         db,
@@ -554,7 +564,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
           issueId,
           stage,
           oldSessionId: agentSessionId!,
-          newSessionId,
+          newSessionId: mintedSessionId,
         }),
       );
     }
@@ -614,6 +624,7 @@ Do NOT run build, test, or lint commands directly on the host — always use \`d
       turns,
       errorMessage: enrichedMessage,
       stageRunId,
+      ...(mintedSessionId ? { newSessionId: mintedSessionId } : {}),
     };
   } finally {
     // Always cancel the wall-clock timer regardless of exit path (BEC-249).

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -905,10 +905,37 @@ export class PipelineRunner {
     // we start this second invocation with `hasInitiatedSession = true` —
     // every resumable stage uses the `resume:` shape, never re-creates the
     // session.
-    const runAgentSessionId = resumeOptions
+    // BEC-268 follow-up — `let` (not `const`) because the executor's
+    // collision-recovery path mints a fresh session ID and returns it in
+    // `StageResult.newSessionId`. Every executeStage call site below
+    // delegates to `applyCollisionRecovery(result)` to keep this in sync
+    // with `pipeline_runs.agent_session_id` between retries.
+    let runAgentSessionId = resumeOptions
       ? resumeOptions.agentSessionId
       : agentSessionId;
     let hasInitiatedSession = !!resumeOptions;
+
+    /**
+     * BEC-268 follow-up — when the executor minted a fresh session ID after
+     * an SDK collision, point the runner's local cache at the new ID and
+     * reset the "first resumable stage" flag so the next attempt creates
+     * (not resumes) with the fresh ID. Without this, the runner's
+     * `fix-and-retry` loop re-sends the original session ID on every retry
+     * and the SDK keeps refusing with "already in use" — see the BEC-270
+     * soak run on dogfood (`FNFokcgj5g2tQe9oe6_lw`).
+     */
+    const applyCollisionRecovery = (result: { newSessionId?: string }): void => {
+      if (result.newSessionId && result.newSessionId !== runAgentSessionId) {
+        runLog.warn(
+          { oldSessionId: runAgentSessionId, newSessionId: result.newSessionId },
+          "BEC-268: refreshing runAgentSessionId from collision-recovered StageResult",
+        );
+        runAgentSessionId = result.newSessionId;
+        // Fresh session — next resumable stage call must `create` (sessionId)
+        // not `resume`, because the new ID has never been seen by the SDK.
+        hasInitiatedSession = false;
+      }
+    };
 
     /**
      * Returns `true` for the first non-fresh stage in this run, flips the
@@ -1196,6 +1223,7 @@ export class PipelineRunner {
           agentSessionId: runAgentSessionId,
           isFirstResumableStage: isFirstResumableStageForMain,
         });
+        applyCollisionRecovery(result);
 
         // Operator stop check (cancel path) — the AbortController inside the
         // executor surfaces as result.status === "cancelled". Don't try to use
@@ -1325,6 +1353,7 @@ export class PipelineRunner {
               // that produced them.
               iteration,
             });
+            applyCollisionRecovery(result);
 
             // Accumulate each RALPH iteration's tokens
             run.totalInputTokens += result.inputTokens;
@@ -1384,6 +1413,7 @@ export class PipelineRunner {
                 agentSessionId: runAgentSessionId,
                 isFirstResumableStage: isFirstResumableStageForRetry,
               });
+              applyCollisionRecovery(result);
               if (result.status === "completed") break;
             } else if (config.retry.strategy === "escalate") {
               break;
@@ -1503,6 +1533,7 @@ export class PipelineRunner {
                   agentSessionId: runAgentSessionId,
                   isFirstResumableStage: isFirstResumableStageForValRetry,
                 });
+                applyCollisionRecovery(result);
                 if (result.status === "completed" && result.handoffArtifact) {
                   // BEC-227 — `isFirstResumableStageForValRetry` reflects the
                   // retry execution that just produced `result`. Same formula
@@ -1717,6 +1748,7 @@ export class PipelineRunner {
               promptOverride: surgicalPrompt,
               suppressHandoff: surgicalSuppressHandoff,
             });
+            applyCollisionRecovery(fixResult);
 
             // BEC-134: track latest review stage_run id for fanout persistence.
             if (fixStage === "review") {
@@ -2092,6 +2124,7 @@ export class PipelineRunner {
             agentSessionId: runAgentSessionId,
             isFirstResumableStage: isFirstResumableStageForDrImpl,
           });
+          applyCollisionRecovery(drImplementResult);
 
           run.totalInputTokens += drImplementResult.inputTokens;
           run.totalOutputTokens += drImplementResult.outputTokens;
@@ -2137,6 +2170,7 @@ export class PipelineRunner {
             agentSessionId: runAgentSessionId,
             isFirstResumableStage: isFirstResumableStageForDrReview,
           });
+          applyCollisionRecovery(drReviewResult);
 
           // BEC-134: refresh latest review stage_run id for any subsequent
           // fanout persistence inside this loop.
@@ -2602,6 +2636,7 @@ export class PipelineRunner {
               agentSessionId: runAgentSessionId,
               isFirstResumableStage: isFirstResumableStageForResolve,
             });
+            applyCollisionRecovery(resolveResult);
 
             run.totalInputTokens += resolveResult.inputTokens;
             run.totalOutputTokens += resolveResult.outputTokens;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -426,6 +426,12 @@ export interface StageResult {
    *  need to associate per-stage artifacts (e.g. `review_model_runs`) with the
    *  same row the executor inserted. Always populated by `executeStage`. */
   stageRunId: string;
+  /** BEC-268 follow-up — set when the executor's collision-recovery path minted
+   *  a fresh `agent_session_id` (and persisted it to `pipeline_runs`). Callers
+   *  that hold a local cache of the run's session id (e.g. runner.ts's
+   *  `runAgentSessionId`) MUST refresh from this value before the next retry,
+   *  otherwise the new attempt re-sends the original ID and collides again. */
+  newSessionId?: string;
 }
 
 // --- Pipeline Run ---


### PR DESCRIPTION
## Summary

Two related fixes triggered by soak observations on the BEC-270 pipeline run `FNFokcgj5g2tQe9oe6_lw`:

### 1. Session-ID collision retries kept colliding with the original ID

BEC-268 added executor-side recovery that detects the SDK's `"Session ID … is already in use"` error, mints a fresh UUID, and `UPDATE`s `pipeline_runs.agent_session_id`. But `runner.ts` caches `runAgentSessionId` as a `const` at the top of `executePipeline` (line ~908) and re-uses it across every `executeStage` call inside the `fix-and-retry` loop (line ~1357). The DB persists fine — the runner's local variable just never refreshes. So every retry sends the original ID, hits the same SDK wall, and BEC-268 mints yet another new ID that goes nowhere.

Soak signature (FNFokcgj5g2tQe9oe6_lw):
```
pipeline.agent_session_collision_recovered  old=f90a32a1 new=bd149be0
pipeline.agent_session_collision_recovered  old=f90a32a1 new=5a899aa9
pipeline.agent_session_collision_recovered  old=f90a32a1 new=b73aa53d
```

Every `oldSessionId` is the *original* (f90a32a1), confirming the runner cache wasn't refreshing.

**Fix:**
- Add `newSessionId?: string` to `StageResult` (types.ts).
- Executor's collision-recovery branch returns the minted ID via that field.
- Runner changes `runAgentSessionId` from `const` to `let` and adds a tiny `applyCollisionRecovery(result)` helper that updates the local cache + resets `hasInitiatedSession = false` (so the next stage call uses `create`, not `resume`, with the fresh ID).
- Helper called after each of the 8 `executeStage` call sites in runner.ts.

### 2. Token accounting lost when the SDK throws mid-stream

Same run, first stage (BkYpmjF1) ran 5 minutes / 20 turns and recorded 0 input / 0 output tokens. `consumeAgentStream` accumulates tokens in function-scope variables and only returns them in the `ConsumeResult` on success; when the SDK throws (e.g., `"Reached maximum number of turns (20)"`) the result is never assigned and the executor's catch block writes 0 to `stage_runs`. This corrupts cost dashboards and budget tracking on every agent-side timeout.

**Fix:** the existing `onProgress` callback already receives cumulative `{ inputTokens, outputTokens, turns }` — capture those into the executor's outer-scope vars so the catch block has a non-zero snapshot from the last progress tick.

Cache token fields (`cache_creation_input_tokens` / `cache_read_input_tokens`) aren't on the `onProgress` stats yet; they remain 0 on throws. Could be added in a follow-up if needed for precise cost attribution.

## Test plan
- [x] `pnpm -w typecheck` clean
- [x] `pnpm -w test` — 2,445 / 2,466 passing (21 skipped, all pre-existing)
- [ ] Deploy to dogfood; re-run BEC-270 and confirm successive `agent_session_collision_recovered` events show *different* `oldSessionId`s (not the original each time) — i.e., each retry uses the prior recovery's new ID
- [ ] Confirm `stage_runs.input_tokens` / `output_tokens` are non-zero on a run that hits "Reached maximum number of turns"

## References
- Regresses observed against BEC-268's collision-recovery fix (PR #430)
- Soak case: pipeline_run `FNFokcgj5g2tQe9oe6_lw` (BEC-270)

🤖 Generated with [Claude Code](https://claude.com/claude-code)